### PR TITLE
METHODOLOGY §7: audit the choice, not the trigger

### DIFF
--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -140,5 +140,32 @@ could not support.
 
 ---
 
+## 7. Audit the choice, not the trigger
+
+Many mechanisms here have two stages: a **trigger** selects candidates (a lift fires on a name
+match, a router picks a ranker, a hook decides to nudge, an anchor detects a mention), and a
+**choice** orders or places what fired. The stages fail independently, and a healthy trigger
+statistic says nothing about the choice — a trigger can reach the right symbol in two thirds of
+instances while the ordering buries it at median rank 33.
+
+The rule, earned the expensive way (the r5 nameboost round — see its REJECT in `docs/EVALS.md` §7):
+
+- **A pre-registration's gating statistic must be end-to-end** — "is the right answer inside the
+  top-K of what the mechanism would actually emit" — never a stage statistic like fire-rate,
+  candidate-pool recall, or trigger precision. Stage statistics are diagnostics for explaining a
+  result, not criteria for advancing one.
+- **Compute the end-to-end statistic on train before spending anything scarce** — a grid sweep, a
+  held-out set, a judged corpus. It is almost always free, and it is the cheapest kill available:
+  r5's was computable before its grid ran and read 0/97; the round instead audited its trigger
+  (60–69%, healthy), spent the grid, and learned nothing the free number had not already said.
+- **When a round dies, record which stage killed it.** "The trigger reaches gold; the choice buries
+  it" is a reusable finding that shapes the successor; "it didn't work" is not.
+
+The general failure this prevents: auditing the stage that is easy to instrument instead of the
+stage that carries the claim. A mechanism advances on the number a user would experience, or it
+does not advance.
+
+---
+
 *See `CONTRIBUTING.md` for how these rules land as concrete requirements on a change, and
 `docs/EVALS.md` for the instruments and the numbers.*


### PR DESCRIPTION
Institutionalizes the r5 nameboost lesson (whose REJECT verdict lands in PR #25) as a methodology rule rather than prose: pre-registrations for select-then-rank mechanisms must gate on the end-to-end statistic (right answer inside top-K of what would actually be emitted), computed on train before spending a grid, held-out set, or judged corpus. Stage statistics (fire-rate, pool recall) become diagnostics, never advancement criteria. Rounds that die must record which stage killed them.

Docs-only, 8 doc-facing gates green (RIPWIRE_BIN form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)