### PR TITLE
fix(format): radixSort.h loses the indented preprocessor directives that made main red

### DIFF
--- a/src/infra/radixSort.h
+++ b/src/infra/radixSort.h
@@ -57,16 +57,16 @@
 // either) takes the scalar path; x86 is always little-endian.
 #if ( defined( __ARM_NEON ) || defined( __ARM_NEON__ ) ) && \
     ( !defined( __BYTE_ORDER__ ) || __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ )
-    #include <arm_neon.h>
-    #define RADIXSORT_NEON 1
-    #define RADIXSORT_SSE2 0
+#include <arm_neon.h>
+#define RADIXSORT_NEON 1
+#define RADIXSORT_SSE2 0
 #elif defined( __SSE2__ ) || defined( _M_X64 )
-    #include <emmintrin.h>
-    #define RADIXSORT_NEON 0
-    #define RADIXSORT_SSE2 1
+#include <emmintrin.h>
+#define RADIXSORT_NEON 0
+#define RADIXSORT_SSE2 1
 #else
-    #define RADIXSORT_NEON 0
-    #define RADIXSORT_SSE2 0
+#define RADIXSORT_NEON 0
+#define RADIXSORT_SSE2 0
 #endif
 
 namespace radix


### PR DESCRIPTION
**CI on main has been red since `b598266`** merged `integration/branch-sweep`. The imported `src/infra/radixSort.h` indents its `#include`/`#define` lines inside the NEON/SSE2 selection block, and the clang-format gate rejects it. Every PR opened since inherits the failure, so this blocks the queue rather than being a cosmetic backlog item.

The fix is the one `.clang-format` already specifies, not a judgement call: it sets `IndentPPDirectives: None`, and the repository's own headers agree — `platform.h`, `infra/platform.h` and `serialize.h` carry zero indented preprocessor lines between them. The file arrived from an internal tree (`0c0e7bf import from internal development tree`) with a different convention; this is the import catching up, not a style change.

`scripts/formatcheck.sh` offers a second remedy — drop the path from `GATED`. That would be wrong here: the escape hatch exists for code whose house style is right and whose clang-format rendering is wrong, and this is the opposite.

**Whitespace only** — 8 preprocessor lines de-indented, no token order changed.

Verified locally with the gate's own clang-format 22 (`formatcheck: ALL PASS, 9 gated files`), tree rebuilds, and 383 gates pass with 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)