### PR TITLE
CI: portable perfgate byte count; v0.2.1 — Linux binaries run on RHEL 8+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 # Guardrails as automated gates (CLAUDE.md "The guardrails as automated gates"):
 #   - release job:  configure (portable default, no RIPWIRE_NATIVE — CI hardware is not "this dev machine")
-#                    + build + the full gate suite (170+ gates incl. determinism/G4/quality) per OS, run
-#                    in parallel via test/pargates.py -j 3 (same authoritative list as regression.sh).
+#                    + build + the full gate suite (170+ gates incl. determinism/G4/quality) per
+#                    OS x build-flavour (Release / plain — see the job comment), run in parallel via
+#                    test/pargates.py -j 3 (same authoritative list as regression.sh).
 #                    ubuntu-24.04 here is also the FIRST real proof of L1's portability fix: real x86-64
 #                    Linux hardware, not the local RIPWIRE_PRETEND_LINUX proxy test/portablebuildcheck.sh
 #                    uses on the (Apple Silicon) dev machines this repo is normally built on.
@@ -104,11 +105,21 @@ jobs:
             src/main.cpp src/ingest.cpp src/pagerank.cpp src/tsprobe.cpp src/infra/diagnostics.cpp
 
   release:
-    name: release (${{ matrix.os }})
+    # Two independent flavours per OS, each on its OWN runner — they used to run stacked in one job,
+    # doubling wall time for no coverage gain:
+    #   Release — defines NDEBUG, which compiles DEGRADED_PATH_ALERT out; the optimizer-visible build.
+    #   plain   — NDEBUG off, so DEGRADED_PATH_ALERT compiles in and the degrade-path gates can observe
+    #             the alert they assert. The e7405e7 qsnap fix was invisible to CI before this flavour
+    #             existed. estchargecheck #14 / qualitystalecheck arms 7/8c probe the flavour (an
+    #             already-gated degrade path + --version's build-type token) and SKIP honestly on the
+    #             Release leg, pointing at the plain leg as where the alert is proven; a missing alert
+    #             on the plain flavour still FAILS. Neither flavour alone is enough.
+    name: release (${{ matrix.os }}, ${{ matrix.flavor }})
     strategy:
       fail-fast: false
       matrix:
         os: [macos-14, ubuntu-24.04]
+        flavor: [Release, plain]
     runs-on: ${{ matrix.os }}
     steps:
       # L4 (Linux probe): checkout@v4 defaults to a --depth 1 clone, which leaves ONE commit of history
@@ -130,8 +141,8 @@ jobs:
         run: brew install ripgrep
 
 
-      - name: Configure (portable default — no RIPWIRE_NATIVE)
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Configure (portable — no RIPWIRE_NATIVE; empty build type = the plain flavour)
+        run: cmake -S . -B build ${{ matrix.flavor == 'Release' && '-DCMAKE_BUILD_TYPE=Release' || '' }}
 
       - name: Build
         run: cmake --build build -j
@@ -139,32 +150,11 @@ jobs:
       # test/pargates.py runs the SAME authoritative gate list regression.sh holds (manifestcheck.sh
       # keeps that list honest) in parallel, with the timing-sensitive edit-check budget isolated via
       # its `exclusive` group — the exact runner CLAUDE.md prescribes locally. Sequential regression.sh
-      # here cost ~15-20 min per suite pass; the release job runs the suite twice (Release + plain).
+      # cost ~26 min per suite pass; parallel at -j 3 measures ~15-18 min (the 4-vCPU runners saturate —
+      # many gates are internally multi-threaded), and the flavour matrix keeps the two passes off each
+      # other's critical path.
       - name: "gate suite, parallel (170+ gates: determinism, cache transparency, G4 XML, quality, …)"
         run: python3 test/pargates.py . build/ripwire -j 3
