### PR TITLE
docs(readme): opencode joins the agent list it already shipped support for

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,8 @@ measurements in [`docs/EVALS.md`](docs/EVALS.md) — each with its instrument, i
 counterexamples, because the losses ship beside the wins. Zero runtime dependencies, C++23, builds
 with the network off.
 
-Built for **Codex, Claude Code, Cursor, Windsurf, Gemini, aider**, and any agent that can call a CLI.
+Built for **Codex, Claude Code, Cursor, Windsurf, Gemini, opencode, aider**, and any agent that can
+call a CLI.
 
 <details>
 <summary><b>What comes back</b> — real output from this repository, pretty-printed and trimmed</summary>
@@ -1268,6 +1269,7 @@ ripwire wrap cursor      # MCP:      the mcpServers stanza for .cursor/mcp.json 
 ripwire wrap codex       # MCP:      codex mcp add ripwire -- ripwire --mcp (+ TOML fallback)
 ripwire wrap windsurf    # MCP:      that client's stanza
 ripwire wrap gemini      # MCP:      that client's stanza
+ripwire wrap opencode    # CLI-1st:  the AGENTS.md wiring; its "mcp" stanza offered as the alternative
 ripwire wrap aider       # no MCP:   a ranked map file, and the aider invocation that reads it
 ripwire wrap --all       # detect every installed agent and emit each one's config
 ```

--- a/skills/ripwire-mcp/SKILL.md
+++ b/skills/ripwire-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: >
   read incl. fetch_body/flags + 12 flagship-reflex verbs incl. connect/explore/from_trace/edit_check and the
   cross-branch pair whereis/stray_content + 3 edit verbs) and when each beats the CLI form or a native editor tool, the lazy-body handle posture, the edit
   verbs' safety contract, and the server's staleness/ rebuild behavior. Use when setting up ripwire for
-  Claude Code / Cursor / Codex / Windsurf / Gemini / aider, when deciding which ripwire MCP verb to call
+  Claude Code / Cursor / Codex / Windsurf / Gemini / opencode / aider, when deciding which ripwire MCP verb to call
   mid-task, or when wondering whether the server's index is stale. Backed by ripwire (deterministic, on
   PATH).
 allowed-tools: Bash, Read
@@ -43,6 +43,7 @@ writes) detailed below and in full in [`mcp-reference.md`](mcp-reference.md).
 ripwire wrap claude      # → claude mcp add ripwire -- ripwire --mcp
 ripwire wrap cursor      # → JSON mcpServers stanza for .cursor/mcp.json (also: windsurf, gemini)
 ripwire wrap codex       # → TOML stanza for ~/.codex/config.toml
+ripwire wrap opencode    # → CLI first (AGENTS.md is read automatically); its config key is "mcp", NOT mcpServers
 ripwire wrap aider       # → no MCP: ripwire . --for="<task>" > .ripwire-map.txt; aider --read .ripwire-map.txt
 ripwire wrap --all       # → auto-detect installed agents, emit each one's config in one run
 ```


### PR DESCRIPTION
`ripwire wrap opencode` landed in #15 with its gate — but **opencode appeared zero times in README.md**, so the only way to discover the feature was to read `wrap.h` or guess the argument. That round's own plan said to update the agent list once the gate was green; the gate went green and the list did not follow.

Four places, all lists that already enumerate the supported agents:

- `README.md` — the "Built for" line, and the `wrap <agent>` recipe block
- `skills/ripwire-mcp/SKILL.md` — the same two

The recipe line says **CLI-first** rather than describing an MCP stanza, because that is what the emitter actually prints, and why: opencode ships a `bash` tool so it can pay zero for retrieval, where a registered MCP server's 30 verb schemas are resident context every turn whether called or not (`docs/EVALS.md` §5, ~12–15K tokens).

The SKILL.md line additionally names the `"mcp"` key and warns it is **not** the `mcpServers` shape every other client uses — that config parses and is then silently ignored, which is the failure mode `opencodewrapcheck` exists to catch.

`docs/LINEAGE.md` also lists Windsurf, but that is a competitive-landscape table of IDE pair-programmers rather than a support list, so it is deliberately untouched.

Verified: 383 gates, 0 failures — including `readmedriftcheck`, `readmeexamplecheck`, `docscommandscheck`, `skilltruthcheck`, `skillroutingjudgedcheck`, `skillevalcheck` and `ripwirepubliccheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)