### PR TITLE
agentloop: measure the model-substitution rate, not just whether ripwire was called

### DIFF
--- a/bench/agentloop/analyze.py
+++ b/bench/agentloop/analyze.py
@@ -108,6 +108,26 @@ def paired_ratio( pairs, field ):
     p95 = ratios[ max( 0, math.ceil( 0.95 * len( ratios ) ) - 1 ) ]
     return p50, p95
 
+def substitution_rate( rec ):
+    """ripwire_calls / (ripwire_calls + native_read_calls) for ONE run, or None if unmeasured.
+
+    This is the metric every skill/hook/primer change is trying to move, and the one the harness could
+    not previously express: `ripwire_calls` alone cannot tell a run that used the tool for everything
+    apart from one that used it once and then read twenty files.
+
+    None (never 0.0) when either count is missing — `claude -p` self-logs neither, and a missing
+    measurement rendered as 0.0 would read as "defaulted every time", inverting the conclusion. A run
+    that genuinely did neither (no reads AND no ripwire calls) is also None: no denominator, no rate."""
+    rw, native = rec.get( "ripwire_calls" ), rec.get( "native_read_calls" )
+    if rw is None or native is None:
+        return None
+    total = rw + native
+    return ( rw / total ) if total else None
+
+def mean_substitution( recs ):
+    vals = [ v for v in ( substitution_rate( r ) for r in recs ) if v is not None ]
+    return ( mean( vals ), len( vals ) ) if vals else ( None, 0 )
+
 def analyze( records, n_boot=10000, bootstrap_seed="ripwire-b4-agentloop-bootstrap-v1" ):
     paired, incomplete = pair_by_task_seed( records )
     repos = sorted( { repo for _, repo, *_ in paired } )