-
-      # The Release build above defines NDEBUG, which compiles DEGRADED_PATH_ALERT out — so a degrade-path
-      # gate run against it cannot observe the alert it asserts. The e7405e7 qsnap fix was invisible to CI
-      # before it landed, and the 2026-07-27 round added several more degrade gates (shallow-clone
-      # v="unknown", the pr-context ref refusal, the doc-drift VERIFY demotion). Build a SECOND time with
-      # the plain local flavour and re-run the suite against it, so both the optimizer-visible Release
-      # behaviour and the degrade paths are covered — neither alone is enough.
-      #
-      # 2026-08-01: the two gates that assert an alert directly (estchargecheck #14, qualitystalecheck
-      # arms 7/8c) no longer pass — or fail — silently on the Release leg. Each probes the flavour with
-      # TWO independent readings (an unrelated already-gated degrade path, plus --version's build-type
-      # token) and, only when both agree the binary is NDEBUG, prints a SKIP naming what is unobservable
-      # and pointing at THIS second leg as where it is proven. If the alert is missing on a flavour that
-      # should see it, they still FAIL. So the Release leg is honestly green rather than either
-      # vacuously green (the 2026-07-27 trap) or unconditionally red (the same trap inverted).
-      - name: Configure (plain — NDEBUG off, so DEGRADED_PATH_ALERT compiles in)
-        run: cmake -S . -B build-debugalerts
-
-      - name: Build (plain)
-        run: cmake --build build-debugalerts -j
-
-      - name: "gate suite, parallel, against the non-Release build (degrade paths visible)"
-        run: python3 test/pargates.py . build-debugalerts/ripwire -j 3
 
       - name: det-gate — 2-run byte-identical diff
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 # Guardrails as automated gates (CLAUDE.md "The guardrails as automated gates"):
 #   - release job:  configure (portable default, no RIPWIRE_NATIVE — CI hardware is not "this dev machine")
-#                    + build + full test/regression.sh (170+ gates incl. determinism/G4/quality) per OS.
+#                    + build + the full gate suite (170+ gates incl. determinism/G4/quality) per OS, run
+#                    in parallel via test/pargates.py -j 3 (same authoritative list as regression.sh).
 #                    ubuntu-24.04 here is also the FIRST real proof of L1's portability fix: real x86-64
 #                    Linux hardware, not the local RIPWIRE_PRETEND_LINUX proxy test/portablebuildcheck.sh
 #                    uses on the (Apple Silicon) dev machines this repo is normally built on.
@@ -135,8 +136,12 @@ jobs:
       - name: Build
         run: cmake --build build -j
 
-      - name: "test/regression.sh (170+ gates: determinism, cache transparency, G4 XML, quality, …)"
-        run: RIPWIRE_BIN=build/ripwire bash test/regression.sh
+      # test/pargates.py runs the SAME authoritative gate list regression.sh holds (manifestcheck.sh
+      # keeps that list honest) in parallel, with the timing-sensitive edit-check budget isolated via
+      # its `exclusive` group — the exact runner CLAUDE.md prescribes locally. Sequential regression.sh
+      # here cost ~15-20 min per suite pass; the release job runs the suite twice (Release + plain).
+      - name: "gate suite, parallel (170+ gates: determinism, cache transparency, G4 XML, quality, …)"
+        run: python3 test/pargates.py . build/ripwire -j 3
 
       # The Release build above defines NDEBUG, which compiles DEGRADED_PATH_ALERT out — so a degrade-path
       # gate run against it cannot observe the alert it asserts. The e7405e7 qsnap fix was invisible to CI
@@ -158,8 +163,8 @@ jobs:
       - name: Build (plain)
         run: cmake --build build-debugalerts -j
 
-      - name: "test/regression.sh against the non-Release build (degrade paths visible)"
-        run: RIPWIRE_BIN=build-debugalerts/ripwire bash test/regression.sh
+      - name: "gate suite, parallel, against the non-Release build (degrade paths visible)"
+        run: python3 test/pargates.py . build-debugalerts/ripwire -j 3
 
       - name: det-gate — 2-run byte-identical diff
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,21 +45,33 @@ jobs:
             cmake_extra: -DCMAKE_OSX_ARCHITECTURES=x86_64
           - name: linux-x64
             os: ubuntu-24.04
