### PR TITLE
Skills: stop rules in every verb-menu frontmatter; front page: query-shape routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ visible *before* the agent touches them, in a few thousand tokens instead of fiv
 
 </details>
 
+**Name a symbol and it's the first hit.** A confidence-gated router detects when the query *names*
+something and switches rankers: recall@1 on name-shaped queries jumps **76.7% → 98.7%** in `src/`
+(MRR 0.859 → 0.993) and **63.3% → 87.3%** at the repository root. The gate is the load-bearing
+part — ungated, doc-phrase queries collapse from 0.993 to 0.427: an ungated router routes the
+wrong queries, so both numbers are published together. Reproduce with `ripwire <dir>
+--eval-retrieval`; full tables in [`bench/ANSWERQUALITY.md`](bench/ANSWERQUALITY.md) and
+[Measured](#measured).
+
 [Quickstart](#quickstart) · [Benchmarks](#measured) · [What it answers](#what-it-answers) ·
 [Honesty contract](#the-honesty-contract) · [Agent setup](#set-it-up-in-your-coding-agent) ·
 [Docs](#documentation) · [Slides](present/ripwire-showcase.pdf)

--- a/bench/agentloop/results/pilot-6run.json
+++ b/bench/agentloop/results/pilot-6run.json
@@ -56,11 +56,11 @@
       "command_calls": 11,
       "ripwire_calls": 5,
       "ripwire_commands": [
-        "/bin/zsh -lc \"sed -n '1,240p' /Users/qgames/AppDevelopLocal/project2/ripwire/skills/ripwire-find-bug/SKILL.md\"",
+        "/bin/zsh -lc \"sed -n '1,240p' <checkout>/skills/ripwire-find-bug/SKILL.md\"",
         "/bin/zsh -lc 'ripwire . --for=\"nested CompoundModel separability matrix computes independent branches as coupled\" --max-tokens=4000'",
-        "/bin/zsh -lc \"sed -n '1,220p' /Users/qgames/AppDevelopLocal/project2/ripwire/skills/ripwire-reuse-first/SKILL.md\"",
+        "/bin/zsh -lc \"sed -n '1,220p' <checkout>/skills/ripwire-reuse-first/SKILL.md\"",
         "/bin/zsh -lc 'ripwire . --for=\"embed an existing coordinate matrix in the right block of a larger stacked matrix\"'",
-        "/bin/zsh -lc \"sed -n '1,240p' /Users/qgames/AppDevelopLocal/project2/ripwire/skills/ripwire-quality-bar/SKILL.md && sed -n '1,280p' /Users/qgames/AppDevelopLocal/project2/ripwire/skills/ripwire-change-check/SKILL.md\""
+        "/bin/zsh -lc \"sed -n '1,240p' <checkout>/skills/ripwire-quality-bar/SKILL.md && sed -n '1,280p' <checkout>/skills/ripwire-change-check/SKILL.md\""
       ],
       "events_path": "/private/tmp/ripwire-codex-cli-agentloop-v2/events/astropy__astropy-12907-ripwire_cli-1.jsonl",
       "error": null,
@@ -108,7 +108,7 @@
       "command_calls": 16,
       "ripwire_calls": 2,
       "ripwire_commands": [
-        "/bin/zsh -lc \"sed -n '1,240p' /Users/qgames/AppDevelopLocal/project2/ripwire/skills/ripwire-find-bug/SKILL.md\"",
+        "/bin/zsh -lc \"sed -n '1,240p' <checkout>/skills/ripwire-find-bug/SKILL.md\"",
         "/bin/zsh -lc 'ripwire . --for=\"resolve redirects copies original request causing wrong method after 303 then 307\" --max-tokens=4000'"
       ],
       "events_path": "/private/tmp/ripwire-codex-cli-agentloop-v2/events/psf__requests-1963-ripwire_cli-1.jsonl",
@@ -157,9 +157,9 @@
       "command_calls": 26,
       "ripwire_calls": 6,
       "ripwire_commands": [
-        "/bin/zsh -lc 'cat /Users/qgames/AppDevelopLocal/project2/ripwire/skills/ripwire-find-bug/SKILL.md'",
+        "/bin/zsh -lc 'cat <checkout>/skills/ripwire-find-bug/SKILL.md'",
         "/bin/zsh -lc 'ripwire . --for=\"concatenate datasets with different missing variables outer join\" --max-tokens=4000'",
-        "/bin/zsh -lc 'cat /Users/qgames/AppDevelopLocal/project2/ripwire/skills/ripwire-quality-bar/SKILL.md'",
+        "/bin/zsh -lc 'cat <checkout>/skills/ripwire-quality-bar/SKILL.md'",
         "/bin/zsh -lc 'ripwire . --quality-delta'",
         "/bin/zsh -lc 'ripwire . --quality-delta'",
         "/bin/zsh -lc 'ripwire . --quality-delta'"

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -137,10 +137,10 @@ proxy; one corpus, one language, fixed idealized agents on every arm.
 
 ### Agent-in-the-loop: the Codex CLI pilot (2026-08-04/05)
 
-**Source:** `bench/agentloop/` (harness, README, tasks.lock); result records committed at
-[`bench/agentloop/results/pilot-6run.json`](../bench/agentloop/results/pilot-6run.json) and
-[`pilot-postguard.json`](../bench/agentloop/results/pilot-postguard.json), raw per-run Codex JSONL
-retained outside the tree (paths inside the records).
+**Source:** `bench/agentloop/` (harness, README, tasks.lock); round-1 records committed at
+[`bench/agentloop/results/pilot-6run.json`](../bench/agentloop/results/pilot-6run.json) — absolute
+local paths in the records are rewritten to the `<checkout>` placeholder before commit — with the
+raw per-run Codex JSONL retained outside the tree.
 
 **Setup.** `codex exec` (codex-cli 0.144.0-alpha.4, CLI default model), two arms on the same
 SWE-bench-Lite instances, seed-1 prompts, MCP disabled in both, per-run isolated `CODEX_HOME`;

--- a/skills/ripwire-before-you-build/SKILL.md
+++ b/skills/ripwire-before-you-build/SKILL.md
@@ -8,7 +8,8 @@ description: >
   (scope/effort)? Each takes ~30s and often surfaces an existing implementation to reuse. For a SINGLE
   function/class/helper you're about to write → ripwire-reuse-first. NOT for reviewing an already-written
   diff — that's ripwire-change-check. NOT for restructuring EXISTING code — that's ripwire-fresh-eyes; this
-  skill is for NEW work. Backed by ripwire (deterministic, on PATH).
+  skill is for NEW work. Run only the homework the task actually lacks — a small feature with an obvious
+  home needs none of this: skip the skill and build. Backed by ripwire (deterministic, on PATH).
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-fresh-eyes/SKILL.md
+++ b/skills/ripwire-fresh-eyes/SKILL.md
@@ -10,7 +10,8 @@ description: >
   should review, or producing a health snapshot. Everything emits FACTS, not verdicts — you judge. Backed
   by ripwire (deterministic, on PATH). This is for an explicit risk/rot/refactor question after the target
   area is identified; cold structure mapping belongs to ripwire-orient. For any DIFF — yours or an incoming
-  PR — use ripwire-change-check; this skill is whole subsystems, not diffs.
+  PR — use ripwire-change-check; this skill is whole subsystems, not diffs. A single-lens question is a
+  single call — run only the lenses the question names, not the whole battery.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-layers/SKILL.md
+++ b/skills/ripwire-layers/SKILL.md
@@ -6,7 +6,8 @@ description: >
   call-graph modules, propagation cost (the change-amplification tax of touching a file), and optional
   `--arch` layering rules with a baseline/CI gate — in one pass, and for every metric it reports, what to DO
   about a bad number: formalize a boundary, write a `deny` rule, gate it. This is the enforcement/gates lens
-  on architecture; for the one-screen structure/overview lens (no gating) → ripwire-orient. Backed by
+  on architecture; for the one-screen structure/overview lens (no gating) → ripwire-orient. One pass
+  answers the health question — re-run only after you change the rules or the code. Backed by
   ripwire (deterministic, on PATH).
 allowed-tools: Bash, Read
 ---

--- a/skills/ripwire-navigate/SKILL.md
+++ b/skills/ripwire-navigate/SKILL.md
@@ -5,8 +5,9 @@ description: >
   symbol reaches another, a full-body deep-dive of a named symbol with its callers/callees/design-docs, or
   find a literal / regex / AST-shape with its enclosing symbol. Use when you know (or can name) the symbol
   and need the call graph, its contract, or to locate code precisely — instead of grepping and guessing.
-  Also the answer to "is it safe to change X?" (blast radius, not just 1-hop callers).
-  Backed by ripwire (deterministic, on PATH).
+  Also the answer to "is it safe to change X?" (blast radius, not just 1-hop callers). Run the ONE verb
+  that matches the question; when its answer is unambiguous, stop — don't stack callers + callees +
+  impact as a ritual. Backed by ripwire (deterministic, on PATH).
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-orient/SKILL.md
+++ b/skills/ripwire-orient/SKILL.md
@@ -10,7 +10,8 @@ description: >
   communities, nested zoom, and a rendered diagram — instead of blind grep + whole-file reads. Prefer this
   over reading many files when orienting. A NAMED symbol's deep-dive (its own contract/callers/callees, not
   the whole subsystem) → ripwire-navigate instead. For architecture HEALTH/enforcement (propagation cost,
-  layering violations, CI gates) → ripwire-layers instead.
+  layering violations, CI gates) → ripwire-layers instead. Stop at the first rung that answers — the
+  one-screen report usually does; climb the ladder only while the question is still open.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-perf-target/SKILL.md
+++ b/skills/ripwire-perf-target/SKILL.md
@@ -4,7 +4,9 @@ description: >
   Investigate a measured performance problem. Start from a representative benchmark, a flame graph, or a
   profiler sample, then use ripwire to locate the measured symbols, map callers/callees, and inspect
   structural hypotheses such as complexity, churn, coupling, and nesting. Static graph metrics are
-  maintenance/change-risk signals, not runtime heat or call frequency. Backed by ripwire (deterministic, on PATH).
+  maintenance/change-risk signals, not runtime heat or call frequency. Inspect only the symbols the
+  profile names — no repo-wide hotspot sweeps for a localized measurement. Backed by ripwire
+  (deterministic, on PATH).
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-reuse-first/SKILL.md
+++ b/skills/ripwire-reuse-first/SKILL.md
@@ -7,8 +7,10 @@ description: >
   block, the repo's best-in-class exemplar to imitate (by ROLE, not text similarity), the duplicate you are
   about to recreate, and whether the dependency is already in the tree, so you compose instead of reinvent.
   The least code is the least complexity, the fewest bugs, the smallest review, and the most cache-friendly
-  diff. For a whole multi-symbol FEATURE (plan/interface/sizing) → ripwire-before-you-build. Backed by
-  ripwire (deterministic, on PATH).
+  diff. For a whole multi-symbol FEATURE (plan/interface/sizing) → ripwire-before-you-build. One
+  --exemplar (or --grep) call at most — and if the fix is a one-line edit to an existing symbol, or the
+  ranked output already showed the building block, skip this skill (and this file) and just write it.
+  Backed by ripwire (deterministic, on PATH).
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-security-scan/SKILL.md
+++ b/skills/ripwire-security-scan/SKILL.md
@@ -8,7 +8,9 @@ description: >
   exec/eval, network-facing handlers) → assemble STRUCTURAL signal: unsafe-C-fn / c-style-cast lint hits,
   forward taint-reach via transitive callees, untested integration seams, sink use-sites. Use when you receive a
   skill or MCP config from an external source, as a periodic check on already-installed ones, or when you're
-  about to review/write code that touches untrusted input. Backed by ripwire (deterministic, on PATH).
+  about to review/write code that touches untrusted input. One scan pass over the artifact in question is
+  the verdict — a clean result doesn't need a second sweep with more verbs. Backed by ripwire
+  (deterministic, on PATH).
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-write-tests/SKILL.md
+++ b/skills/ripwire-write-tests/SKILL.md
@@ -6,7 +6,8 @@ description: >
   (ripwire-quality-bar): this is about FINDING what lacks a safety net and writing the test that closes the
   gap, before or without touching the code itself. Ranks candidates by `--seams` (untested cross-module call
   edges) and the `tested=1` coverage lens, gives you the symbol's outside contract via `--callers`, then verifies the
-  new test actually registers with `--affected`. Backed by ripwire (deterministic, on PATH).
+  new test actually registers with `--affected`. For one target one --seams or --callers pass suffices —
+  don't audit repo-wide coverage to write a single test. Backed by ripwire (deterministic, on PATH).
 allowed-tools: Bash, Read
 ---
 

--- a/test/agentloopcodexcheck.sh
+++ b/test/agentloopcodexcheck.sh
@@ -112,10 +112,28 @@ assert "single-line leaf fix" in quality_bar
 # read was unnecessary. The guard must live in the FRONTMATTER the agent sees for free.
 def frontmatter( text ):
     parts = text.split( "---" )
-    return parts[1] if len( parts ) >= 3 else ""
+    fm = parts[1] if len( parts ) >= 3 else ""
+    return " ".join( fm.split() )   # whitespace-normalized: guards must not depend on line-wrap positions
 assert "is enough" in frontmatter( find_bug ), "find-bug: evidence-sufficiency stop must be advertised in frontmatter"
 assert "single-line leaf fix" in frontmatter( quality_bar ), "quality-bar: scope guard must be advertised in frontmatter"
 assert "one-line leaf fix" in frontmatter( change_check ), "change-check: scope guard must be advertised in frontmatter"
+
+# Every skill whose body offers a MENU of verbs gets a one-sentence stop rule in frontmatter too —
+# the pilot's ritual expansion (multiple calls where the first sufficed) is not find-bug-specific.
+stop_guards = {
+    "ripwire-reuse-first":      "at most",
+    "ripwire-orient":           "first rung",
+    "ripwire-navigate":         "one verb",
+    "ripwire-before-you-build": "needs none of this",
+    "ripwire-fresh-eyes":       "single call",
+    "ripwire-write-tests":      "one target",
+    "ripwire-perf-target":      "the profile names",
+    "ripwire-security-scan":    "one scan pass",
+    "ripwire-layers":           "one pass",
+}
+for skill_name, marker in stop_guards.items():
+    text = ( root / "skills" / skill_name / "SKILL.md" ).read_text()
+    assert marker in frontmatter( text ).lower(), f"{skill_name}: stop rule ({marker!r}) must be advertised in frontmatter"
 
 print( "agentloopcodexcheck: PASS — Codex arms are config-isolated and JSONL usage is captured" )
 PY


### PR DESCRIPTION
Two changes:

**Skills** — the pilot's ritual-expansion loss (multiple ripwire calls where the first answer sufficed) is not find-bug-specific. Nine more verb-menu skills now advertise a one-sentence stop rule in the frontmatter the agent sees for free: reuse-first (one --exemplar at most; skip entirely for a one-line edit), orient (stop at the first rung that answers), navigate (the ONE matching verb, no callers+callees+impact stacking), before-you-build, fresh-eyes, write-tests, perf-target, security-scan, layers. agentloopcodexcheck.sh asserts each guard stays in frontmatter (whitespace-normalized).

**Front page** — the query-shape routing result, reworded for the hero area: name-shaped recall@1 76.7% → 98.7% (src/), 63.3% → 87.3% (root), with the ungated collapse (0.993 → 0.427) published in the same breath.

Also: ripwirepubliccheck caught absolute local paths in the committed pilot record — sanitized to a <checkout> placeholder, disclosed in EVALS.

Gates: 340 gates, 339 pass / 1 expected skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)