@@ -125,6 +145,12 @@ def analyze( records, n_boot=10000, bootstrap_seed="ripwire-b4-agentloop-bootstr
     tok_p50, tok_p95 = paired_ratio( paired, "tokens_out" )
     wall_p50, wall_p95 = paired_ratio( paired, "wall_seconds" )
     cost_p50, cost_p95 = paired_ratio( paired, "cost_usd" )
+    # Substitution rate is reported PER ARM, not as a paired delta: the baseline arm has no ripwire on
+    # PATH at all, so its rate is 0 by construction and a delta against it measures nothing. The number
+    # that matters is how close the ripwire arm gets to 1.0 — i.e. how often, when it needed to read or
+    # search, it actually reached for the tool instead of defaulting.
+    sub_base, n_sub_base = mean_substitution( [ b for *_, b, _ in paired ] )
+    sub_ctx,  n_sub_ctx  = mean_substitution( [ c for *_, _, c in paired ] )
     out.update(
         resolved_delta_mean=mean( rdeltas ) if scored else None,
         resolved_delta_bootstrap_95_lower=lower,
@@ -132,6 +158,8 @@ def analyze( records, n_boot=10000, bootstrap_seed="ripwire-b4-agentloop-bootstr
         tokens_out_ratio_p50=tok_p50, tokens_out_ratio_p95=tok_p95,
         wall_seconds_ratio_p50=wall_p50, wall_seconds_ratio_p95=wall_p95,
         cost_usd_ratio_p50=cost_p50, cost_usd_ratio_p95=cost_p95,
+        substitution_rate_baseline=sub_base, n_substitution_baseline=n_sub_base,
+        substitution_rate_ripwire=sub_ctx,  n_substitution_ripwire=n_sub_ctx,
     )
     return out
 
@@ -149,6 +177,15 @@ def print_report( out ):
     print( f"  tokens_out ratio p50/p95 {rat(out['tokens_out_ratio_p50'])}/{rat(out['tokens_out_ratio_p95'])}" )
     print( f"  wall_seconds ratio p50/p95 {rat(out['wall_seconds_ratio_p50'])}/{rat(out['wall_seconds_ratio_p95'])}" )
     print( f"  cost_usd ratio p50/p95 {rat(out['cost_usd_ratio_p50'])}/{rat(out['cost_usd_ratio_p95'])}" )
+    def sub( x ): return f"{100*x:.1f}%" if x is not None else "n/a"
+    print( f"  substitution rate (ripwire_calls / read+search calls): "
+           f"ripwire arm {sub(out.get('substitution_rate_ripwire'))} "
+           f"(n={out.get('n_substitution_ripwire', 0)}), "
+           f"baseline {sub(out.get('substitution_rate_baseline'))} "
+           f"(n={out.get('n_substitution_baseline', 0)})" )
+    print(  "    ^ how often the agent reached for ripwire instead of defaulting to a read/grep/glob."
+            " Baseline is 0% by construction (no ripwire on PATH); n counts runs where BOTH counts were"
+            " measured — `claude -p` self-logs neither, so its runs are excluded rather than scored 0." )
 
 # ── self-test: synthetic fixture, no real run data needed ────────────────────────────────────────────
 def _fixture_record( repo, instance_id, seed, arm, resolved, tokens_out, wall_seconds, cost_usd ):
@@ -157,8 +194,12 @@ def _fixture_record( repo, instance_id, seed, arm, resolved, tokens_out, wall_se
                  status="ok", resolved=resolved, localization_hit=resolved,
                  tokens_in=1000, tokens_out=tokens_out, wall_seconds=wall_seconds, cost_usd=cost_usd,
                  command_calls=1,
-                 ripwire_calls=0 if arm == ARM_BASELINE else 1,
+                 ripwire_calls=0 if arm == ARM_BASELINE else 3,
                  ripwire_commands=[] if arm == ARM_BASELINE else [ "ripwire . --for=fixture" ],
+                 # 0/4 baseline vs 3/4 treatment — a deterministic, checkable substitution rate. The
+                 # baseline reads 4 files and reaches for ripwire zero times (it has none); the
+                 # treatment reaches for it 3 of 4 times, i.e. still defaults once.
+                 native_read_calls=4 if arm == ARM_BASELINE else 1,
                  events_path=None,
                  error=None, started_unix=0, finished_unix=0 )
 
@@ -202,6 +243,21 @@ def self_test():
                           f"got {out['tokens_out_ratio_p50']}" )
     if out.get( "n_resolved_pairs" ) != 27:
         failures.append( f"expected all 27 pairs resolution-scored, got {out.get('n_resolved_pairs')}" )
+    # substitution rate: the fixture pins 0/4 baseline and 3/4 treatment, exactly.
+    if out.get( "substitution_rate_baseline" ) != 0.0:
+        failures.append( f"expected baseline substitution rate 0.0 (no ripwire on PATH), "
+                          f"got {out.get('substitution_rate_baseline')}" )
+    if out.get( "substitution_rate_ripwire" ) is None or abs( out["substitution_rate_ripwire"] - 0.75 ) > 1e-9:
+        failures.append( f"expected ripwire-arm substitution rate 0.75 exactly (fixture is 3 ripwire / "
+                          f"1 native per run), got {out.get('substitution_rate_ripwire')}" )
+    if out.get( "n_substitution_ripwire" ) != 27:
+        failures.append( f"expected 27 substitution-scored ripwire runs, got {out.get('n_substitution_ripwire')}" )
+    # an UNMEASURED run (claude -p: neither count logged) must be excluded, never scored 0.0 — a
+    # missing measurement rendered as "defaulted every time" would invert the conclusion.
+    blind = [ dict( r, ripwire_calls=None, native_read_calls=None ) for r in records ]
+    out3 = analyze( blind, n_boot=100 )
+    if out3.get( "substitution_rate_ripwire" ) is not None or out3.get( "n_substitution_ripwire" ) != 0:
+        failures.append( "unmeasured substitution counts must report n/a with n=0, not a fabricated rate" )
     # evaluator=none pilot mode: resolved is None in BOTH arms — pairs must still form so the
     # localization/token/wall claims that stage supports remain analyzable; resolved stats say n/a.
     unscored = [ dict( r, resolved=None ) for r in records ]

--- a/bench/agentloop/run_agentloop.py
+++ b/bench/agentloop/run_agentloop.py
@@ -86,6 +86,10 @@ RECORD_FIELDS = (
     "instance_id", "repo", "base_commit", "arm", "seed", "harness", "model",
     "status", "resolved", "localization_hit", "tokens_in", "tokens_out",
     "wall_seconds", "cost_usd", "command_calls", "ripwire_calls", "ripwire_commands", "events_path",
+    # native_read_calls — the DENOMINATOR for ripwire_calls: the agent's own read/search calls that
+    # went somewhere other than ripwire. Without it "ripwire_calls=3" cannot distinguish a run that
+    # used the tool for everything from one that used it once and then read twenty files.
+    "native_read_calls",
     "error", "started_unix", "finished_unix",
     # v3 additions, both of them honesty fields rather than measurements:
     #   resolved_model  — the model the harness ACTUALLY used, read back from its own transcript.
@@ -120,6 +124,7 @@ def make_record( task, arm, seed, harness, model, status="not_implemented", **ov
         status=status, resolved=None, localization_hit=None,
         tokens_in=None, tokens_out=None, wall_seconds=None, cost_usd=None,
         command_calls=None, ripwire_calls=None, ripwire_commands=None, events_path=None,
+        native_read_calls=None,
         error=None, started_unix=now, finished_unix=now,
         resolved_model=None, harness_version=None,
     )
@@ -292,10 +297,44 @@ def parse_codex_jsonl_usage( stdout ):
         tokens_out = usage.get( "output_tokens" )
     return tokens_in, tokens_out
 
+# ── native-read accounting (2026-08-10 skill-orientation audit) ──────────────────────────────────────
+# ripwire_calls answers "did it reach for the tool"; it cannot answer "how often did it default
+# INSTEAD", which is the question every skill/hook/primer change is actually trying to move. That needs
+# the denominator: the agent's own read+search calls.
+#
+# Two honest limits, both of which the reported metric must carry rather than hide:
+#   - Codex has NO native read tool — every read is a shell command — while opencode has both a native
+#     `read`/`grep`/`glob` and a `bash`. So this counts BOTH channels, and the number is comparable
+#     WITHIN a harness, never across harnesses.
+#   - `claude -p` self-logs neither, so its native_read_calls stays None (same known gap that has kept
+#     ripwire_calls None for that harness since this file was written). None, never 0 — a missing
+#     measurement that reads as "never defaulted" would invert the conclusion.
+NATIVE_READ_TOOLS = frozenset( { "read", "grep", "glob", "list", "ls", "search", "find" } )
+
+# Shell forms of the same habit. Anchored at a command boundary (start, pipe, ;, &&, ||) so that a
+# `--for="cat the file"` argument or a path containing "less" cannot count as a read.
+SHELL_READ_RE = re.compile(
+    r"(?:^|[|;&]|&&|\|\|)\s*(?:sudo\s+)?"
+    r"(cat|head|tail|less|more|nl|sed|awk|rg|ag|ack|grep|egrep|fgrep|find|ls|tree)\b" )
+
+def classify_native_read( tool_name=None, command=None ):
+    """True when this call is the agent reading/searching source by a NON-ripwire route.
+
+    A command that invokes ripwire is never a native read even if it also pipes through grep — the
+    ripwire call is the behavior under test, and the pipe is just how its output was consumed."""
+    if tool_name and tool_name.strip().lower() in NATIVE_READ_TOOLS:
+        return True
+    if not command:
+        return False
+    text = command if isinstance( command, str ) else " ".join( map( str, command ) )
+    if "ripwire" in text:
+        return False
+    return bool( SHELL_READ_RE.search( text ) )
+
 def parse_codex_jsonl_metrics( stdout, ripwire_bin ):
     """Return token usage plus explicit command/ripwire-CLI evidence from retained Codex JSONL."""
     tokens_in, tokens_out = parse_codex_jsonl_usage( stdout )
-    command_calls = ripwire_calls = 0
+    command_calls = ripwire_calls = native_read_calls = 0
     ripwire_commands = []
     for line in stdout.splitlines():
         try:
@@ -313,7 +352,9 @@ def parse_codex_jsonl_metrics( stdout, ripwire_bin ):
         if ripwire_bin and ripwire_bin in command:
             ripwire_calls += 1
             ripwire_commands.append( command )
-    return tokens_in, tokens_out, command_calls, ripwire_calls, ripwire_commands
+        elif classify_native_read( command=command ):
+            native_read_calls += 1
+    return tokens_in, tokens_out, command_calls, ripwire_calls, ripwire_commands, native_read_calls
 
 def build_opencode_command( prompt, model ):
     """Build a non-interactive opencode invocation.
@@ -343,7 +384,7 @@ def parse_opencode_ndjson_metrics( stdout, ripwire_bin ):
     Returns nulls rather than raising on schema drift — opencode ships releases daily and the
     retained transcript is the evidence of record either way."""
     tokens_in = tokens_out = cost = model_id = None
-    command_calls = ripwire_calls = 0
+    command_calls = ripwire_calls = native_read_calls = 0
     ripwire_commands = []
     for line in ( stdout or "" ).splitlines():
         try:
@@ -360,16 +401,24 @@ def parse_opencode_ndjson_metrics( stdout, ripwire_bin ):
             cost       = part.get( "cost", cost )
         if etype in ( "step_start", "step_finish" ):
             model_id = part.get( "modelID" ) or event.get( "modelID" ) or model_id
-        if etype == "tool_use" and part.get( "tool" ) == "bash":
-            command_calls += 1
-            state   = part.get( "state" ) or {}
-            payload = state.get( "input" ) or {}
-            command = payload.get( "command" ) if isinstance( payload, dict ) else payload
-            command = " ".join( map( str, command ) ) if isinstance( command, list ) else str( command or "" )
-            if ripwire_bin and ripwire_bin in command:
-                ripwire_calls += 1
-                ripwire_commands.append( command )
-    return tokens_in, tokens_out, cost, model_id, command_calls, ripwire_calls, ripwire_commands
+        if etype == "tool_use":
+            tool = str( part.get( "tool" ) or "" )
+            if tool == "bash":
+                command_calls += 1
+                state   = part.get( "state" ) or {}
+                payload = state.get( "input" ) or {}
+                command = payload.get( "command" ) if isinstance( payload, dict ) else payload
+                command = " ".join( map( str, command ) ) if isinstance( command, list ) else str( command or "" )
+                if ripwire_bin and ripwire_bin in command:
+                    ripwire_calls += 1
+                    ripwire_commands.append( command )
+                elif classify_native_read( command=command ):
+                    native_read_calls += 1
+            # opencode's NATIVE read/grep/glob tools — the channel codex does not have at all, and the
+            # one a shim on PATH can never see, since no subprocess is spawned.
+            elif classify_native_read( tool_name=tool ):
+                native_read_calls += 1
+    return tokens_in, tokens_out, cost, model_id, command_calls, ripwire_calls, ripwire_commands, native_read_calls
 
 def prepare_opencode_environment( work_dir, instance_id, arm, seed, ripwire_bin ):
     """Create a fully isolated opencode environment for one run, and return (env, run_home, shim).
@@ -607,7 +656,7 @@ def _codex_metrics( stdout, work_dir, task, arm, seed, ripwire_bin, shim_log=Non
     events_file = events_dir / f"{task['instance_id']}-{arm}-{seed}.jsonl"
     events_file.write_text( stdout )
     ( tokens_in, tokens_out, command_calls,
-      ripwire_calls, ripwire_commands ) = parse_codex_jsonl_metrics( stdout, ripwire_bin )
+      ripwire_calls, ripwire_commands, native_read_calls ) = parse_codex_jsonl_metrics( stdout, ripwire_bin )
     if shim_log is not None:
         shim_calls, shim_commands = read_shim_log( shim_log )
         if shim_calls != ripwire_calls:
@@ -615,7 +664,7 @@ def _codex_metrics( stdout, work_dir, task, arm, seed, ripwire_bin, shim_log=Non
         ripwire_calls = shim_calls
     return dict( tokens_in=tokens_in, tokens_out=tokens_out, command_calls=command_calls,
                  ripwire_calls=ripwire_calls, ripwire_commands=ripwire_commands,
-                 events_path=str( events_file ) )
+                 native_read_calls=native_read_calls, events_path=str( events_file ) )
 
 def _opencode_metrics( stdout, work_dir, task, arm, seed, ripwire_bin, shim_log=None ):
     """Retain opencode's NDJSON transcript and parse it into record fields.
@@ -633,7 +682,8 @@ def _opencode_metrics( stdout, work_dir, task, arm, seed, ripwire_bin, shim_log=
     events_file.write_text( stdout )
 
     ( tokens_in, tokens_out, cost, model_id,
-      command_calls, ripwire_calls, ripwire_commands ) = parse_opencode_ndjson_metrics( stdout, ripwire_bin )
+      command_calls, ripwire_calls, ripwire_commands,
+      native_read_calls ) = parse_opencode_ndjson_metrics( stdout, ripwire_bin )
 
     if shim_log is not None:
         shim_calls, shim_commands = read_shim_log( shim_log )
@@ -642,8 +692,8 @@ def _opencode_metrics( stdout, work_dir, task, arm, seed, ripwire_bin, shim_log=
         ripwire_calls = shim_calls
     return dict( tokens_in=tokens_in, tokens_out=tokens_out, cost_usd=cost,
                  command_calls=command_calls, ripwire_calls=ripwire_calls,
-                 ripwire_commands=ripwire_commands, events_path=str( events_file ),
-                 resolved_model=model_id )
+                 ripwire_commands=ripwire_commands, native_read_calls=native_read_calls,
+                 events_path=str( events_file ), resolved_model=model_id )
 
 def _claude_metrics( stdout, shim_log=None ):
     """Parse the `claude -p --output-format json` single-result trailer into record fields.

--- a/test/agentloopcodexcheck.sh
+++ b/test/agentloopcodexcheck.sh
@@ -37,12 +37,25 @@ assert "CLI" in ctx[-1], ctx[-1]
 events = "\n".join( (
     '{"type":"thread.started","thread_id":"fixture"}',
     '{"type":"item.completed","item":{"type":"command_execution","command":"/repo/build/ripwire . --for=issue"}}',
+    '{"type":"item.completed","item":{"type":"command_execution","command":"sed -n 1,200p src/foo.py"}}',
+    '{"type":"item.completed","item":{"type":"command_execution","command":"python -m pytest -q"}}',
     '{"type":"turn.completed","usage":{"input_tokens":1234,"cached_input_tokens":234,"output_tokens":56}}',
 ) )
 tokens_in, tokens_out = module.parse_codex_jsonl_usage( events )
 assert tokens_in == 1234 and tokens_out == 56, ( tokens_in, tokens_out )
 metrics = module.parse_codex_jsonl_metrics( events, "/repo/build/ripwire" )
-assert metrics[2:] == ( 1, 1, [ "/repo/build/ripwire . --for=issue" ] ), metrics
+# (command_calls, ripwire_calls, ripwire_commands, native_read_calls): 3 commands seen — one ripwire,
+# one `sed -n` read (the DEFAULT this whole surface exists to displace), one pytest run that is
+# neither. A test invocation must NOT inflate the native-read denominator.
+assert metrics[2:] == ( 3, 1, [ "/repo/build/ripwire . --for=issue" ], 1 ), metrics
+
+# a ripwire call PIPED through grep is still a ripwire call, never a native read — otherwise the
+# substitution rate would penalize the very usage the docs recommend.
+piped = "\n".join( (
+    '{"type":"item.completed","item":{"type":"command_execution","command":"/repo/build/ripwire . --grep=x | head -20"}}',
+) )
+pm = module.parse_codex_jsonl_metrics( piped, "/repo/build/ripwire" )
+assert pm[2:4] == ( 1, 1 ) and pm[5] == 0, pm
 
 tasks = [
     { "instance_id": "a1", "repo": "org/a" },
@@ -86,7 +99,8 @@ with tempfile.TemporaryDirectory() as td:
     events_file = pathlib.Path( td ) / "events" / "x1-baseline-1.jsonl"
     assert events_file.is_file() and events_file.read_text() == events, "raw Codex JSONL must be retained verbatim"
     assert ( m["tokens_in"], m["tokens_out"] ) == ( 1234, 56 ), m
-    assert ( m["command_calls"], m["ripwire_calls"] ) == ( 1, 1 ), m
+    assert ( m["command_calls"], m["ripwire_calls"] ) == ( 3, 1 ), m
+    assert m["native_read_calls"] == 1, m
     assert m["ripwire_commands"] == [ "/repo/build/ripwire . --for=issue" ], m
     assert m["events_path"] == str( events_file ), m
     # TimeoutExpired hands over bytes (possibly invalid UTF-8) or None — both must degrade, not crash

--- a/test/agentloopopencodecheck.sh
+++ b/test/agentloopopencodecheck.sh
@@ -83,13 +83,18 @@ events = [
                                                    "cache": { "read": 7, "write": 8 } } } },
 ]
 stream = "\n".join( json.dumps( e ) for e in events ) + "\n"
-ti, to, cost, model, ncmd, nrip, rips = R.parse_opencode_ndjson_metrics( stream, "/shim/ripwire" )
+ti, to, cost, model, ncmd, nrip, rips, nnative = R.parse_opencode_ndjson_metrics( stream, "/shim/ripwire" )
 checks = [ ( ti == 1234, "tokens_in from step_finish (%r)" % ti ),
            ( to == 56,   "tokens_out from step_finish (%r)" % to ),
            ( cost == 0.42, "cost from step_finish (%r)" % cost ),
            ( model == "claude-sonnet-4-5", "resolved model read back (%r)" % model ),
            ( ncmd == 2,  "counts only bash tool_use events, not every tool (%r)" % ncmd ),
-           ( nrip == 1,  "counts the ripwire invocation (%r)" % nrip ) ]
+           ( nrip == 1,  "counts the ripwire invocation (%r)" % nrip ),
+           # BOTH default channels count toward the substitution denominator: the shell `grep -r`
+           # AND opencode's native `read` tool, which spawns no subprocess and is therefore invisible
+           # to the PATH shim. Codex has no native-tool channel at all — the number is comparable
+           # within a harness, never across.
+           ( nnative == 2, "counts native reads from bash AND the native read tool (%r)" % nnative ) ]
 for good, msg in checks:
     ( ok if good else no )( msg )
 


### PR DESCRIPTION
The one commit from the opencode round's branch that had not yet landed. Authored in a parallel session; rebased onto current `main` as a clean cherry-pick (the other two commits on that branch were already upstream by patch-id, and the round's own three landed in #15).

Builds directly on the harness work in #15: where that PR added `resolved_model` — read back from the agent's own transcript so a run against the wrong model is recorded as an error rather than averaged into an arm — this makes the substitution a *measured rate* across a run set instead of a per-record veto, and surfaces it through `analyze.py`.

Touches Python and shell only; no C++ changes.

- `bench/agentloop/analyze.py` — reports the substitution rate alongside the existing paired stats
- `bench/agentloop/run_agentloop.py` — records the evidence per run
- `test/agentloopcodexcheck.sh`, `test/agentloopopencodecheck.sh` — gates extended to cover it

Verified on this exact tree: 382 gates, 0 failures; `analyze.py --self-test` passes; the 216-run dry run builds its matrix with zero agent calls and zero spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)