+            # AlmaLinux-8-based manylinux container (glibc 2.28) with Red Hat gcc-toolset: newer
+            # libstdc++ symbols are linked statically (the devtoolset model), so ONE binary runs on
+            # RHEL/Alma/Rocky 8+, CentOS Stream, Fedora, Ubuntu 20.04+, Debian 11+. Built on stock
+            # ubuntu-24.04 instead, the binary needs GLIBCXX_3.4.31 and dies on RHEL 9 (verified).
+            container: quay.io/pypa/manylinux_2_28_x86_64
             asset_arch: x64
             asset_os: linux
           - name: linux-arm64
             os: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
             asset_arch: arm64
             asset_os: linux
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container || '' }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Install tooling (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libxml2-utils
+          # manylinux/EL containers use dnf (libxml2 ships xmllint); the bare Ubuntu runner used apt
+          if command -v dnf >/dev/null 2>&1; then
+            dnf install -y libxml2
+          else
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends libxml2-utils
+          fi
 
 
       - name: Configure (portable — no RIPWIRE_NATIVE, this binary ships to other machines)
@@ -84,8 +96,13 @@ jobs:
           tar -C dist -czf "dist/${asset}.tar.gz" "${asset}"
           # basename inside the checksum file — `shasum -a 256 "dist/..."` bakes the dist/ prefix into
           # the published .sha256, which breaks `shasum -c` beside the downloaded pair (and therefore
-          # scripts/install.sh's verification step, which checks exactly that way)
-          ( cd dist && shasum -a 256 "${asset}.tar.gz" > "${asset}.tar.gz.sha256" )
+          # scripts/install.sh's verification step, which checks exactly that way). sha256sum fallback:
+          # the manylinux containers ship coreutils but not perl's shasum; both emit "HASH  NAME".
+          if command -v shasum >/dev/null 2>&1; then
+            ( cd dist && shasum -a 256 "${asset}.tar.gz" > "${asset}.tar.gz.sha256" )
+          else
+            ( cd dist && sha256sum "${asset}.tar.gz" > "${asset}.tar.gz.sha256" )
+          fi
           echo "asset=${asset}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
@@ -96,9 +113,43 @@ jobs:
             dist/${{ steps.package.outputs.asset }}.tar.gz.sha256
           if-no-files-found: error
 
+  smoke-rhel:
+    name: smoke RHEL 9 (${{ matrix.name }})
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            os: ubuntu-24.04
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    # ubi9 = RHEL 9 userland (glibc 2.34, libstdc++ GLIBCXX <= 3.4.29): exactly the environment the
+    # pre-manylinux binaries died on. The packaged tarball must run here or publish is blocked.
+    container: registry.access.redhat.com/ubi9/ubi
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xmllint
+        run: dnf install -y libxml2
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*-${{ matrix.name }}"
+          path: dist
+          merge-multiple: true
+
+      - name: Run the packaged binary on RHEL 9
+        run: |
+          tar -xzf dist/*.tar.gz -C dist
+          bin="$( find dist -type f -name ripwire )"
+          "$bin" --version
+          "$bin" test/fixture --no-cache | xmllint --noout -
+
   publish:
     name: publish GitHub Release
-    needs: build
+    needs: [build, smoke-rhel]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ not published here — see `docs/EVALS.md` for the instruments behind the headli
 
 ---
 
+## [0.2.1] — 2026-08-05
+
+Linux portability patch. The v0.2.0 Linux archives were built on `ubuntu-24.04` and required
+`GLIBCXX_3.4.31`, so they died on RHEL 9 and older (verified on ubi9). The Linux release legs now
+build inside AlmaLinux-8-based `manylinux_2_28` containers with Red Hat gcc-toolset 14 — newer
+libstdc++ symbols link statically (the devtoolset model), so **one binary per arch covers
+RHEL/Alma/Rocky 8+, CentOS Stream, Fedora, Ubuntu 20.04+, and Debian 11+** (glibc 2.28 floor;
+verified on ubi8, ubi9, ubuntu:22.04, ubuntu:24.04). A new `smoke-rhel` CI job runs the packaged
+tarball on a RHEL 9 (ubi9) userland and gates publish. Also: `bench/representative_perfgate.sh`
+byte counting is now GNU-portable (`stat -f %z` is BSD-only and zeroed the corpus-shape preflight
+on every Linux CI leg). No library or CLI behavior changes.
+
 ## [0.2.0] — 2026-08-04
 
 The first binary release: portable archives for macOS arm64/x64 and Linux arm64/x64, each with a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 # The version string lives in exactly ONE place — this project() call. --version (main.cpp)
 # reads it via the generated version.h below; test/versioncheck.sh asserts the two never drift.
-project(ripwire VERSION 0.2.0 LANGUAGES C CXX)
+project(ripwire VERSION 0.2.1 LANGUAGES C CXX)
 
 # ---- language standards (C++23 for our own code / C11 for the vendored C dependencies) ----
 set(CMAKE_CXX_STANDARD 23)

--- a/PLAN.md
+++ b/PLAN.md
@@ -159,6 +159,23 @@ created by today's own gate-suite runs — the leak is ONGOING (~31k files/day o
   download, checksum "OK", install, `--version` correct. Its TODO(P6) default repo stays unset
   pending the fresh-history export decision.
 
+## v0.2.1 — Linux portability patch (2026-08-05)
+
+- Found while answering "does it run on RHEL": the v0.2.0 Linux archives (built on ubuntu-24.04)
+  require `GLIBCXX_3.4.31` and die on RHEL 9 — verified on ubi9. Fix (`d2c1d51`-era commits, tag
+  `v0.2.1`): the Linux release legs build inside AlmaLinux-8 `manylinux_2_28` containers with Red
+  Hat gcc-toolset 14, so newer libstdc++ symbols link statically — one binary per arch for
+  RHEL/Alma/Rocky 8+, CentOS Stream, Fedora, Ubuntu 20.04+, Debian 11+ (glibc 2.28 floor). A new
+  `smoke-rhel` job runs the packaged tarball on ubi9 and gates publish.
+- Verified: release run 31006116964 all 7 jobs green; all four v0.2.1 archives pass strict
+  `shasum -c`; the published linux-arm64 asset runs `--version` + a full fixture map + xmllint on
+  ubi9 and `--version` on ubi8; `scripts/install.sh` (latest = v0.2.1) end-to-end with checksum OK.
+- CI-on-main was red since 2026-08-04 06:22 for an unrelated reason: `stat -f %z` (BSD-only) in
+  `bench/representative_perfgate.sh` zeroed the corpus-shape preflight on GNU stat — every
+  ubuntu-24.04 leg exited 2. Fixed with POSIX `find -exec cat {} + | wc -c`, verified in an
+  ubuntu:24.04 container. (The Aug-4 recall-floor and deck NUL-byte failures were already fixed on
+  this branch.) The v0.2.0 tag/assets are left untouched.
+
 ## Remaining launch work
 
 - Skill-body head-first restructure + pilot re-run (experiments 1–4 above).

--- a/README.md
+++ b/README.md
@@ -76,9 +76,8 @@ wrong queries, so both numbers are published together. Reproduce with `ripwire <
 
 ## Quickstart
 
-**Prebuilt binary** — macOS (arm64 / x86-64) and Linux (arm64 / x86-64, glibc 2.28 floor:
-**RHEL / Alma / Rocky 8+**, CentOS Stream, Fedora, Ubuntu 20.04+, Debian 11+ — every release is
-smoke-tested on a RHEL 9 userland before it publishes). Downloads the latest
+**Prebuilt binary** — macOS (arm64 / x86-64) and Linux (arm64 / x86-64, built for **RHEL 8+**;
+every release is smoke-tested on a RHEL 9 userland before it publishes). Downloads the latest
 [GitHub Release](https://github.com/redhat-et/ripwire/releases), verifies its SHA-256, and installs
 to `~/.local/bin`:
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ wrong queries, so both numbers are published together. Reproduce with `ripwire <
 
 ## Quickstart
 
-**Prebuilt binary** (macOS / Linux, arm64 / x86-64) — downloads the latest
+**Prebuilt binary** — macOS (arm64 / x86-64) and Linux (arm64 / x86-64, glibc 2.28 floor:
+**RHEL / Alma / Rocky 8+**, CentOS Stream, Fedora, Ubuntu 20.04+, Debian 11+ — every release is
+smoke-tested on a RHEL 9 userland before it publishes). Downloads the latest
 [GitHub Release](https://github.com/redhat-et/ripwire/releases), verifies its SHA-256, and installs
 to `~/.local/bin`:
 

--- a/bench/representative_perfgate.sh
+++ b/bench/representative_perfgate.sh
@@ -35,7 +35,9 @@ while [ "$copyIndex" -lt 80 ]; do
     copyIndex=$(( copyIndex + 1 ))
 done
 fileCount="$( find "$CORPUS" -type f | wc -l | tr -d ' ' )"
-byteCount="$( find "$CORPUS" -type f -exec stat -f %z {} \; | awk '{s+=$1} END{print s+0}' )"
+# cat|wc -c, not stat: `stat -f %z` is BSD-only — GNU stat errors on it, byteCount summed to 0, and
+# this preflight exited 2 on every Linux CI runner (the flavour trap the cache gates document).
+byteCount="$( find "$CORPUS" -type f -exec cat {} + | wc -c | tr -d ' ' )"
 [ "$fileCount" = 480 ] || { echo "representative_perfgate: corpus shape mismatch: files=$fileCount"; exit 2; }
 [ "$byteCount" = 183040 ] || { echo "representative_perfgate: corpus shape mismatch: bytes=$byteCount"; exit 2; }
 "$BIN" "$CORPUS" --no-cache > "$TMP/default.out" 2>/dev/null || { echo "representative_perfgate: default preflight failed"; exit 1; }


### PR DESCRIPTION
Two commits:

- **CI fix**: bench/representative_perfgate.sh used BSD-only `stat -f %z`; GNU stat errors, the byte sum read 0, and the corpus-shape preflight exited 2 on every ubuntu-24.04 leg — the failure behind the red CI on main. Replaced with POSIX `find -exec cat {} + | wc -c`, verified on macOS and in an ubuntu:24.04 container (files=480, bytes=183040, matching the pins).
- **v0.2.1**: the v0.2.0 Linux archives required GLIBCXX_3.4.31 and died on RHEL 9 (verified on ubi9). The Linux release legs now build in AlmaLinux-8-based manylinux_2_28 containers with Red Hat gcc-toolset 14 (devtoolset static-linking of newer libstdc++ symbols): one binary per arch for RHEL/Alma/Rocky 8+, CentOS Stream, Fedora, Ubuntu 20.04+, Debian 11+ (glibc 2.28 floor). Verified locally end-to-end (built in manylinux_2_28_aarch64; ran on ubi8, ubi9, ubuntu:22.04, ubuntu:24.04; full fixture map + xmllint on ubi9). A new smoke-rhel job runs the packaged tarball on ubi9 and gates publish. README advertises the compatibility floor beside the prebuilt install; CHANGELOG cuts 0.2.1. The v0.2.1 tag is pushed and its release run is in flight.

Gates: 340 gates, 339 pass / 1 expected skip / 0 fail; ASan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)