### PR TITLE
VT-2: pooling free-statistic NULL — two missing verdicts published, EVALS drift corrected

### DIFF
--- a/bench/locbench/results/vt2_pooling_freestat/FREESTAT.md
+++ b/bench/locbench/results/vt2_pooling_freestat/FREESTAT.md
@@ -1,0 +1,97 @@
+# VT-2 — file-level pooling, the free end-to-end statistic (2026-08-11)
+
+**STOPPED AT THE FREE STATISTIC. No mechanism was designed, no grid ran, no held-out was touched,
+no code changed.** This directory is the complete record.
+
+## Why this round exists — and what it found before measuring anything
+
+The round was commissioned as "E6 — file-level evidence pooling, the strongest unspent multi-file
+retrieval hypothesis, flagged by three consecutive rounds and never run", sourced from the
+`docs/EVALS.md` §7 nameboost entry ("remains UNSPENT — open headroom", committed 2026-08-11).
+
+That premise was false. Pooling had already been spent, five days before that EVALS text was
+written: pre-registered 2026-08-06 (`../r5_pooling/PREREG.md`), gridded on train, and **REJECTED ON
+HELD-OUT at +0.00pp** (`../r5_pooling/gate_verdict.txt`) as a constrained mechanism (promote-only
+slot ladder over `Σ top-K` with a blend). The same evening, r6 closed the stratum to ranking-side
+mechanisms (`../r6_expansion/gate_verdict.txt`). Neither verdict had been carried into EVALS — the
+stale "UNSPENT" line is exactly how a rejected idea gets re-attempted, and this round nearly was
+that re-attempt. The EVALS correction landed with this directory.
+
+What was still genuinely unmeasured: the r5_pooling REJECT covered one constrained mechanism on the
+legacy n=60 slice. Whether ANY pooling function, applied without constraints (full file reordering,
+no promote-only ladder, no blend — the best case a pooling mechanism could ever emit), has headroom
+on the larger A7 train instrument had never been computed. Per the §7 rule ("compute the free
+end-to-end statistic before spending anything scarce"), that number is free — so it was computed,
+as pure post-processing of the complete routed `--for` scored candidate export.
+
+## Step 1 — baseline reproduction (recorded vs measured)
+
+Recorded invocation (r5_nameboost lineage): `run_locbench.py --n 560 --split train --arms for`.
+Note the sibling recipe `--max-scored 60` in `../r5_pooling/r5_grid.sh` is the *pooling* round's
+first-60 train slice — a different instrument; the numbers below are the full train split.
+
+| metric (train strict file@10) | recorded (r5-era, ~kParserVer 50) | measured (origin/main, this round) |
+| --- | ---: | ---: |
+| overall (n=254) | 61.81% | 61.0% (155/254) |
+| single-file stratum | 70.73% (n=205) | 70.9% (n=203) |
+| multi-file stratum | 24.49% (n=49) | 21.6% (n=51) |
+
+Drift explained: the binary moved (L2 macro edges, L3 fn-ptr bindings, decl-arm noise gate,
+kParserVer 50 → 60); two instances migrated strata because indexing changed which gold files are
+in-universe. Zero skips, parse coverage 484/484. The measured column is the baseline of record for
+this round (`vt2_train_base.json`).
+
+## Step 2 — the free statistic (the round's soul)
+
+For every train instance: full `--for` candidate export (`--format=candidates --top-k=1000000000`,
+scores included, mention-anchor lifts included), pooled per file over positive member scores, file
+ordering by pooled score (tie: best member rank, then path), scored strict@10 with the harness's own
+`file_ranks`. Family and decision bar fixed in the script header before any number was seen:
+**material iff some fn nets ≥ +3 multi-file instances AND ≤ 2 single-file losses** (thresholds in
+instances, floor ≥ 3 — the rule r5_pooling's own verdict demanded after its ±2pp bar proved to be
+below single-instance granularity).
+
+Presence guard: the `max` control replayed through the same pipeline reproduced the recorded
+per-instance baseline on **all 254 instances (0 mismatches)** — the table is readable.
+
+| pooling fn | multi@10 (n=51) | single@10 (n=203) | multi net | single net |
+| --- | ---: | ---: | ---: | ---: |
+| `max` (control = shipped behavior) | 11 (21.6%) | 144 (70.9%) | — | — |
+| `sum` | 8 (15.7%) | 81 (39.9%) | **−3** | **−63** |
+| `top2sum` | 11 (21.6%) | 140 (69.0%) | 0 | −4 |
+| `top3sum` | 11 (21.6%) | 142 (70.0%) | 0 | −2 |
+| `cw` = max·(1+log₂(1+n)) | 9 (17.6%) | 128 (63.1%) | −2 | −16 |
+
+Per-instance gain/loss ledgers: `vt2_freestat_out.json`.
+
+## Verdict
+
+**NULL — no pooling function nets even +1 multi-file instance; the bar (+3) was never approached.
+STOP, per the pre-registered rule.** Three findings worth the round:
+
+1. **The unconstrained upper bound is NEGATIVE, not merely null.** `sum` makes file size the ranking
+   signal and destroys the single-file stratum (−63 instances — Prefect/ray/prowler/jax-scale
+   modules flood the top-10); `cw` loses 16. The constrained r5_pooling mechanism measured +0.00pp
+   because its promote-only ladder was *suppressing this harm* — not because it left gains on the
+   table. There is no less-constrained variant worth registering.
+2. **The one recurring multi-file "gain" is `UXARRAY__uxarray-1117`** (`sum`, `top3sum`) — the same
+   single instance whose flip laundered r5_pooling's train advance under its sub-granular ±2pp bar.
+   Two instruments have now independently identified this instance as the entire pooling signal.
+3. **Stage attribution (§7 third rule): the failure lives in the EVIDENCE, not the trigger and not
+   the choice.** Pooling aggregates the query-derived per-symbol scores that already buried the
+   sibling files; aggregation either moves nothing (`top2sum`/`top3sum`) or imports the file-size
+   confound (`sum`/`cw`). This confirms, from the unconstrained side and on the larger instrument,
+   both r5_pooling's own diagnosis ("the query produced NO evidence to re-weight") and the r6
+   closure: the multi-file stratum is closed to ranking-side mechanisms. Open headroom lives in
+   candidate GENERATION (11/22 decomposed failures), query understanding (4/22), and non-symbol
+   gold (3/22) — different subsystems.
+
+## Reproducing
+
+```sh
+RIPWIRE=<repo>/build/ripwire python3 ../../run_locbench.py --n 560 --split train --arms for \
+    --work-dir <work> --json-out vt2_train_base.json
+RIPWIRE=<repo>/build/ripwire LOCBENCH_WORK=<work> python3 vt2_freestat.py
+```
+
+Deterministic given (dataset slice, binary); the dataset row cache is hash-pinned by the harness.

--- a/bench/locbench/results/vt2_pooling_freestat/vt2_freestat.py
+++ b/bench/locbench/results/vt2_pooling_freestat/vt2_freestat.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# vt2_freestat.py — file-level evidence pooling: the FREE end-to-end statistic (docs/METHODOLOGY.md §7),
+# computed BEFORE any mechanism was designed, on the A7 train split (n=254), routed --for arm.
+#
+# CONTEXT THIS ROUND INHERITS (read FREESTAT.md first): pooling was ALREADY pre-registered
+# (../r5_pooling/PREREG.md, 2026-08-06), gridded, and REJECTED ON HELD-OUT at +0.00pp — as a
+# CONSTRAINED mechanism (promote-only slot ladder, top-K-sum blend). This script measures the
+# UNCONSTRAINED upper bound — full pooled file reordering, no ladder, no blend — for a small fixed
+# family of pooling functions, as pure post-processing of the complete routed --for candidate export.
+#
+# POOLING FAMILY (fixed before any number was seen):
+#   max      — control: today's behavior (file = best member). MUST reproduce the baseline run exactly
+#              (presence guard: if it does not, the pipeline is wrong and no number may be read).
+#   sum      — sum of ALL positive member scores (the file-size-confound end of the family)
+#   top2sum  — sum of top-2 positive member scores
+#   top3sum  — sum of top-3 positive member scores
+#   cw       — count-weighted: max * (1 + log2(1 + n_positive_members))
+#
+# DECISION BAR (fixed before any number was seen, per r5_pooling's own defect note — thresholds in
+# INSTANCES, floor >= 3): MATERIAL iff some non-control fn nets >= +3 multi-file strict@10 instances
+# on train AND costs <= 2 single-file strict@10 instances. Otherwise STOP: publish the negative.
+#
+# Tie-breaking (deterministic): pooled score desc, then best-member export rank asc, then path asc.
+#
+# RUN:  RIPWIRE=<repo>/build/ripwire LOCBENCH_WORK=<work-dir> python3 vt2_freestat.py [base.json]
+#   <work-dir> is the run_locbench.py --work-dir that produced base.json (repos/, datasets/, indexes/).
+#   base.json defaults to vt2_train_base.json next to this script
+#   (produced by: run_locbench.py --n 560 --split train --arms for --work-dir <work-dir>).
+import json, math, os, pathlib, sys, xml.etree.ElementTree as ET
+
+HERE = pathlib.Path( __file__ ).resolve().parent
+WORK = pathlib.Path( os.environ.get( "LOCBENCH_WORK", "" ) or sys.exit( "set LOCBENCH_WORK=<work-dir>" ) )
+sys.path.insert( 0, str( HERE.parents[1] ) )   # bench/locbench
+import run_locbench as rl
+
+def parse_cands_with_scores( xml, repo_path ):
+    # Compose the harness's own parser (identity + rank + path normalization) with one score pass —
+    # both iterate the same findall("cand") order, so the zip is 1:1 by construction.
+    cands  = rl.parse_candidates( xml, repo_path )
+    scores = [ float( c.attrib.get( "s", "0" ) ) for c in ET.fromstring( xml ).findall( "cand" ) ]
+    return [ ( c["path"], s, c["rank"] ) for c, s in zip( cands, scores ) ]
+
+def ranked_files_first_appearance( rows ):
+    seen, out = set(), []
+    for p, _, _ in rows:
+        if p not in seen: seen.add( p ); out.append( p )
+    return out
+
+def pooled_order( rows, fn ):
+    # rows: full export (score desc, id asc). Pool POSITIVE member scores per file.
+    agg = {}
+    for p, s, r in rows:
+        e = agg.setdefault( p, dict( scores=[], best_rank=r ) )
+        if s > 0.0: e["scores"].append( s )
+        e["best_rank"] = min( e["best_rank"], r )
+    scored = []
+    for p, e in agg.items():
+        v = sorted( e["scores"], reverse=True )
+        if not v: continue          # a file with no positive evidence is never placed
+        if   fn == "max":     sc = v[0]
+        elif fn == "sum":     sc = sum( v )
+        elif fn == "top2sum": sc = sum( v[:2] )
+        elif fn == "top3sum": sc = sum( v[:3] )
+        elif fn == "cw":      sc = v[0] * ( 1.0 + math.log2( 1.0 + len( v ) ) )
+        else: raise ValueError( fn )
+        scored.append( ( -sc, e["best_rank"], p ) )
+    scored.sort()
+    return [ p for _, _, p in scored ]
+
+def strict10( ranked_files, gold, universe_files ):
+    ranks = rl.file_ranks( ranked_files, gold, universe_files )
+    return 1 if ranks and all( r is not None and r < 10 for r in ranks ) else 0
+
+def main():
+    base_path = pathlib.Path( sys.argv[1] ) if len( sys.argv ) > 1 else HERE / "vt2_train_base.json"
+    base = json.loads( base_path.read_text() )
+    rows_by_id = { r["instance_id"]: r for r in json.loads(
+        ( WORK / "datasets" / "rows_czlll__Loc-Bench_V1_test_560.json" ).read_text() ) }
+    fns = [ "max", "sum", "top2sum", "top3sum", "cw" ]
+    res = { fn: dict( single=0, multi=0, gains=[], losses=[], sgains=[], slosses=[] ) for fn in fns }
+    n_single = n_multi = 0
+    control_mismatch = []
+    for inst in base["instances"]:
+        iid = inst["instance_id"]; row = rows_by_id[iid]
+        repo_path = rl.checkout( row["repo"], row["base_commit"], WORK / "repos" )
+        assert repo_path is not None, iid
+        rich = WORK / "indexes" / ( iid.replace( "/", "__" ) + ".rich.ripwirecache" )
+        assert rich.exists(), f"missing rich cache {iid}"
+        query = " ".join( row.get( "problem_statement", "" ).split() )[:1200]
+        xml, _, rc = rl.run_ctx( repo_path, [ f"--for={query}", "--format=candidates",
+                                              "--top-k=1000000000", f"--cache={rich}" ] )
+        assert rc == 0, f"ctx fail {iid} rc={rc}"
+        rows = parse_cands_with_scores( xml, repo_path )
+        universe_files = sorted( { p for p, _, _ in rows } )
+        gold = inst["primary_files"]
+        stratum = "single" if len( gold ) == 1 else "multi"
+        if stratum == "single": n_single += 1
+        else:                   n_multi  += 1
+        # presence guard: the 200-row prefix must reproduce the recorded arm outcome exactly
+        prefix_files = ranked_files_first_appearance( rows[:200] )
+        base_hit_recorded = 1 if ( inst["arms"]["for"]["file_worst"] is not None
+                                   and inst["arms"]["for"]["file_worst"] < 10 ) else 0
+        base_hit_replayed = strict10( prefix_files, gold, universe_files )
+        if base_hit_recorded != base_hit_replayed:
+            control_mismatch.append( iid )
+        for fn in fns:
+            hit = strict10( pooled_order( rows, fn ), gold, universe_files )
+            res[fn][stratum] += hit
+            if hit and not base_hit_replayed:
+                ( res[fn]["gains"] if stratum == "multi" else res[fn]["sgains"] ).append( iid )
+            if base_hit_replayed and not hit:
+                ( res[fn]["losses"] if stratum == "multi" else res[fn]["slosses"] ).append( iid )
+    out = dict( n_single=n_single, n_multi=n_multi, control_mismatch=control_mismatch, res=res )
+    ( base_path.parent / "vt2_freestat_out.json" ).write_text( json.dumps( out, indent=2 ) )
+    print( f"train: single n={n_single}  multi n={n_multi}  control mismatches={len(control_mismatch)} {control_mismatch[:5]}" )
+    print( f"{'fn':8} | {'multi@10':>9} | {'single@10':>9} | {'multi +/-':>12} | {'single +/-':>12}" )
+    for fn in fns:
+        r = res[fn]
+        print( f"{fn:8} | {r['multi']:4d} ({100.0*r['multi']/max(1,n_multi):5.2f}%) | "
+               f"{r['single']:4d} ({100.0*r['single']/max(1,n_single):5.2f}%) | "
+               f"+{len(r['gains'])}/-{len(r['losses'])}          | +{len(r['sgains'])}/-{len(r['slosses'])}" )
+    for fn in fns:
+        r = res[fn]
+        if r["gains"] or r["losses"] or r["slosses"]:
+            print( f"{fn}: multi gains={r['gains']} losses={r['losses']} single losses={r['slosses']}" )
+
+if __name__ == "__main__":
+    main()

--- a/bench/locbench/results/vt2_pooling_freestat/vt2_freestat_out.json
+++ b/bench/locbench/results/vt2_pooling_freestat/vt2_freestat_out.json
@@ -1,0 +1,197 @@
+{
+  "n_single": 203,
+  "n_multi": 51,
+  "control_mismatch": [],
+  "res": {
+    "max": {
+      "single": 144,
+      "multi": 11,
+      "gains": [],
+      "losses": [],
+      "sgains": [],
+      "slosses": []
+    },
+    "sum": {
+      "single": 81,
+      "multi": 8,
+      "gains": [
+        "UXARRAY__uxarray-1117",
+        "NatLibFi__Annif-610"
+      ],
+      "losses": [
+        "vllm-project__vllm-6050",
+        "Bears-R-Us__arkouda-1969",
+        "home-assistant__core-15182",
+        "UXARRAY__uxarray-1151",
+        "spacetelescope__stcal-337"
+      ],
+      "sgains": [
+        "huggingface__optimum-benchmark-266",
+        "prowler-cloud__prowler-5930",
+        "jax-ml__jax-24823",
+        "jax-ml__jax-20862",
+        "yt-dlp__yt-dlp-11734",
+        "yt-dlp__yt-dlp-11711",
+        "yt-dlp__yt-dlp-11667",
+        "yt-dlp__yt-dlp-11645"
+      ],
+      "slosses": [
+        "pypa__pip-13085",
+        "matplotlib__matplotlib-25887",
+        "vllm-project__vllm-9390",
+        "numba__numba-9757",
+        "plone__plone.restapi-859",
+        "rucio__rucio-4930",
+        "PrefectHQ__prefect-16369",
+        "PrefectHQ__prefect-16145",
+        "PrefectHQ__prefect-16117",
+        "PrefectHQ__prefect-15909",
+        "PrefectHQ__prefect-15468",
+        "PrefectHQ__prefect-14693",
+        "PrefectHQ__prefect-14608",
+        "PrefectHQ__prefect-14259",
+        "PrefectHQ__prefect-13756",
+        "PrefectHQ__prefect-12410",
+        "PrefectHQ__prefect-12045",
+        "getmoto__moto-8365",
+        "getmoto__moto-8342",
+        "getmoto__moto-8316",
+        "ray-project__ray-48957",
+        "ray-project__ray-48907",
+        "ray-project__ray-48623",
+        "spotify__luigi-3308",
+        "bridgecrewio__checkov-6895",
+        "stanfordnlp__dspy-1741",
+        "Qiskit__qiskit-12214",
+        "scipy__scipy-21918",
+        "scipy__scipy-21912",
+        "prowler-cloud__prowler-6128",
+        "prowler-cloud__prowler-6119",
+        "prowler-cloud__prowler-6108",
+        "prowler-cloud__prowler-6004",
+        "prowler-cloud__prowler-5933",
+        "modin-project__modin-7189",
+        "iterative__dvc-10641",
+        "jax-ml__jax-25511",
+        "jax-ml__jax-24492",
+        "jax-ml__jax-23020",
+        "jax-ml__jax-19909",
+        "sqlfluff__sqlfluff-6554",
+        "sqlfluff__sqlfluff-6312",
+        "sqlfluff__sqlfluff-5805",
+        "instructor-ai__instructor-1254",
+        "prowler-cloud__prowler-6157",
+        "prowler-cloud__prowler-5811",
+        "vllm-project__vllm-11138",
+        "vllm-project__vllm-9974",
+        "scipy__scipy-22106",
+        "scipy__scipy-22052",
+        "jax-ml__jax-24717",
+        "phidatahq__phidata-1589",
+        "phidatahq__phidata-1563",
+        "bridgecrewio__checkov-6826",
+        "spotify__luigi-3324",
+        "ray-project__ray-49071",
+        "ray-project__ray-48891",
+        "ray-project__ray-48793",
+        "ray-project__ray-48790",
+        "ray-project__ray-48786",
+        "ray-project__ray-48756",
+        "flet-dev__flet-4554",
+        "flet-dev__flet-4384",
+        "flet-dev__flet-4340",
+        "explodinggradients__ragas-1627",
+        "Lightning-AI__pytorch-lightning-20420",
+        "wandb__wandb-9011",
+        "wandb__wandb-8931",
+        "fortra__impacket-1858",
+        "langchain-ai__langgraph-2571",
+        "vllm-project__vllm-11275"
+      ]
+    },
+    "top2sum": {
+      "single": 140,
+      "multi": 11,
+      "gains": [],
+      "losses": [],
+      "sgains": [
+        "bridgecrewio__checkov-6828",
+        "flet-dev__flet-4314"
+      ],
+      "slosses": [
+        "Qiskit__qiskit-12214",
+        "prowler-cloud__prowler-5933",
+        "yt-dlp__yt-dlp-11827",
+        "yt-dlp__yt-dlp-11819",
+        "ray-project__ray-48891",
+        "flet-dev__flet-4384"
+      ]
+    },
+    "top3sum": {
+      "single": 142,
+      "multi": 11,
+      "gains": [
+        "UXARRAY__uxarray-1117"
+      ],
+      "losses": [
+        "UXARRAY__uxarray-1151"
+      ],
+      "sgains": [
+        "PrefectHQ__prefect-16328",
+        "bridgecrewio__checkov-6828",
+        "vllm-project__vllm-11073",
+        "flet-dev__flet-4314"
+      ],
+      "slosses": [
+        "Qiskit__qiskit-12214",
+        "prowler-cloud__prowler-5933",
+        "jax-ml__jax-24492",
+        "phidatahq__phidata-1589",
+        "ray-project__ray-48891",
+        "flet-dev__flet-4384"
+      ]
+    },
+    "cw": {
+      "single": 128,
+      "multi": 9,
+      "gains": [
+        "kedro-org__kedro-4367",
+        "NatLibFi__Annif-610"
+      ],
+      "losses": [
+        "Bears-R-Us__arkouda-1969",
+        "home-assistant__core-15182",
+        "UXARRAY__uxarray-1151",
+        "spacetelescope__stcal-337"
+      ],
+      "sgains": [
+        "PrefectHQ__prefect-16328",
+        "py-pdf__pypdf-2644",
+        "jax-ml__jax-20862",
+        "prowler-cloud__prowler-5961"
+      ],
+      "slosses": [
+        "pypa__pip-13085",
+        "getmoto__moto-8316",
+        "ray-project__ray-48957",
+        "spotify__luigi-3308",
+        "Qiskit__qiskit-12214",
+        "prowler-cloud__prowler-6128",
+        "prowler-cloud__prowler-5933",
+        "iterative__dvc-10641",
+        "jax-ml__jax-24492",
+        "instructor-ai__instructor-1254",
+        "prowler-cloud__prowler-6157",
+        "jax-ml__jax-24717",
+        "phidatahq__phidata-1563",
+        "bridgecrewio__checkov-6826",
+        "ray-project__ray-48891",
+        "ray-project__ray-48793",
+        "flet-dev__flet-4554",
+        "Lightning-AI__pytorch-lightning-20420",
+        "fortra__impacket-1858",
+        "langchain-ai__langgraph-2571"
+      ]
+    }
+  }
+}

--- a/bench/locbench/results/vt2_pooling_freestat/vt2_train_base.json
+++ b/bench/locbench/results/vt2_pooling_freestat/vt2_train_base.json
@@ -1,0 +1,14053 @@
+{
+  "dataset": "locbench",
+  "split": "train",
+  "split_contract": "repo-disjoint sha256(ripwire-a7-v2\\0 + lowercase(repo)), byte0<128=train",
+  "history_depth": 1,
+  "ctx_extra_args": "",
+  "n_scored": 254,
+  "skipped": {
+    "nonpy": 0,
+    "checkout": 0,
+    "ctx": 0,
+    "unindexable": 0
+  },
+  "coverage": {
+    "covered": 484,
+    "gold": 484,
+    "added": 85
+  },
+  "arms": {
+    "for": {
+      "n": 254,
+      "f1": 62,
+      "f3": 101,
+      "f5": 127,
+      "f10": 155,
+      "allf10": 146,
+      "fn5": 50,
+      "fn10": 67,
+      "mrr": 58.30357983527579,
+      "anyf10": 186,
+      "anyfn10": 107,
+      "wall": 47.62771274615079,
+      "p95": 47.62771274615079,
+      "output_bytes": 1151947,
+      "output_tokens_ceiling": 488237,
+      "candidate_bytes": 18985926,
+      "cold_wall": 0.0,
+      "index_wall": 0.0,
+      "primary_gold_files": 395,
+      "all_gold_files": 430
+    }
+  },
+  "instances": [
+    {
+      "instance_id": "UXARRAY__uxarray-1117",
+      "partition": "train",
+      "repo": "UXARRAY/uxarray",
+      "gold_files": [
+        "uxarray/grid/connectivity.py",
+        "uxarray/grid/coordinates.py"
+      ],
+      "primary_files": [
+        "uxarray/grid/connectivity.py",
+        "uxarray/grid/coordinates.py"
+      ],
+      "gold_funcs": [
+        [
+          "uxarray/grid/connectivity.py",
+          "",
+          "_build_n_nodes_per_face"
+        ],
+        [
+          "uxarray/grid/coordinates.py",
+          "",
+          "_construct_face_centroids"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "uxarray/grid/connectivity.py",
+          "",
+          "_build_n_nodes_per_face"
+        ],
+        [
+          "uxarray/grid/coordinates.py",
+          "",
+          "_construct_face_centroids"
+        ]
+      ],
+      "n_files": 158,
+      "n_syms": 1529,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 15,
+          "all_file_worst": 15,
+          "func_first": 8,
+          "wall_median": 0.0421,
+          "wall_p95": 0.0421,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7251,
+          "output_tokens_ceiling": 3073,
+          "candidate_bytes": 69325
+        }
+      }
+    },
+    {
+      "instance_id": "internetarchive__openlibrary-7929",
+      "partition": "train",
+      "repo": "internetarchive/openlibrary",
+      "gold_files": [
+        "openlibrary/core/lending.py",
+        "openlibrary/core/models.py",
+        "openlibrary/core/waitinglist.py",
+        "openlibrary/macros/LoanStatus.html",
+        "openlibrary/plugins/upstream/borrow.py"
+      ],
+      "primary_files": [
+        "openlibrary/core/lending.py",
+        "openlibrary/core/models.py",
+        "openlibrary/core/waitinglist.py",
+        "openlibrary/macros/LoanStatus.html",
+        "openlibrary/plugins/upstream/borrow.py"
+      ],
+      "gold_funcs": [
+        [
+          "openlibrary/core/lending.py",
+          "",
+          "get_loans_of_user"
+        ],
+        [
+          "openlibrary/core/models.py",
+          "User",
+          "get_loan_for"
+        ],
+        [
+          "openlibrary/core/models.py",
+          "User",
+          "get_waiting_loan_for"
+        ],
+        [
+          "openlibrary/plugins/upstream/borrow.py",
+          "borrow",
+          "POST"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "openlibrary/core/lending.py",
+          "",
+          "get_user_waiting_loans"
+        ],
+        [
+          "openlibrary/core/models.py",
+          "User",
+          "get_user_waiting_loans"
+        ]
+      ],
+      "covered": [
+        [
+          "openlibrary/core/lending.py",
+          "",
+          "get_loans_of_user"
+        ],
+        [
+          "openlibrary/core/models.py",
+          "User",
+          "get_loan_for"
+        ],
+        [
+          "openlibrary/core/models.py",
+          "User",
+          "get_waiting_loan_for"
+        ],
+        [
+          "openlibrary/plugins/upstream/borrow.py",
+          "borrow",
+          "POST"
+        ]
+      ],
+      "n_files": 887,
+      "n_syms": 8139,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 33,
+          "wall_median": 0.0763,
+          "wall_p95": 0.0763,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3766,
+          "output_tokens_ceiling": 1596,
+          "candidate_bytes": 64933
+        }
+      }
+    },
+    {
+      "instance_id": "rwth-i6__sisyphus-191",
+      "partition": "train",
+      "repo": "rwth-i6/sisyphus",
+      "gold_files": [
+        "sisyphus/aws_batch_engine.py",
+        "sisyphus/load_sharing_facility_engine.py",
+        "sisyphus/simple_linux_utility_for_resource_management_engine.py",
+        "sisyphus/son_of_grid_engine.py"
+      ],
+      "primary_files": [
+        "sisyphus/aws_batch_engine.py",
+        "sisyphus/load_sharing_facility_engine.py",
+        "sisyphus/simple_linux_utility_for_resource_management_engine.py",
+        "sisyphus/son_of_grid_engine.py"
+      ],
+      "gold_funcs": [
+        [
+          "sisyphus/aws_batch_engine.py",
+          "AWSBatchEngine",
+          "system_call"
+        ],
+        [
+          "sisyphus/load_sharing_facility_engine.py",
+          "LoadSharingFacilityEngine",
+          "system_call"
+        ],
+        [
+          "sisyphus/simple_linux_utility_for_resource_management_engine.py",
+          "SimpleLinuxUtilityForResourceManagementEngine",
+          "system_call"
+        ],
+        [
+          "sisyphus/son_of_grid_engine.py",
+          "SonOfGridEngine",
+          "system_call"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sisyphus/aws_batch_engine.py",
+          "AWSBatchEngine",
+          "system_call"
+        ],
+        [
+          "sisyphus/load_sharing_facility_engine.py",
+          "LoadSharingFacilityEngine",
+          "system_call"
+        ],
+        [
+          "sisyphus/simple_linux_utility_for_resource_management_engine.py",
+          "SimpleLinuxUtilityForResourceManagementEngine",
+          "system_call"
+        ],
+        [
+          "sisyphus/son_of_grid_engine.py",
+          "SonOfGridEngine",
+          "system_call"
+        ]
+      ],
+      "n_files": 64,
+      "n_syms": 1139,
+      "arms": {
+        "for": {
+          "file_first": 16,
+          "file_worst": 30,
+          "all_file_worst": 30,
+          "func_first": 102,
+          "wall_median": 0.0361,
+          "wall_p95": 0.0361,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4138,
+          "output_tokens_ceiling": 1754,
+          "candidate_bytes": 63016
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-6836",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/core/dataframe/algebra/binary.py",
+        "modin/core/dataframe/pandas/dataframe/dataframe.py",
+        "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+        "modin/core/execution/ray/common/engine_wrapper.py"
+      ],
+      "primary_files": [
+        "modin/core/dataframe/algebra/binary.py",
+        "modin/core/dataframe/pandas/dataframe/dataframe.py",
+        "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+        "modin/core/execution/ray/common/engine_wrapper.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/core/dataframe/algebra/binary.py",
+          "Binary",
+          "register"
+        ],
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "map"
+        ],
+        [
+          "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+          "PandasDataframePartitionManager",
+          "map_partitions"
+        ],
+        [
+          "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+          "PandasDataframePartitionManager",
+          "lazy_map_partitions"
+        ],
+        [
+          "modin/core/execution/ray/common/engine_wrapper.py",
+          "RayWrapper",
+          "put"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/core/dataframe/algebra/binary.py",
+          "Binary",
+          "register"
+        ],
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "map"
+        ],
+        [
+          "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+          "PandasDataframePartitionManager",
+          "map_partitions"
+        ],
+        [
+          "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+          "PandasDataframePartitionManager",
+          "lazy_map_partitions"
+        ],
+        [
+          "modin/core/execution/ray/common/engine_wrapper.py",
+          "RayWrapper",
+          "put"
+        ]
+      ],
+      "n_files": 434,
+      "n_syms": 8252,
+      "arms": {
+        "for": {
+          "file_first": 12,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 17,
+          "wall_median": 0.0898,
+          "wall_p95": 0.0898,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2949,
+          "output_tokens_ceiling": 1250,
+          "candidate_bytes": 85276
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-5473",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/config.py",
+        "vllm/distributed/device_communicators/custom_all_reduce.py",
+        "vllm/distributed/device_communicators/custom_all_reduce_utils.py",
+        "vllm/executor/multiproc_gpu_executor.py",
+        "vllm/utils.py"
+      ],
+      "primary_files": [
+        "vllm/config.py",
+        "vllm/distributed/device_communicators/custom_all_reduce.py",
+        "vllm/distributed/device_communicators/custom_all_reduce_utils.py",
+        "vllm/executor/multiproc_gpu_executor.py",
+        "vllm/utils.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/config.py",
+          "ParallelConfig",
+          "__init__"
+        ],
+        [
+          "vllm/distributed/device_communicators/custom_all_reduce.py",
+          "CustomAllreduce",
+          "__init__"
+        ],
+        [
+          "vllm/distributed/device_communicators/custom_all_reduce_utils.py",
+          "",
+          "gpu_p2p_access_check"
+        ],
+        [
+          "vllm/executor/multiproc_gpu_executor.py",
+          "MultiprocessingGPUExecutor",
+          "_init_executor"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "vllm/utils.py",
+          "",
+          "_cuda_device_count_stateless"
+        ],
+        [
+          "vllm/utils.py",
+          "",
+          "cuda_device_count_stateless"
+        ]
+      ],
+      "covered": [
+        [
+          "vllm/config.py",
+          "ParallelConfig",
+          "__init__"
+        ],
+        [
+          "vllm/distributed/device_communicators/custom_all_reduce.py",
+          "CustomAllreduce",
+          "__init__"
+        ],
+        [
+          "vllm/distributed/device_communicators/custom_all_reduce_utils.py",
+          "",
+          "gpu_p2p_access_check"
+        ],
+        [
+          "vllm/executor/multiproc_gpu_executor.py",
+          "MultiprocessingGPUExecutor",
+          "_init_executor"
+        ]
+      ],
+      "n_files": 562,
+      "n_syms": 10931,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 68,
+          "all_file_worst": 68,
+          "func_first": 95,
+          "wall_median": 0.0972,
+          "wall_p95": 0.0972,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3703,
+          "output_tokens_ceiling": 1570,
+          "candidate_bytes": 72157
+        }
+      }
+    },
+    {
+      "instance_id": "tardis-sn__tardis-2782",
+      "partition": "train",
+      "repo": "tardis-sn/tardis",
+      "gold_files": [
+        "benchmarks/opacities_opacity.py",
+        "benchmarks/transport_montecarlo_packet_trackers.py"
+      ],
+      "primary_files": [
+        "benchmarks/opacities_opacity.py",
+        "benchmarks/transport_montecarlo_packet_trackers.py"
+      ],
+      "gold_funcs": [
+        [
+          "benchmarks/opacities_opacity.py",
+          "BenchmarkMontecarloMontecarloNumbaOpacities",
+          "time_pair_creation_opacity_calculation"
+        ],
+        [
+          "benchmarks/transport_montecarlo_packet_trackers.py",
+          "BenchmarkTransportMontecarloPacketTrackers",
+          "setup"
+        ],
+        [
+          "benchmarks/transport_montecarlo_packet_trackers.py",
+          "BenchmarkTransportMontecarloPacketTrackers",
+          "time_rpacket_trackers_to_dataframe"
+        ],
+        [
+          "benchmarks/transport_montecarlo_packet_trackers.py",
+          "BenchmarkTransportMontecarloPacketTrackers",
+          "time_generate_rpacket_tracker_list"
+        ],
+        [
+          "benchmarks/transport_montecarlo_packet_trackers.py",
+          "BenchmarkTransportMontecarloPacketTrackers",
+          "time_generate_rpacket_last_interaction_tracker_list"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "benchmarks/opacities_opacity.py",
+          "BenchmarkMontecarloMontecarloNumbaOpacities",
+          "time_pair_creation_opacity_calculation"
+        ],
+        [
+          "benchmarks/transport_montecarlo_packet_trackers.py",
+          "BenchmarkTransportMontecarloPacketTrackers",
+          "setup"
+        ],
+        [
+          "benchmarks/transport_montecarlo_packet_trackers.py",
+          "BenchmarkTransportMontecarloPacketTrackers",
+          "time_rpacket_trackers_to_dataframe"
+        ],
+        [
+          "benchmarks/transport_montecarlo_packet_trackers.py",
+          "BenchmarkTransportMontecarloPacketTrackers",
+          "time_generate_rpacket_tracker_list"
+        ],
+        [
+          "benchmarks/transport_montecarlo_packet_trackers.py",
+          "BenchmarkTransportMontecarloPacketTrackers",
+          "time_generate_rpacket_last_interaction_tracker_list"
+        ]
+      ],
+      "n_files": 384,
+      "n_syms": 13368,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 2,
+          "wall_median": 0.0599,
+          "wall_p95": 0.0599,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3073,
+          "output_tokens_ceiling": 1303,
+          "candidate_bytes": 79233
+        }
+      }
+    },
+    {
+      "instance_id": "sopel-irc__sopel-2285",
+      "partition": "train",
+      "repo": "sopel-irc/sopel",
+      "gold_files": [
+        "pyproject.toml",
+        "sopel/builtins/url.py"
+      ],
+      "primary_files": [
+        "pyproject.toml",
+        "sopel/builtins/url.py"
+      ],
+      "gold_funcs": [
+        [
+          "sopel/builtins/url.py",
+          "",
+          "configure"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "title_command"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "title_auto"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "process_urls"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "find_title"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "get_tinyurl"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sopel/builtins/url.py",
+          "",
+          "configure"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "title_command"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "title_auto"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "process_urls"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "find_title"
+        ],
+        [
+          "sopel/builtins/url.py",
+          "",
+          "get_tinyurl"
+        ]
+      ],
+      "n_files": 148,
+      "n_syms": 3272,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 0,
+          "wall_median": 0.0461,
+          "wall_p95": 0.0461,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3673,
+          "output_tokens_ceiling": 1557,
+          "candidate_bytes": 61274
+        }
+      }
+    },
+    {
+      "instance_id": "pypa__pip-13085",
+      "partition": "train",
+      "repo": "pypa/pip",
+      "gold_files": [
+        "news/13079.bugfix.rst",
+        "src/pip/_internal/commands/install.py"
+      ],
+      "primary_files": [
+        "src/pip/_internal/commands/install.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/pip/_internal/commands/install.py",
+          "InstallCommand",
+          "run"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/pip/_internal/commands/install.py",
+          "InstallCommand",
+          "run"
+        ]
+      ],
+      "n_files": 636,
+      "n_syms": 11582,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": null,
+          "func_first": 7,
+          "wall_median": 0.1003,
+          "wall_p95": 0.1003,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4292,
+          "output_tokens_ceiling": 1819,
+          "candidate_bytes": 76031
+        }
+      }
+    },
+    {
+      "instance_id": "gammasim__simtools-1183",
+      "partition": "train",
+      "repo": "gammasim/simtools",
+      "gold_files": [
+        "simtools/applications/db_get_parameter_from_db.py",
+        "simtools/db/db_array_elements.py",
+        "simtools/db/db_handler.py"
+      ],
+      "primary_files": [
+        "simtools/applications/db_get_parameter_from_db.py",
+        "simtools/db/db_array_elements.py",
+        "simtools/db/db_handler.py"
+      ],
+      "gold_funcs": [
+        [
+          "simtools/applications/db_get_parameter_from_db.py",
+          "",
+          "main"
+        ],
+        [
+          "simtools/db/db_array_elements.py",
+          "",
+          "get_array_elements"
+        ],
+        [
+          "simtools/db/db_array_elements.py",
+          "",
+          "get_array_element_list_for_db_query"
+        ],
+        [
+          "simtools/db/db_array_elements.py",
+          "",
+          "get_array_elements_of_type"
+        ],
+        [
+          "simtools/db/db_handler.py",
+          "DatabaseHandler",
+          "get_model_parameters"
+        ],
+        [
+          "simtools/db/db_handler.py",
+          "DatabaseHandler",
+          "get_simulation_configuration_parameters"
+        ],
+        [
+          "simtools/db/db_handler.py",
+          "DatabaseHandler",
+          "get_sim_telarray_configuration_parameters"
+        ],
+        [
+          "simtools/db/db_handler.py",
+          "DatabaseHandler",
+          "_parameter_cache_key"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "simtools/applications/db_get_parameter_from_db.py",
+          "",
+          "main"
+        ],
+        [
+          "simtools/db/db_array_elements.py",
+          "",
+          "get_array_elements"
+        ],
+        [
+          "simtools/db/db_array_elements.py",
+          "",
+          "get_array_element_list_for_db_query"
+        ],
+        [
+          "simtools/db/db_array_elements.py",
+          "",
+          "get_array_elements_of_type"
+        ],
+        [
+          "simtools/db/db_handler.py",
+          "DatabaseHandler",
+          "get_model_parameters"
+        ],
+        [
+          "simtools/db/db_handler.py",
+          "DatabaseHandler",
+          "get_simulation_configuration_parameters"
+        ],
+        [
+          "simtools/db/db_handler.py",
+          "DatabaseHandler",
+          "get_sim_telarray_configuration_parameters"
+        ],
+        [
+          "simtools/db/db_handler.py",
+          "DatabaseHandler",
+          "_parameter_cache_key"
+        ]
+      ],
+      "n_files": 530,
+      "n_syms": 8479,
+      "arms": {
+        "for": {
+          "file_first": 8,
+          "file_worst": 26,
+          "all_file_worst": 26,
+          "func_first": 18,
+          "wall_median": 0.0507,
+          "wall_p95": 0.0507,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5701,
+          "output_tokens_ceiling": 2416,
+          "candidate_bytes": 75288
+        }
+      }
+    },
+    {
+      "instance_id": "matplotlib__matplotlib-25887",
+      "partition": "train",
+      "repo": "matplotlib/matplotlib",
+      "gold_files": [
+        "lib/matplotlib/cbook.py"
+      ],
+      "primary_files": [
+        "lib/matplotlib/cbook.py"
+      ],
+      "gold_funcs": [
+        [
+          "lib/matplotlib/cbook.py",
+          "",
+          "_unpack_to_numpy"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "lib/matplotlib/cbook.py",
+          "",
+          "_is_torch_array"
+        ],
+        [
+          "lib/matplotlib/cbook.py",
+          "",
+          "_is_jax_array"
+        ]
+      ],
+      "covered": [
+        [
+          "lib/matplotlib/cbook.py",
+          "",
+          "_unpack_to_numpy"
+        ]
+      ],
+      "n_files": 1219,
+      "n_syms": 30606,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 85,
+          "wall_median": 0.408,
+          "wall_p95": 0.408,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3679,
+          "output_tokens_ceiling": 1559,
+          "candidate_bytes": 69192
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-9390",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "benchmarks/benchmark_serving.py"
+      ],
+      "primary_files": [
+        "benchmarks/benchmark_serving.py"
+      ],
+      "gold_funcs": [
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "benchmark"
+        ],
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "main"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "benchmark"
+        ],
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "main"
+        ]
+      ],
+      "n_files": 1033,
+      "n_syms": 22650,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 1,
+          "wall_median": 0.1562,
+          "wall_p95": 0.1562,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3891,
+          "output_tokens_ceiling": 1649,
+          "candidate_bytes": 87900
+        }
+      }
+    },
+    {
+      "instance_id": "okta__okta-jwt-verifier-python-59",
+      "partition": "train",
+      "repo": "okta/okta-jwt-verifier-python",
+      "gold_files": [
+        "okta_jwt_verifier/jwt_utils.py",
+        "requirements.txt"
+      ],
+      "primary_files": [
+        "okta_jwt_verifier/jwt_utils.py"
+      ],
+      "gold_funcs": [
+        [
+          "okta_jwt_verifier/jwt_utils.py",
+          "JWTUtils",
+          "parse_token"
+        ],
+        [
+          "okta_jwt_verifier/jwt_utils.py",
+          "JWTUtils",
+          "verify_claims"
+        ],
+        [
+          "okta_jwt_verifier/jwt_utils.py",
+          "JWTUtils",
+          "verify_signature"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "okta_jwt_verifier/jwt_utils.py",
+          "JWTUtils",
+          "parse_token"
+        ],
+        [
+          "okta_jwt_verifier/jwt_utils.py",
+          "JWTUtils",
+          "verify_claims"
+        ],
+        [
+          "okta_jwt_verifier/jwt_utils.py",
+          "JWTUtils",
+          "verify_signature"
+        ]
+      ],
+      "n_files": 22,
+      "n_syms": 142,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": null,
+          "func_first": 0,
+          "wall_median": 0.0319,
+          "wall_p95": 0.0319,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6862,
+          "output_tokens_ceiling": 2908,
+          "candidate_bytes": 48284
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-26818",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "dashboard/client/src/api.ts",
+        "dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx",
+        "dashboard/client/src/pages/dashboard/node-info/dialogs/logs/Logs.tsx",
+        "dashboard/client/src/pages/dashboard/node-info/features/Logs.tsx",
+        "dashboard/datacenter.py",
+        "dashboard/modules/actor/actor_head.py",
+        "dashboard/modules/node/node_head.py"
+      ],
+      "primary_files": [
+        "dashboard/client/src/api.ts",
+        "dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx",
+        "dashboard/client/src/pages/dashboard/node-info/dialogs/logs/Logs.tsx",
+        "dashboard/client/src/pages/dashboard/node-info/features/Logs.tsx",
+        "dashboard/datacenter.py",
+        "dashboard/modules/actor/actor_head.py",
+        "dashboard/modules/node/node_head.py"
+      ],
+      "gold_funcs": [
+        [
+          "dashboard/datacenter.py",
+          "DataOrganizer",
+          "get_node_workers"
+        ],
+        [
+          "dashboard/datacenter.py",
+          "DataOrganizer",
+          "get_node_info"
+        ],
+        [
+          "dashboard/modules/actor/actor_head.py",
+          "ActorHead",
+          "__init__"
+        ],
+        [
+          "dashboard/modules/actor/actor_head.py",
+          "ActorHead",
+          "_update_actors"
+        ],
+        [
+          "dashboard/modules/actor/actor_head.py",
+          "ActorHead",
+          "run"
+        ],
+        [
+          "dashboard/modules/node/node_head.py",
+          "NodeHead",
+          "get_logs"
+        ],
+        [
+          "dashboard/modules/node/node_head.py",
+          "NodeHead",
+          "_update_log_info"
+        ],
+        [
+          "dashboard/modules/node/node_head.py",
+          "NodeHead",
+          "_update_error_info"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "dashboard/modules/actor/actor_head.py",
+          "ActorHead",
+          "_cleanup_actors"
+        ]
+      ],
+      "covered": [
+        [
+          "dashboard/datacenter.py",
+          "DataOrganizer",
+          "get_node_workers"
+        ],
+        [
+          "dashboard/datacenter.py",
+          "DataOrganizer",
+          "get_node_info"
+        ],
+        [
+          "dashboard/modules/actor/actor_head.py",
+          "ActorHead",
+          "__init__"
+        ],
+        [
+          "dashboard/modules/actor/actor_head.py",
+          "ActorHead",
+          "_update_actors"
+        ],
+        [
+          "dashboard/modules/actor/actor_head.py",
+          "ActorHead",
+          "run"
+        ],
+        [
+          "dashboard/modules/node/node_head.py",
+          "NodeHead",
+          "get_logs"
+        ],
+        [
+          "dashboard/modules/node/node_head.py",
+          "NodeHead",
+          "_update_log_info"
+        ],
+        [
+          "dashboard/modules/node/node_head.py",
+          "NodeHead",
+          "_update_error_info"
+        ]
+      ],
+      "n_files": 3935,
+      "n_syms": 60705,
+      "arms": {
+        "for": {
+          "file_first": 62,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.4365,
+          "wall_p95": 0.4365,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4056,
+          "output_tokens_ceiling": 1719,
+          "candidate_bytes": 72907
+        }
+      }
+    },
+    {
+      "instance_id": "gitpython-developers__GitPython-1636",
+      "partition": "train",
+      "repo": "gitpython-developers/GitPython",
+      "gold_files": [
+        "git/cmd.py"
+      ],
+      "primary_files": [
+        "git/cmd.py"
+      ],
+      "gold_funcs": [
+        [
+          "git/cmd.py",
+          "Git",
+          "execute"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "git/cmd.py",
+          "Git",
+          "execute"
+        ]
+      ],
+      "n_files": 76,
+      "n_syms": 1505,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": 6,
+          "all_file_worst": 6,
+          "func_first": 22,
+          "wall_median": 0.0398,
+          "wall_p95": 0.0398,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3024,
+          "output_tokens_ceiling": 1282,
+          "candidate_bytes": 80173
+        }
+      }
+    },
+    {
+      "instance_id": "huggingface__optimum-benchmark-266",
+      "partition": "train",
+      "repo": "huggingface/optimum-benchmark",
+      "gold_files": [
+        "optimum_benchmark/trackers/latency.py"
+      ],
+      "primary_files": [
+        "optimum_benchmark/trackers/latency.py"
+      ],
+      "gold_funcs": [
+        [
+          "optimum_benchmark/trackers/latency.py",
+          "LatencyTracker",
+          "__init__"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "optimum_benchmark/trackers/latency.py",
+          "LatencyTracker",
+          "__init__"
+        ]
+      ],
+      "n_files": 217,
+      "n_syms": 1975,
+      "arms": {
+        "for": {
+          "file_first": 54,
+          "file_worst": 54,
+          "all_file_worst": 54,
+          "func_first": null,
+          "wall_median": 0.0364,
+          "wall_p95": 0.0364,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3777,
+          "output_tokens_ceiling": 1601,
+          "candidate_bytes": 77369
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-6050",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/config.py",
+        "vllm/spec_decode/spec_decode_worker.py"
+      ],
+      "primary_files": [
+        "vllm/config.py",
+        "vllm/spec_decode/spec_decode_worker.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/config.py",
+          "SpeculativeConfig",
+          "maybe_create_spec_config"
+        ],
+        [
+          "vllm/spec_decode/spec_decode_worker.py",
+          "SpecDecodeWorker",
+          "create_worker"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/config.py",
+          "SpeculativeConfig",
+          "maybe_create_spec_config"
+        ],
+        [
+          "vllm/spec_decode/spec_decode_worker.py",
+          "SpecDecodeWorker",
+          "create_worker"
+        ]
+      ],
+      "n_files": 635,
+      "n_syms": 12839,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 8,
+          "all_file_worst": 8,
+          "func_first": 2,
+          "wall_median": 0.1038,
+          "wall_p95": 0.1038,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4473,
+          "output_tokens_ceiling": 1896,
+          "candidate_bytes": 83207
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-12019",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/_internal/concurrency/calls.py",
+        "src/prefect/_internal/concurrency/cancellation.py"
+      ],
+      "primary_files": [
+        "src/prefect/_internal/concurrency/calls.py",
+        "src/prefect/_internal/concurrency/cancellation.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/_internal/concurrency/calls.py",
+          "",
+          "get_current_call"
+        ],
+        [
+          "src/prefect/_internal/concurrency/calls.py",
+          "",
+          "set_current_call"
+        ],
+        [
+          "src/prefect/_internal/concurrency/cancellation.py",
+          "AsyncCancelScope",
+          "__exit__"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "src/prefect/_internal/concurrency/calls.py",
+          "Future",
+          "_invoke_callbacks"
+        ]
+      ],
+      "covered": [
+        [
+          "src/prefect/_internal/concurrency/calls.py",
+          "",
+          "get_current_call"
+        ],
+        [
+          "src/prefect/_internal/concurrency/calls.py",
+          "",
+          "set_current_call"
+        ],
+        [
+          "src/prefect/_internal/concurrency/cancellation.py",
+          "AsyncCancelScope",
+          "__exit__"
+        ]
+      ],
+      "n_files": 1215,
+      "n_syms": 22900,
+      "arms": {
+        "for": {
+          "file_first": 28,
+          "file_worst": 34,
+          "all_file_worst": 34,
+          "func_first": null,
+          "wall_median": 0.1512,
+          "wall_p95": 0.1512,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5103,
+          "output_tokens_ceiling": 2163,
+          "candidate_bytes": 78426
+        }
+      }
+    },
+    {
+      "instance_id": "pm4-graders__3ES-72",
+      "partition": "train",
+      "repo": "pm4-graders/3ES",
+      "gold_files": [
+        ".gitignore",
+        "backend/app/core/cv_result.py",
+        "cv/DigitRecognizer.py",
+        "cv/app.py"
+      ],
+      "primary_files": [
+        "backend/app/core/cv_result.py",
+        "cv/DigitRecognizer.py",
+        "cv/app.py"
+      ],
+      "gold_funcs": [
+        [
+          "backend/app/core/cv_result.py",
+          "Exam",
+          "__init__"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "recognize_digits_in_photo"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "predict_double_number"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "predict_handwritten_cell"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "find_grid_in_image"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "get_grid_cells"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "get_lines"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "backend/app/core/cv_result.py",
+          "Exam",
+          "__init__"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "recognize_digits_in_photo"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "predict_double_number"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "predict_handwritten_cell"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "find_grid_in_image"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "get_grid_cells"
+        ],
+        [
+          "cv/DigitRecognizer.py",
+          "DigitRecognizer",
+          "get_lines"
+        ]
+      ],
+      "n_files": 42,
+      "n_syms": 316,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 27,
+          "all_file_worst": null,
+          "func_first": 1,
+          "wall_median": 0.0325,
+          "wall_p95": 0.0325,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5887,
+          "output_tokens_ceiling": 2495,
+          "candidate_bytes": 58238
+        }
+      }
+    },
+    {
+      "instance_id": "fortra__impacket-1636",
+      "partition": "train",
+      "repo": "fortra/impacket",
+      "gold_files": [
+        "examples/ntlmrelayx.py",
+        "impacket/examples/ntlmrelayx/servers/socksserver.py"
+      ],
+      "primary_files": [
+        "examples/ntlmrelayx.py",
+        "impacket/examples/ntlmrelayx/servers/socksserver.py"
+      ],
+      "gold_funcs": [
+        [
+          "examples/ntlmrelayx.py",
+          "MiniShell",
+          "__init__"
+        ],
+        [
+          "examples/ntlmrelayx.py",
+          "MiniShell",
+          "do_socks"
+        ],
+        [
+          "impacket/examples/ntlmrelayx/servers/socksserver.py",
+          "",
+          "webService"
+        ],
+        [
+          "impacket/examples/ntlmrelayx/servers/socksserver.py",
+          "SOCKS",
+          "__init__"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "examples/ntlmrelayx.py",
+          "MiniShell",
+          "__init__"
+        ],
+        [
+          "examples/ntlmrelayx.py",
+          "MiniShell",
+          "do_socks"
+        ],
+        [
+          "impacket/examples/ntlmrelayx/servers/socksserver.py",
+          "",
+          "webService"
+        ],
+        [
+          "impacket/examples/ntlmrelayx/servers/socksserver.py",
+          "SOCKS",
+          "__init__"
+        ]
+      ],
+      "n_files": 288,
+      "n_syms": 23070,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 3,
+          "wall_median": 0.116,
+          "wall_p95": 0.116,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3173,
+          "output_tokens_ceiling": 1345,
+          "candidate_bytes": 77243
+        }
+      }
+    },
+    {
+      "instance_id": "Bears-R-Us__arkouda-1969",
+      "partition": "train",
+      "repo": "Bears-R-Us/arkouda",
+      "gold_files": [
+        "arkouda/dataframe.py",
+        "arkouda/io.py",
+        "src/ArrowFunctions.cpp",
+        "src/ArrowFunctions.h",
+        "src/ParquetMsg.chpl"
+      ],
+      "primary_files": [
+        "arkouda/dataframe.py",
+        "arkouda/io.py",
+        "src/ArrowFunctions.cpp",
+        "src/ArrowFunctions.h"
+      ],
+      "gold_funcs": [
+        [
+          "arkouda/dataframe.py",
+          "DataFrame",
+          "_prep_data"
+        ],
+        [
+          "arkouda/io.py",
+          "",
+          "_parse_errors"
+        ],
+        [
+          "arkouda/io.py",
+          "",
+          "to_parquet"
+        ],
+        [
+          "arkouda/io.py",
+          "",
+          "read"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "arkouda/dataframe.py",
+          "DataFrame",
+          "_prep_data"
+        ],
+        [
+          "arkouda/io.py",
+          "",
+          "_parse_errors"
+        ],
+        [
+          "arkouda/io.py",
+          "",
+          "to_parquet"
+        ],
+        [
+          "arkouda/io.py",
+          "",
+          "read"
+        ]
+      ],
+      "n_files": 193,
+      "n_syms": 2767,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 9,
+          "all_file_worst": null,
+          "func_first": 1,
+          "wall_median": 0.0927,
+          "wall_p95": 0.0927,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6564,
+          "output_tokens_ceiling": 2782,
+          "candidate_bytes": 69688
+        }
+      }
+    },
+    {
+      "instance_id": "sqlfluff__sqlfluff-6399",
+      "partition": "train",
+      "repo": "sqlfluff/sqlfluff",
+      "gold_files": [
+        ".pre-commit-config.yaml",
+        "pyproject.toml",
+        "src/sqlfluff/core/config/loader.py"
+      ],
+      "primary_files": [
+        ".pre-commit-config.yaml",
+        "pyproject.toml",
+        "src/sqlfluff/core/config/loader.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/sqlfluff/core/config/loader.py",
+          "",
+          "_get_user_config_dir_path"
+        ],
+        [
+          "src/sqlfluff/core/config/loader.py",
+          "",
+          "_load_user_appdir_config"
+        ],
+        [
+          "src/sqlfluff/core/config/loader.py",
+          "",
+          "load_config_up_to_path"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/sqlfluff/core/config/loader.py",
+          "",
+          "_get_user_config_dir_path"
+        ],
+        [
+          "src/sqlfluff/core/config/loader.py",
+          "",
+          "_load_user_appdir_config"
+        ],
+        [
+          "src/sqlfluff/core/config/loader.py",
+          "",
+          "load_config_up_to_path"
+        ]
+      ],
+      "n_files": 2358,
+      "n_syms": 32982,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 0,
+          "wall_median": 0.0972,
+          "wall_p95": 0.0972,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3045,
+          "output_tokens_ceiling": 1291,
+          "candidate_bytes": 78702
+        }
+      }
+    },
+    {
+      "instance_id": "mathesar-foundation__mathesar-3117",
+      "partition": "train",
+      "repo": "mathesar-foundation/mathesar",
+      "gold_files": [
+        "db/install.py",
+        "docs/docs/installation/build-from-source/index.md",
+        "docs/docs/installation/docker/index.md",
+        "docs/docs/snippets/docker-compose-prerequisites.md"
+      ],
+      "primary_files": [
+        "db/install.py",
+        "docs/docs/installation/build-from-source/index.md",
+        "docs/docs/installation/docker/index.md",
+        "docs/docs/snippets/docker-compose-prerequisites.md"
+      ],
+      "gold_funcs": [
+        [
+          "db/install.py",
+          "",
+          "_create_database"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "db/install.py",
+          "",
+          "_create_database"
+        ]
+      ],
+      "n_files": 686,
+      "n_syms": 11127,
+      "arms": {
+        "for": {
+          "file_first": 115,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.0752,
+          "wall_p95": 0.0752,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3428,
+          "output_tokens_ceiling": 1453,
+          "candidate_bytes": 68288
+        }
+      }
+    },
+    {
+      "instance_id": "JackPlowman__repo_standards_validator-137",
+      "partition": "train",
+      "repo": "JackPlowman/repo_standards_validator",
+      "gold_files": [
+        "poetry.lock",
+        "pyproject.toml",
+        "validator/__main__.py",
+        "validator/repository_checks.py"
+      ],
+      "primary_files": [
+        "pyproject.toml",
+        "validator/__main__.py",
+        "validator/repository_checks.py"
+      ],
+      "gold_funcs": [
+        [
+          "validator/__main__.py",
+          "",
+          "main"
+        ],
+        [
+          "validator/repository_checks.py",
+          "",
+          "check_repository"
+        ],
+        [
+          "validator/repository_checks.py",
+          "",
+          "check_repository_security_details"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "validator/repository_checks.py",
+          "",
+          "get_private_vulnerability_disclosures"
+        ]
+      ],
+      "covered": [
+        [
+          "validator/__main__.py",
+          "",
+          "main"
+        ],
+        [
+          "validator/repository_checks.py",
+          "",
+          "check_repository"
+        ],
+        [
+          "validator/repository_checks.py",
+          "",
+          "check_repository_security_details"
+        ]
+      ],
+      "n_files": 44,
+      "n_syms": 400,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 1,
+          "wall_median": 0.0311,
+          "wall_p95": 0.0311,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7461,
+          "output_tokens_ceiling": 3162,
+          "candidate_bytes": 56567
+        }
+      }
+    },
+    {
+      "instance_id": "una-auxme__paf-565",
+      "partition": "train",
+      "repo": "una-auxme/paf",
+      "gold_files": [
+        "code/perception/src/lidar_distance.py"
+      ],
+      "primary_files": [
+        "code/perception/src/lidar_distance.py"
+      ],
+      "gold_funcs": [
+        [
+          "code/perception/src/lidar_distance.py",
+          "LidarDistance",
+          "calculate_image"
+        ],
+        [
+          "code/perception/src/lidar_distance.py",
+          "LidarDistance",
+          "reconstruct_img_from_lidar"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "code/perception/src/lidar_distance.py",
+          "LidarDistance",
+          "calculate_image"
+        ],
+        [
+          "code/perception/src/lidar_distance.py",
+          "LidarDistance",
+          "reconstruct_img_from_lidar"
+        ]
+      ],
+      "n_files": 212,
+      "n_syms": 2254,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 14,
+          "wall_median": 0.0389,
+          "wall_p95": 0.0389,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7467,
+          "output_tokens_ceiling": 3164,
+          "candidate_bytes": 77123
+        }
+      }
+    },
+    {
+      "instance_id": "numba__numba-9757",
+      "partition": "train",
+      "repo": "numba/numba",
+      "gold_files": [
+        "docs/upcoming_changes/9757.bug_fix.rst",
+        "numba/core/dispatcher.py"
+      ],
+      "primary_files": [
+        "numba/core/dispatcher.py"
+      ],
+      "gold_funcs": [
+        [
+          "numba/core/dispatcher.py",
+          "_DispatcherBase",
+          "__init__"
+        ],
+        [
+          "numba/core/dispatcher.py",
+          "_DispatcherBase",
+          "_compile_for_args"
+        ],
+        [
+          "numba/core/dispatcher.py",
+          "_DispatcherBase",
+          "typeof_pyval"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "numba/core/dispatcher.py",
+          "_DispatcherBase",
+          "__init__"
+        ],
+        [
+          "numba/core/dispatcher.py",
+          "_DispatcherBase",
+          "_compile_for_args"
+        ],
+        [
+          "numba/core/dispatcher.py",
+          "_DispatcherBase",
+          "typeof_pyval"
+        ]
+      ],
+      "n_files": 810,
+      "n_syms": 33846,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": null,
+          "func_first": 2,
+          "wall_median": 0.2328,
+          "wall_p95": 0.2328,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 10552,
+          "output_tokens_ceiling": 4472,
+          "candidate_bytes": 63503
+        }
+      }
+    },
+    {
+      "instance_id": "jobatabs__textec-53",
+      "partition": "train",
+      "repo": "jobatabs/textec",
+      "gold_files": [
+        "src/repositories/reference_repository.py"
+      ],
+      "primary_files": [
+        "src/repositories/reference_repository.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/repositories/reference_repository.py",
+          "",
+          "create_reference"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/repositories/reference_repository.py",
+          "",
+          "create_reference"
+        ]
+      ],
+      "n_files": 22,
+      "n_syms": 137,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 5,
+          "wall_median": 0.0301,
+          "wall_p95": 0.0301,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7483,
+          "output_tokens_ceiling": 3171,
+          "candidate_bytes": 41160
+        }
+      }
+    },
+    {
+      "instance_id": "internetarchive__openlibrary-3196",
+      "partition": "train",
+      "repo": "internetarchive/openlibrary",
+      "gold_files": [
+        "openlibrary/plugins/upstream/utils.py",
+        "openlibrary/templates/lists/widget.html",
+        "openlibrary/templates/type/edition/view.html"
+      ],
+      "primary_files": [
+        "openlibrary/plugins/upstream/utils.py",
+        "openlibrary/templates/lists/widget.html",
+        "openlibrary/templates/type/edition/view.html"
+      ],
+      "gold_funcs": [
+        [
+          "openlibrary/plugins/upstream/utils.py",
+          "",
+          "setup"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "openlibrary/plugins/upstream/utils.py",
+          "",
+          "setup"
+        ]
+      ],
+      "n_files": 802,
+      "n_syms": 7611,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.0793,
+          "wall_p95": 0.0793,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3926,
+          "output_tokens_ceiling": 1664,
+          "candidate_bytes": 61088
+        }
+      }
+    },
+    {
+      "instance_id": "webcompat__webcompat.com-2731",
+      "partition": "train",
+      "repo": "webcompat/webcompat.com",
+      "gold_files": [
+        ".circleci/config.yml",
+        "grunt-tasks/concat.js",
+        "webcompat/api/endpoints.py",
+        "webcompat/helpers.py",
+        "webcompat/static/js/lib/comments.js",
+        "webcompat/static/js/lib/issues.js",
+        "webcompat/static/js/lib/models/comment.js",
+        "webcompat/static/js/lib/models/issue.js",
+        "webcompat/templates/issue.html",
+        "webcompat/templates/layout.html"
+      ],
+      "primary_files": [
+        ".circleci/config.yml",
+        "webcompat/api/endpoints.py",
+        "webcompat/helpers.py",
+        "webcompat/static/js/lib/comments.js",
+        "webcompat/static/js/lib/issues.js",
+        "webcompat/static/js/lib/models/comment.js",
+        "webcompat/static/js/lib/models/issue.js",
+        "webcompat/templates/issue.html",
+        "webcompat/templates/layout.html"
+      ],
+      "gold_funcs": [
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "proxy_issue"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "edit_issue"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "proxy_issues"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "get_user_activity_issues"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "get_issue_category"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "get_search_results"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "proxy_comments"
+        ],
+        [
+          "webcompat/helpers.py",
+          "",
+          "get_request_headers"
+        ],
+        [
+          "webcompat/helpers.py",
+          "",
+          "get_comment_data"
+        ],
+        [
+          "webcompat/helpers.py",
+          "",
+          "api_request"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "proxy_issue"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "edit_issue"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "proxy_issues"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "get_user_activity_issues"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "get_issue_category"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "get_search_results"
+        ],
+        [
+          "webcompat/api/endpoints.py",
+          "",
+          "proxy_comments"
+        ],
+        [
+          "webcompat/helpers.py",
+          "",
+          "get_request_headers"
+        ],
+        [
+          "webcompat/helpers.py",
+          "",
+          "get_comment_data"
+        ],
+        [
+          "webcompat/helpers.py",
+          "",
+          "api_request"
+        ]
+      ],
+      "n_files": 158,
+      "n_syms": 1886,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 5,
+          "wall_median": 0.0351,
+          "wall_p95": 0.0351,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7462,
+          "output_tokens_ceiling": 3162,
+          "candidate_bytes": 53375
+        }
+      }
+    },
+    {
+      "instance_id": "airbnb__knowledge-repo-558",
+      "partition": "train",
+      "repo": "airbnb/knowledge-repo",
+      "gold_files": [
+        "knowledge_repo/app/routes/comment.py"
+      ],
+      "primary_files": [
+        "knowledge_repo/app/routes/comment.py"
+      ],
+      "gold_funcs": [
+        [
+          "knowledge_repo/app/routes/comment.py",
+          "",
+          "post_comment"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "knowledge_repo/app/routes/comment.py",
+          "",
+          "post_comment"
+        ]
+      ],
+      "n_files": 163,
+      "n_syms": 1617,
+      "arms": {
+        "for": {
+          "file_first": 31,
+          "file_worst": 31,
+          "all_file_worst": 31,
+          "func_first": 177,
+          "wall_median": 0.0396,
+          "wall_p95": 0.0396,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3907,
+          "output_tokens_ceiling": 1656,
+          "candidate_bytes": 65353
+        }
+      }
+    },
+    {
+      "instance_id": "pulp__pulp_rpm-3224",
+      "partition": "train",
+      "repo": "pulp/pulp_rpm",
+      "gold_files": [
+        "CHANGES/3225.misc",
+        "CHANGES/3226.misc",
+        "pulp_rpm/app/tasks/publishing.py",
+        "pulp_rpm/app/tasks/synchronizing.py"
+      ],
+      "primary_files": [
+        "pulp_rpm/app/tasks/publishing.py",
+        "pulp_rpm/app/tasks/synchronizing.py"
+      ],
+      "gold_funcs": [
+        [
+          "pulp_rpm/app/tasks/publishing.py",
+          "PublicationData",
+          "publish_artifacts"
+        ],
+        [
+          "pulp_rpm/app/tasks/publishing.py",
+          "",
+          "generate_repo_metadata"
+        ],
+        [
+          "pulp_rpm/app/tasks/synchronizing.py",
+          "",
+          "add_metadata_to_publication"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "pulp_rpm/app/tasks/publishing.py",
+          "PublicationData",
+          "publish_artifacts"
+        ],
+        [
+          "pulp_rpm/app/tasks/publishing.py",
+          "",
+          "generate_repo_metadata"
+        ],
+        [
+          "pulp_rpm/app/tasks/synchronizing.py",
+          "",
+          "add_metadata_to_publication"
+        ]
+      ],
+      "n_files": 179,
+      "n_syms": 1453,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 6,
+          "all_file_worst": null,
+          "func_first": 16,
+          "wall_median": 0.041,
+          "wall_p95": 0.041,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5379,
+          "output_tokens_ceiling": 2280,
+          "candidate_bytes": 69582
+        }
+      }
+    },
+    {
+      "instance_id": "scipy__scipy-5647",
+      "partition": "train",
+      "repo": "scipy/scipy",
+      "gold_files": [
+        "benchmarks/benchmarks/spatial.py",
+        "scipy/spatial/ckdtree.pyx",
+        "scipy/spatial/ckdtree/src/build.cxx",
+        "scipy/spatial/ckdtree/src/ckdtree_decl.h",
+        "scipy/spatial/ckdtree/src/ckdtree_methods.h",
+        "scipy/spatial/ckdtree/src/count_neighbors.cxx",
+        "scipy/spatial/ckdtree/src/query.cxx",
+        "scipy/spatial/ckdtree/src/query_ball_point.cxx",
+        "scipy/spatial/ckdtree/src/query_ball_tree.cxx",
+        "scipy/spatial/ckdtree/src/query_pairs.cxx",
+        "scipy/spatial/ckdtree/src/sparse_distances.cxx"
+      ],
+      "primary_files": [
+        "benchmarks/benchmarks/spatial.py",
+        "scipy/spatial/ckdtree/src/build.cxx",
+        "scipy/spatial/ckdtree/src/ckdtree_decl.h",
+        "scipy/spatial/ckdtree/src/ckdtree_methods.h",
+        "scipy/spatial/ckdtree/src/count_neighbors.cxx",
+        "scipy/spatial/ckdtree/src/query.cxx",
+        "scipy/spatial/ckdtree/src/query_ball_point.cxx",
+        "scipy/spatial/ckdtree/src/query_ball_tree.cxx",
+        "scipy/spatial/ckdtree/src/query_pairs.cxx",
+        "scipy/spatial/ckdtree/src/sparse_distances.cxx"
+      ],
+      "gold_funcs": [
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "Neighbors",
+          "setup"
+        ],
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "Neighbors",
+          "time_sparse_distance_matrix"
+        ],
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "Neighbors",
+          "time_count_neighbors"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "CNeighbors",
+          "setup"
+        ],
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "CNeighbors",
+          "time_count_neighbors_deep"
+        ],
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "CNeighbors",
+          "time_count_neighbors_shallow"
+        ]
+      ],
+      "covered": [
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "Neighbors",
+          "setup"
+        ],
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "Neighbors",
+          "time_sparse_distance_matrix"
+        ],
+        [
+          "benchmarks/benchmarks/spatial.py",
+          "Neighbors",
+          "time_count_neighbors"
+        ]
+      ],
+      "n_files": 964,
+      "n_syms": 21981,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1756,
+          "wall_p95": 0.1756,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4435,
+          "output_tokens_ceiling": 1880,
+          "candidate_bytes": 56578
+        }
+      }
+    },
+    {
+      "instance_id": "plone__plone.restapi-859",
+      "partition": "train",
+      "repo": "plone/plone.restapi",
+      "gold_files": [
+        "news/857.bugfix",
+        "src/plone/restapi/deserializer/local_roles.py"
+      ],
+      "primary_files": [
+        "src/plone/restapi/deserializer/local_roles.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/plone/restapi/deserializer/local_roles.py",
+          "DeserializeFromJson",
+          "__call__"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/plone/restapi/deserializer/local_roles.py",
+          "DeserializeFromJson",
+          "__call__"
+        ]
+      ],
+      "n_files": 193,
+      "n_syms": 2324,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": null,
+          "func_first": 4,
+          "wall_median": 0.0514,
+          "wall_p95": 0.0514,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3782,
+          "output_tokens_ceiling": 1603,
+          "candidate_bytes": 75982
+        }
+      }
+    },
+    {
+      "instance_id": "rucio__rucio-4930",
+      "partition": "train",
+      "repo": "rucio/rucio",
+      "gold_files": [
+        "lib/rucio/web/ui/flask/common/utils.py"
+      ],
+      "primary_files": [
+        "lib/rucio/web/ui/flask/common/utils.py"
+      ],
+      "gold_funcs": [
+        [
+          "lib/rucio/web/ui/flask/common/utils.py",
+          "",
+          "add_cookies"
+        ],
+        [
+          "lib/rucio/web/ui/flask/common/utils.py",
+          "",
+          "redirect_to_last_known_url"
+        ],
+        [
+          "lib/rucio/web/ui/flask/common/utils.py",
+          "",
+          "finalize_auth"
+        ],
+        [
+          "lib/rucio/web/ui/flask/common/utils.py",
+          "",
+          "authenticate"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "lib/rucio/web/ui/flask/common/utils.py",
+          "",
+          "add_cookies"
+        ],
+        [
+          "lib/rucio/web/ui/flask/common/utils.py",
+          "",
+          "redirect_to_last_known_url"
+        ],
+        [
+          "lib/rucio/web/ui/flask/common/utils.py",
+          "",
+          "finalize_auth"
+        ],
+        [
+          "lib/rucio/web/ui/flask/common/utils.py",
+          "",
+          "authenticate"
+        ]
+      ],
+      "n_files": 609,
+      "n_syms": 7645,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 2,
+          "wall_median": 0.1004,
+          "wall_p95": 0.1004,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3644,
+          "output_tokens_ceiling": 1545,
+          "candidate_bytes": 65609
+        }
+      }
+    },
+    {
+      "instance_id": "home-assistant__core-15182",
+      "partition": "train",
+      "repo": "home-assistant/core",
+      "gold_files": [
+        "homeassistant/components/http/__init__.py",
+        "homeassistant/components/http/real_ip.py"
+      ],
+      "primary_files": [
+        "homeassistant/components/http/__init__.py",
+        "homeassistant/components/http/real_ip.py"
+      ],
+      "gold_funcs": [
+        [
+          "homeassistant/components/http/__init__.py",
+          "HomeAssistantHTTP",
+          "__init__"
+        ],
+        [
+          "homeassistant/components/http/real_ip.py",
+          "",
+          "setup_real_ip"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "homeassistant/components/http/__init__.py",
+          "HomeAssistantHTTP",
+          "__init__"
+        ],
+        [
+          "homeassistant/components/http/real_ip.py",
+          "",
+          "setup_real_ip"
+        ]
+      ],
+      "n_files": 1991,
+      "n_syms": 36596,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 2,
+          "wall_median": 0.2184,
+          "wall_p95": 0.2184,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3647,
+          "output_tokens_ceiling": 1546,
+          "candidate_bytes": 70124
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-3404",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/push.yml",
+        "modin/experimental/xgboost/xgboost.py",
+        "modin/experimental/xgboost/xgboost_ray.py"
+      ],
+      "primary_files": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/push.yml",
+        "modin/experimental/xgboost/xgboost.py",
+        "modin/experimental/xgboost/xgboost_ray.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "__init__"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "Booster",
+          "predict"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "ModinXGBoostActor",
+          "_get_dmatrix"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "ModinXGBoostActor",
+          "set_train_data"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "ModinXGBoostActor",
+          "add_eval_data"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "",
+          "_train"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "",
+          "_map_predict"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "",
+          "_predict"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "get_dmatrix_params"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "feature_names"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "feature_types"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "num_row"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "num_col"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "get_float_info"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "set_info"
+        ]
+      ],
+      "covered": [
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "DMatrix",
+          "__init__"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost.py",
+          "Booster",
+          "predict"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "ModinXGBoostActor",
+          "_get_dmatrix"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "ModinXGBoostActor",
+          "set_train_data"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "ModinXGBoostActor",
+          "add_eval_data"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "",
+          "_train"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "",
+          "_map_predict"
+        ],
+        [
+          "modin/experimental/xgboost/xgboost_ray.py",
+          "",
+          "_predict"
+        ]
+      ],
+      "n_files": 295,
+      "n_syms": 6052,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 13,
+          "wall_median": 0.0718,
+          "wall_p95": 0.0718,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4009,
+          "output_tokens_ceiling": 1699,
+          "candidate_bytes": 83109
+        }
+      }
+    },
+    {
+      "instance_id": "matchms__matchms-backup-187",
+      "partition": "train",
+      "repo": "matchms/matchms-backup",
+      "gold_files": [
+        "environment.yml",
+        "matchms/filtering/derive_inchi_from_smiles.py",
+        "matchms/filtering/derive_inchikey_from_inchi.py",
+        "matchms/filtering/derive_smiles_from_inchi.py",
+        "matchms/utils.py",
+        "meta.yaml"
+      ],
+      "primary_files": [
+        "environment.yml",
+        "matchms/filtering/derive_inchi_from_smiles.py",
+        "matchms/filtering/derive_inchikey_from_inchi.py",
+        "matchms/filtering/derive_smiles_from_inchi.py",
+        "matchms/utils.py"
+      ],
+      "gold_funcs": [
+        [
+          "matchms/filtering/derive_inchi_from_smiles.py",
+          "",
+          "derive_inchi_from_smiles"
+        ],
+        [
+          "matchms/filtering/derive_inchikey_from_inchi.py",
+          "",
+          "derive_inchikey_from_inchi"
+        ],
+        [
+          "matchms/filtering/derive_smiles_from_inchi.py",
+          "",
+          "derive_smiles_from_inchi"
+        ],
+        [
+          "matchms/utils.py",
+          "",
+          "mol_converter"
+        ],
+        [
+          "matchms/utils.py",
+          "",
+          "is_valid_inchi"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "matchms/utils.py",
+          "",
+          "convert_smiles_to_inchi"
+        ],
+        [
+          "matchms/utils.py",
+          "",
+          "convert_inchi_to_smiles"
+        ],
+        [
+          "matchms/utils.py",
+          "",
+          "convert_inchi_to_inchikey"
+        ]
+      ],
+      "covered": [
+        [
+          "matchms/filtering/derive_inchi_from_smiles.py",
+          "",
+          "derive_inchi_from_smiles"
+        ],
+        [
+          "matchms/filtering/derive_inchikey_from_inchi.py",
+          "",
+          "derive_inchikey_from_inchi"
+        ],
+        [
+          "matchms/filtering/derive_smiles_from_inchi.py",
+          "",
+          "derive_smiles_from_inchi"
+        ],
+        [
+          "matchms/utils.py",
+          "",
+          "mol_converter"
+        ],
+        [
+          "matchms/utils.py",
+          "",
+          "is_valid_inchi"
+        ]
+      ],
+      "n_files": 78,
+      "n_syms": 282,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 30,
+          "all_file_worst": null,
+          "func_first": 1,
+          "wall_median": 0.0333,
+          "wall_p95": 0.0333,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6226,
+          "output_tokens_ceiling": 2639,
+          "candidate_bytes": 59583
+        }
+      }
+    },
+    {
+      "instance_id": "latchset__jwcrypto-195",
+      "partition": "train",
+      "repo": "latchset/jwcrypto",
+      "gold_files": [
+        "README.md",
+        "jwcrypto/jwe.py",
+        "jwcrypto/jwt.py"
+      ],
+      "primary_files": [
+        "README.md",
+        "jwcrypto/jwe.py",
+        "jwcrypto/jwt.py"
+      ],
+      "gold_funcs": [
+        [
+          "jwcrypto/jwt.py",
+          "JWT",
+          "make_encrypted_token"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jwcrypto/jwt.py",
+          "JWT",
+          "make_encrypted_token"
+        ]
+      ],
+      "n_files": 11,
+      "n_syms": 742,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 8,
+          "all_file_worst": 8,
+          "func_first": 14,
+          "wall_median": 0.0313,
+          "wall_p95": 0.0313,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3103,
+          "output_tokens_ceiling": 1315,
+          "candidate_bytes": 65148
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-25114",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "CHANGELOG.md",
+        "jax/_src/compiler.py",
+        "jax/_src/config.py"
+      ],
+      "primary_files": [
+        "CHANGELOG.md",
+        "jax/_src/compiler.py",
+        "jax/_src/config.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/compiler.py",
+          "",
+          "get_compile_options"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/compiler.py",
+          "",
+          "get_compile_options"
+        ]
+      ],
+      "n_files": 867,
+      "n_syms": 32621,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 2,
+          "wall_median": 0.2962,
+          "wall_p95": 0.2962,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4586,
+          "output_tokens_ceiling": 1944,
+          "candidate_bytes": 68248
+        }
+      }
+    },
+    {
+      "instance_id": "fractal-analytics-platform__fractal-tasks-core-889",
+      "partition": "train",
+      "repo": "fractal-analytics-platform/fractal-tasks-core",
+      "gold_files": [
+        "CHANGELOG.md",
+        "fractal_tasks_core/tasks/cellpose_segmentation.py"
+      ],
+      "primary_files": [
+        "CHANGELOG.md",
+        "fractal_tasks_core/tasks/cellpose_segmentation.py"
+      ],
+      "gold_funcs": [
+        [
+          "fractal_tasks_core/tasks/cellpose_segmentation.py",
+          "",
+          "cellpose_segmentation"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "fractal_tasks_core/tasks/cellpose_segmentation.py",
+          "",
+          "cellpose_segmentation"
+        ]
+      ],
+      "n_files": 225,
+      "n_syms": 1586,
+      "arms": {
+        "for": {
+          "file_first": 9,
+          "file_worst": 42,
+          "all_file_worst": 42,
+          "func_first": 19,
+          "wall_median": 0.0458,
+          "wall_p95": 0.0458,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7393,
+          "output_tokens_ceiling": 3133,
+          "candidate_bytes": 81755
+        }
+      }
+    },
+    {
+      "instance_id": "OpenEnergyPlatform__open-MaStR-598",
+      "partition": "train",
+      "repo": "OpenEnergyPlatform/open-MaStR",
+      "gold_files": [
+        "CHANGELOG.md",
+        "CITATION.cff",
+        "open_mastr/xml_download/utils_write_to_database.py"
+      ],
+      "primary_files": [
+        "CHANGELOG.md",
+        "open_mastr/xml_download/utils_write_to_database.py"
+      ],
+      "gold_funcs": [
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "write_mastr_xml_to_database"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "is_table_relevant"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "create_database_table"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "cast_date_columns_to_datetime"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "is_date_column"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "preprocess_table_for_writing_to_database"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "change_column_names_to_orm_format"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "add_table_to_database"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "write_single_entries_until_not_unique_comes_up"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "add_missing_columns_to_table"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "extract_xml_table_name"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "extract_sql_table_name"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "cast_date_columns_to_string"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "read_xml_file"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "add_table_to_non_sqlite_database"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "process_table_before_insertion"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "add_table_to_sqlite_database"
+        ]
+      ],
+      "covered": [
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "write_mastr_xml_to_database"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "is_table_relevant"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "create_database_table"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "cast_date_columns_to_datetime"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "is_date_column"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "preprocess_table_for_writing_to_database"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "change_column_names_to_orm_format"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "add_table_to_database"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "write_single_entries_until_not_unique_comes_up"
+        ],
+        [
+          "open_mastr/xml_download/utils_write_to_database.py",
+          "",
+          "add_missing_columns_to_table"
+        ]
+      ],
+      "n_files": 87,
+      "n_syms": 982,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 17,
+          "all_file_worst": null,
+          "func_first": 0,
+          "wall_median": 0.034,
+          "wall_p95": 0.034,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7273,
+          "output_tokens_ceiling": 3082,
+          "candidate_bytes": 68777
+        }
+      }
+    },
+    {
+      "instance_id": "kedro-org__kedro-4367",
+      "partition": "train",
+      "repo": "kedro-org/kedro",
+      "gold_files": [
+        "RELEASE.md",
+        "kedro/config/omegaconf_config.py"
+      ],
+      "primary_files": [
+        "RELEASE.md",
+        "kedro/config/omegaconf_config.py"
+      ],
+      "gold_funcs": [
+        [
+          "kedro/config/omegaconf_config.py",
+          "OmegaConfigLoader",
+          "__init__"
+        ],
+        [
+          "kedro/config/omegaconf_config.py",
+          "OmegaConfigLoader",
+          "load_and_merge_dir_config"
+        ],
+        [
+          "kedro/config/omegaconf_config.py",
+          "OmegaConfigLoader",
+          "_get_globals_value"
+        ],
+        [
+          "kedro/config/omegaconf_config.py",
+          "OmegaConfigLoader",
+          "_get_runtime_value"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "kedro/config/omegaconf_config.py",
+          "OmegaConfigLoader",
+          "__init__"
+        ],
+        [
+          "kedro/config/omegaconf_config.py",
+          "OmegaConfigLoader",
+          "load_and_merge_dir_config"
+        ],
+        [
+          "kedro/config/omegaconf_config.py",
+          "OmegaConfigLoader",
+          "_get_globals_value"
+        ],
+        [
+          "kedro/config/omegaconf_config.py",
+          "OmegaConfigLoader",
+          "_get_runtime_value"
+        ]
+      ],
+      "n_files": 338,
+      "n_syms": 4808,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 15,
+          "all_file_worst": 15,
+          "func_first": 1,
+          "wall_median": 0.0586,
+          "wall_p95": 0.0586,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4427,
+          "output_tokens_ceiling": 1876,
+          "candidate_bytes": 75572
+        }
+      }
+    },
+    {
+      "instance_id": "Qiskit__qiskit-13052",
+      "partition": "train",
+      "repo": "Qiskit/qiskit",
+      "gold_files": [
+        "crates/accelerate/src/filter_op_nodes.rs",
+        "crates/accelerate/src/lib.rs",
+        "crates/accelerate/src/remove_diagonal_gates_before_measure.rs",
+        "crates/circuit/src/dag_circuit.rs",
+        "crates/circuit/src/packed_instruction.rs",
+        "crates/pyext/src/lib.rs",
+        "qiskit/__init__.py",
+        "qiskit/transpiler/passes/utils/filter_op_nodes.py"
+      ],
+      "primary_files": [
+        "crates/accelerate/src/lib.rs",
+        "crates/accelerate/src/remove_diagonal_gates_before_measure.rs",
+        "crates/circuit/src/dag_circuit.rs",
+        "crates/circuit/src/packed_instruction.rs",
+        "crates/pyext/src/lib.rs",
+        "qiskit/__init__.py",
+        "qiskit/transpiler/passes/utils/filter_op_nodes.py"
+      ],
+      "gold_funcs": [
+        [
+          "qiskit/transpiler/passes/utils/filter_op_nodes.py",
+          "FilterOpNodes",
+          "run"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "qiskit/transpiler/passes/utils/filter_op_nodes.py",
+          "FilterOpNodes",
+          "run"
+        ]
+      ],
+      "n_files": 2827,
+      "n_syms": 23316,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.2259,
+          "wall_p95": 0.2259,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2020,
+          "output_tokens_ceiling": 856,
+          "candidate_bytes": 82016
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-7209",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/core/evictor.py"
+      ],
+      "primary_files": [
+        "vllm/core/evictor.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/core/evictor.py",
+          "LRUEvictor",
+          "__init__"
+        ],
+        [
+          "vllm/core/evictor.py",
+          "LRUEvictor",
+          "evict"
+        ],
+        [
+          "vllm/core/evictor.py",
+          "LRUEvictor",
+          "add"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "vllm/core/evictor.py",
+          "LRUEvictor",
+          "_cleanup_if_necessary"
+        ],
+        [
+          "vllm/core/evictor.py",
+          "LRUEvictor",
+          "_cleanup"
+        ]
+      ],
+      "covered": [
+        [
+          "vllm/core/evictor.py",
+          "LRUEvictor",
+          "__init__"
+        ],
+        [
+          "vllm/core/evictor.py",
+          "LRUEvictor",
+          "evict"
+        ],
+        [
+          "vllm/core/evictor.py",
+          "LRUEvictor",
+          "add"
+        ]
+      ],
+      "n_files": 1227,
+      "n_syms": 26308,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1916,
+          "wall_p95": 0.1916,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3577,
+          "output_tokens_ceiling": 1516,
+          "candidate_bytes": 71253
+        }
+      }
+    },
+    {
+      "instance_id": "kiasambrook__tfl-live-tracker-7",
+      "partition": "train",
+      "repo": "kiasambrook/tfl-live-tracker",
+      "gold_files": [
+        "app/api/tfl_api.py",
+        "app/ui/main_window.py",
+        "requirements.txt"
+      ],
+      "primary_files": [
+        "app/api/tfl_api.py",
+        "app/ui/main_window.py"
+      ],
+      "gold_funcs": [
+        [
+          "app/api/tfl_api.py",
+          "TfLAPI",
+          "fetch_all_stop_points"
+        ],
+        [
+          "app/ui/main_window.py",
+          "MainWindow",
+          "build"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "app/api/tfl_api.py",
+          "TfLAPI",
+          "fetch_all_stop_points"
+        ],
+        [
+          "app/ui/main_window.py",
+          "MainWindow",
+          "build"
+        ]
+      ],
+      "n_files": 9,
+      "n_syms": 28,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 6,
+          "all_file_worst": null,
+          "func_first": 5,
+          "wall_median": 0.0279,
+          "wall_p95": 0.0279,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6589,
+          "output_tokens_ceiling": 2792,
+          "candidate_bytes": 8935
+        }
+      }
+    },
+    {
+      "instance_id": "ckan__ckan-8226",
+      "partition": "train",
+      "repo": "ckan/ckan",
+      "gold_files": [
+        "changes/6146.feature",
+        "ckan/config/middleware/flask_app.py",
+        "ckan/lib/helpers.py",
+        "ckan/lib/jinja_extensions.py",
+        "ckan/templates/group/read.html",
+        "ckan/templates/organization/bulk_process.html",
+        "ckan/templates/organization/read.html",
+        "ckan/templates/package/search.html",
+        "ckan/templates/package/snippets/package_form.html",
+        "ckan/templates/package/snippets/resource_form.html"
+      ],
+      "primary_files": [
+        "ckan/config/middleware/flask_app.py",
+        "ckan/lib/helpers.py",
+        "ckan/lib/jinja_extensions.py",
+        "ckan/templates/group/read.html",
+        "ckan/templates/organization/bulk_process.html",
+        "ckan/templates/organization/read.html",
+        "ckan/templates/package/search.html",
+        "ckan/templates/package/snippets/package_form.html",
+        "ckan/templates/package/snippets/resource_form.html"
+      ],
+      "gold_funcs": [
+        [
+          "ckan/config/middleware/flask_app.py",
+          "",
+          "_ungettext_alias"
+        ],
+        [
+          "ckan/config/middleware/flask_app.py",
+          "",
+          "make_flask_stack"
+        ],
+        [
+          "ckan/config/middleware/flask_app.py",
+          "",
+          "helper_functions"
+        ],
+        [
+          "ckan/config/middleware/flask_app.py",
+          "",
+          "c_object"
+        ],
+        [
+          "ckan/lib/helpers.py",
+          "",
+          "snippet"
+        ],
+        [
+          "ckan/lib/jinja_extensions.py",
+          "CkanFileSystemLoader",
+          "get_source"
+        ],
+        [
+          "ckan/lib/jinja_extensions.py",
+          "SnippetExtension",
+          "_call"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "ckan/lib/jinja_extensions.py",
+          "SnippetExtension",
+          "parse"
+        ]
+      ],
+      "covered": [
+        [
+          "ckan/config/middleware/flask_app.py",
+          "",
+          "_ungettext_alias"
+        ],
+        [
+          "ckan/config/middleware/flask_app.py",
+          "",
+          "make_flask_stack"
+        ],
+        [
+          "ckan/config/middleware/flask_app.py",
+          "",
+          "helper_functions"
+        ],
+        [
+          "ckan/config/middleware/flask_app.py",
+          "",
+          "c_object"
+        ],
+        [
+          "ckan/lib/helpers.py",
+          "",
+          "snippet"
+        ],
+        [
+          "ckan/lib/jinja_extensions.py",
+          "CkanFileSystemLoader",
+          "get_source"
+        ],
+        [
+          "ckan/lib/jinja_extensions.py",
+          "SnippetExtension",
+          "_call"
+        ]
+      ],
+      "n_files": 1063,
+      "n_syms": 9914,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 1,
+          "wall_median": 0.1029,
+          "wall_p95": 0.1029,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3838,
+          "output_tokens_ceiling": 1627,
+          "candidate_bytes": 64400
+        }
+      }
+    },
+    {
+      "instance_id": "nautobot__nautobot-6364",
+      "partition": "train",
+      "repo": "nautobot/nautobot",
+      "gold_files": [
+        "changes/6297.fixed",
+        "nautobot/core/models/tree_queries.py",
+        "nautobot/core/signals.py",
+        "nautobot/extras/models/groups.py",
+        "nautobot/extras/views.py"
+      ],
+      "primary_files": [
+        "nautobot/core/models/tree_queries.py",
+        "nautobot/core/signals.py",
+        "nautobot/extras/models/groups.py",
+        "nautobot/extras/views.py"
+      ],
+      "gold_funcs": [
+        [
+          "nautobot/core/signals.py",
+          "",
+          "invalidate_max_depth_cache"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "_set_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "add_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "_add_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "remove_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "_remove_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "update_cached_members"
+        ],
+        [
+          "nautobot/extras/views.py",
+          "DynamicGroupView",
+          "get_extra_context"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "nautobot/core/models/tree_queries.py",
+          "TreeModel",
+          "__init_subclass__"
+        ]
+      ],
+      "covered": [
+        [
+          "nautobot/core/signals.py",
+          "",
+          "invalidate_max_depth_cache"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "_set_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "add_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "_add_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "remove_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "_remove_members"
+        ],
+        [
+          "nautobot/extras/models/groups.py",
+          "DynamicGroup",
+          "update_cached_members"
+        ],
+        [
+          "nautobot/extras/views.py",
+          "DynamicGroupView",
+          "get_extra_context"
+        ]
+      ],
+      "n_files": 1667,
+      "n_syms": 23818,
+      "arms": {
+        "for": {
+          "file_first": 14,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 101,
+          "wall_median": 0.1504,
+          "wall_p95": 0.1504,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4008,
+          "output_tokens_ceiling": 1699,
+          "candidate_bytes": 71502
+        }
+      }
+    },
+    {
+      "instance_id": "UXARRAY__uxarray-1144",
+      "partition": "train",
+      "repo": "UXARRAY/uxarray",
+      "gold_files": [
+        "uxarray/formatting_html.py",
+        "uxarray/grid/grid.py"
+      ],
+      "primary_files": [
+        "uxarray/formatting_html.py",
+        "uxarray/grid/grid.py"
+      ],
+      "gold_funcs": [
+        [
+          "uxarray/formatting_html.py",
+          "",
+          "_grid_sections"
+        ],
+        [
+          "uxarray/grid/grid.py",
+          "Grid",
+          "__repr__"
+        ],
+        [
+          "uxarray/grid/grid.py",
+          "Grid",
+          "face_node_connectivity"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "uxarray/formatting_html.py",
+          "",
+          "_grid_sections"
+        ],
+        [
+          "uxarray/grid/grid.py",
+          "Grid",
+          "__repr__"
+        ],
+        [
+          "uxarray/grid/grid.py",
+          "Grid",
+          "face_node_connectivity"
+        ]
+      ],
+      "n_files": 158,
+      "n_syms": 1529,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": 34,
+          "all_file_worst": 34,
+          "func_first": 21,
+          "wall_median": 0.0425,
+          "wall_p95": 0.0425,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7278,
+          "output_tokens_ceiling": 3084,
+          "candidate_bytes": 71293
+        }
+      }
+    },
+    {
+      "instance_id": "UXARRAY__uxarray-1151",
+      "partition": "train",
+      "repo": "UXARRAY/uxarray",
+      "gold_files": [
+        "uxarray/grid/slice.py",
+        "uxarray/subset/dataarray_accessor.py",
+        "uxarray/subset/grid_accessor.py"
+      ],
+      "primary_files": [
+        "uxarray/grid/slice.py",
+        "uxarray/subset/dataarray_accessor.py",
+        "uxarray/subset/grid_accessor.py"
+      ],
+      "gold_funcs": [
+        [
+          "uxarray/grid/slice.py",
+          "",
+          "_slice_face_indices"
+        ],
+        [
+          "uxarray/subset/dataarray_accessor.py",
+          "DataArraySubsetAccessor",
+          "bounding_circle"
+        ],
+        [
+          "uxarray/subset/dataarray_accessor.py",
+          "DataArraySubsetAccessor",
+          "nearest_neighbor"
+        ],
+        [
+          "uxarray/subset/grid_accessor.py",
+          "GridSubsetAccessor",
+          "bounding_circle"
+        ],
+        [
+          "uxarray/subset/grid_accessor.py",
+          "GridSubsetAccessor",
+          "nearest_neighbor"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "uxarray/grid/slice.py",
+          "",
+          "_slice_face_indices"
+        ],
+        [
+          "uxarray/subset/dataarray_accessor.py",
+          "DataArraySubsetAccessor",
+          "bounding_circle"
+        ],
+        [
+          "uxarray/subset/dataarray_accessor.py",
+          "DataArraySubsetAccessor",
+          "nearest_neighbor"
+        ],
+        [
+          "uxarray/subset/grid_accessor.py",
+          "GridSubsetAccessor",
+          "bounding_circle"
+        ],
+        [
+          "uxarray/subset/grid_accessor.py",
+          "GridSubsetAccessor",
+          "nearest_neighbor"
+        ]
+      ],
+      "n_files": 158,
+      "n_syms": 1529,
+      "arms": {
+        "for": {
+          "file_first": 5,
+          "file_worst": 7,
+          "all_file_worst": 7,
+          "func_first": 12,
+          "wall_median": 0.0426,
+          "wall_p95": 0.0426,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7429,
+          "output_tokens_ceiling": 3148,
+          "candidate_bytes": 68924
+        }
+      }
+    },
+    {
+      "instance_id": "nautobot__nautobot-6837",
+      "partition": "train",
+      "repo": "nautobot/nautobot",
+      "gold_files": [
+        "changes/6767.added",
+        "changes/6767.fixed",
+        "nautobot/core/views/utils.py",
+        "nautobot/dcim/templates/dcim/device.html",
+        "nautobot/dcim/views.py",
+        "nautobot/extras/models/customfields.py",
+        "nautobot/extras/signals.py"
+      ],
+      "primary_files": [
+        "nautobot/core/views/utils.py",
+        "nautobot/dcim/templates/dcim/device.html",
+        "nautobot/dcim/views.py",
+        "nautobot/extras/models/customfields.py",
+        "nautobot/extras/signals.py"
+      ],
+      "gold_funcs": [
+        [
+          "nautobot/core/views/utils.py",
+          "",
+          "get_csv_form_fields_from_serializer_class"
+        ],
+        [
+          "nautobot/extras/models/customfields.py",
+          "CustomFieldManager",
+          "get_for_model"
+        ],
+        [
+          "nautobot/extras/models/customfields.py",
+          "CustomField",
+          "to_form_field"
+        ],
+        [
+          "nautobot/extras/models/customfields.py",
+          "CustomField",
+          "validate"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "nautobot/extras/models/customfields.py",
+          "CustomField",
+          "choices_cache_key"
+        ],
+        [
+          "nautobot/extras/models/customfields.py",
+          "CustomField",
+          "choices"
+        ],
+        [
+          "nautobot/extras/signals.py",
+          "",
+          "invalidate_choices_cache"
+        ]
+      ],
+      "covered": [
+        [
+          "nautobot/core/views/utils.py",
+          "",
+          "get_csv_form_fields_from_serializer_class"
+        ],
+        [
+          "nautobot/extras/models/customfields.py",
+          "CustomFieldManager",
+          "get_for_model"
+        ],
+        [
+          "nautobot/extras/models/customfields.py",
+          "CustomField",
+          "to_form_field"
+        ],
+        [
+          "nautobot/extras/models/customfields.py",
+          "CustomField",
+          "validate"
+        ]
+      ],
+      "n_files": 1805,
+      "n_syms": 25181,
+      "arms": {
+        "for": {
+          "file_first": 9,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1648,
+          "wall_p95": 0.1648,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4139,
+          "output_tokens_ceiling": 1754,
+          "candidate_bytes": 75054
+        }
+      }
+    },
+    {
+      "instance_id": "spacetelescope__stcal-337",
+      "partition": "train",
+      "repo": "spacetelescope/stcal",
+      "gold_files": [
+        "changes/337.general.rst",
+        "src/stcal/jump/jump.py",
+        "src/stcal/jump/twopoint_difference.py"
+      ],
+      "primary_files": [
+        "src/stcal/jump/jump.py",
+        "src/stcal/jump/twopoint_difference.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "extend_saturation"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "extend_ellipses"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "find_last_grp"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "find_faint_extended"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "get_bigcontours"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "diff_meddiff_int"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "diff_meddiff_grp"
+        ],
+        [
+          "src/stcal/jump/twopoint_difference.py",
+          "",
+          "find_crs_old"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "ellipse_subim"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "convolve_fast"
+        ],
+        [
+          "src/stcal/jump/twopoint_difference.py",
+          "",
+          "propagate_flags"
+        ]
+      ],
+      "covered": [
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "extend_saturation"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "extend_ellipses"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "find_last_grp"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "find_faint_extended"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "get_bigcontours"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "diff_meddiff_int"
+        ],
+        [
+          "src/stcal/jump/jump.py",
+          "",
+          "diff_meddiff_grp"
+        ],
+        [
+          "src/stcal/jump/twopoint_difference.py",
+          "",
+          "find_crs_old"
+        ]
+      ],
+      "n_files": 65,
+      "n_syms": 1211,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 2,
+          "all_file_worst": null,
+          "func_first": 0,
+          "wall_median": 0.0392,
+          "wall_p95": 0.0392,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7427,
+          "output_tokens_ceiling": 3148,
+          "candidate_bytes": 65815
+        }
+      }
+    },
+    {
+      "instance_id": "hyeneung__tech-blog-hub-site-49",
+      "partition": "train",
+      "repo": "hyeneung/tech-blog-hub-site",
+      "gold_files": [
+        "serverless/apis/recommend/lambda_function.py",
+        "serverless/apis/recommend/opensearch/article_analyze.py",
+        "serverless/apis/recommend/recommend.py",
+        "serverless/apis/recommend/requirements.txt",
+        "serverless/apis/search/go.mod",
+        "serverless/apis/search/go.sum",
+        "serverless/apis/search/internal/handler/handler.go",
+        "serverless/apis/search/internal/service/search.go",
+        "serverless/apis/search/main.go",
+        "serverless/crawler/config/config.go",
+        "serverless/crawler/go.mod",
+        "serverless/crawler/go.sum",
+        "serverless/crawler/internal/crawler/crawler.go",
+        "serverless/crawler/internal/db/elasticsearch.go",
+        "serverless/crawler/internal/db/opensearch.go",
+        "serverless/crawler/main.go"
+      ],
+      "primary_files": [
+        "serverless/apis/recommend/lambda_function.py",
+        "serverless/apis/recommend/opensearch/article_analyze.py",
+        "serverless/apis/recommend/recommend.py",
+        "serverless/apis/search/internal/handler/handler.go",
+        "serverless/apis/search/internal/service/search.go",
+        "serverless/apis/search/main.go",
+        "serverless/crawler/config/config.go",
+        "serverless/crawler/internal/crawler/crawler.go",
+        "serverless/crawler/internal/db/opensearch.go",
+        "serverless/crawler/main.go"
+      ],
+      "gold_funcs": [
+        [
+          "serverless/apis/recommend/opensearch/article_analyze.py",
+          "",
+          "get_db_dataframe"
+        ],
+        [
+          "serverless/apis/recommend/opensearch/article_analyze.py",
+          "",
+          "get_contents_base_recommendations"
+        ],
+        [
+          "serverless/apis/recommend/recommend.py",
+          "",
+          "get_recommend_articles_by_url"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "serverless/apis/recommend/opensearch/article_analyze.py",
+          "",
+          "get_db_dataframe"
+        ],
+        [
+          "serverless/apis/recommend/opensearch/article_analyze.py",
+          "",
+          "get_contents_base_recommendations"
+        ],
+        [
+          "serverless/apis/recommend/recommend.py",
+          "",
+          "get_recommend_articles_by_url"
+        ]
+      ],
+      "n_files": 151,
+      "n_syms": 856,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 48,
+          "all_file_worst": null,
+          "func_first": 63,
+          "wall_median": 0.0358,
+          "wall_p95": 0.0358,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5814,
+          "output_tokens_ceiling": 2464,
+          "candidate_bytes": 71560
+        }
+      }
+    },
+    {
+      "instance_id": "home-assistant__core-136739",
+      "partition": "train",
+      "repo": "home-assistant/core",
+      "gold_files": [
+        "homeassistant/components/fritzbox/climate.py",
+        "homeassistant/components/fritzbox/cover.py",
+        "homeassistant/components/fritzbox/light.py",
+        "homeassistant/components/fritzbox/switch.py"
+      ],
+      "primary_files": [
+        "homeassistant/components/fritzbox/climate.py",
+        "homeassistant/components/fritzbox/cover.py",
+        "homeassistant/components/fritzbox/light.py",
+        "homeassistant/components/fritzbox/switch.py"
+      ],
+      "gold_funcs": [
+        [
+          "homeassistant/components/fritzbox/climate.py",
+          "FritzboxThermostat",
+          "async_set_temperature"
+        ],
+        [
+          "homeassistant/components/fritzbox/cover.py",
+          "FritzboxCover",
+          "async_open_cover"
+        ],
+        [
+          "homeassistant/components/fritzbox/cover.py",
+          "FritzboxCover",
+          "async_close_cover"
+        ],
+        [
+          "homeassistant/components/fritzbox/cover.py",
+          "FritzboxCover",
+          "async_set_cover_position"
+        ],
+        [
+          "homeassistant/components/fritzbox/cover.py",
+          "FritzboxCover",
+          "async_stop_cover"
+        ],
+        [
+          "homeassistant/components/fritzbox/light.py",
+          "FritzboxLight",
+          "async_turn_on"
+        ],
+        [
+          "homeassistant/components/fritzbox/light.py",
+          "FritzboxLight",
+          "async_turn_off"
+        ],
+        [
+          "homeassistant/components/fritzbox/switch.py",
+          "FritzboxSwitch",
+          "async_turn_on"
+        ],
+        [
+          "homeassistant/components/fritzbox/switch.py",
+          "FritzboxSwitch",
+          "async_turn_off"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "homeassistant/components/fritzbox/climate.py",
+          "FritzboxThermostat",
+          "async_set_temperature"
+        ],
+        [
+          "homeassistant/components/fritzbox/cover.py",
+          "FritzboxCover",
+          "async_open_cover"
+        ],
+        [
+          "homeassistant/components/fritzbox/cover.py",
+          "FritzboxCover",
+          "async_close_cover"
+        ],
+        [
+          "homeassistant/components/fritzbox/cover.py",
+          "FritzboxCover",
+          "async_set_cover_position"
+        ],
+        [
+          "homeassistant/components/fritzbox/cover.py",
+          "FritzboxCover",
+          "async_stop_cover"
+        ],
+        [
+          "homeassistant/components/fritzbox/light.py",
+          "FritzboxLight",
+          "async_turn_on"
+        ],
+        [
+          "homeassistant/components/fritzbox/light.py",
+          "FritzboxLight",
+          "async_turn_off"
+        ],
+        [
+          "homeassistant/components/fritzbox/switch.py",
+          "FritzboxSwitch",
+          "async_turn_on"
+        ],
+        [
+          "homeassistant/components/fritzbox/switch.py",
+          "FritzboxSwitch",
+          "async_turn_off"
+        ]
+      ],
+      "n_files": 17144,
+      "n_syms": 207938,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 1.4093,
+          "wall_p95": 1.4093,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5435,
+          "output_tokens_ceiling": 2303,
+          "candidate_bytes": 79467
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-9338",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "benchmarks/benchmark_serving.py"
+      ],
+      "primary_files": [
+        "benchmarks/benchmark_serving.py"
+      ],
+      "gold_funcs": [
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "calculate_metrics"
+        ],
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "benchmark"
+        ],
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "main"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "check_goodput_args"
+        ],
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "parse_goodput"
+        ]
+      ],
+      "covered": [
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "calculate_metrics"
+        ],
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "benchmark"
+        ],
+        [
+          "benchmarks/benchmark_serving.py",
+          "",
+          "main"
+        ]
+      ],
+      "n_files": 1045,
+      "n_syms": 22799,
+      "arms": {
+        "for": {
+          "file_first": 58,
+          "file_worst": 58,
+          "all_file_worst": 58,
+          "func_first": 83,
+          "wall_median": 0.1654,
+          "wall_p95": 0.1654,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4613,
+          "output_tokens_ceiling": 1955,
+          "candidate_bytes": 81099
+        }
+      }
+    },
+    {
+      "instance_id": "Standard-Labs__real-intent-27",
+      "partition": "train",
+      "repo": "Standard-Labs/real-intent",
+      "gold_files": [
+        "bigdbm/validate/email.py",
+        "bigdbm/validate/phone.py"
+      ],
+      "primary_files": [
+        "bigdbm/validate/email.py",
+        "bigdbm/validate/phone.py"
+      ],
+      "gold_funcs": [
+        [
+          "bigdbm/validate/email.py",
+          "EmailValidator",
+          "__init__"
+        ],
+        [
+          "bigdbm/validate/email.py",
+          "EmailValidator",
+          "validate"
+        ],
+        [
+          "bigdbm/validate/phone.py",
+          "PhoneValidator",
+          "__init__"
+        ],
+        [
+          "bigdbm/validate/phone.py",
+          "PhoneValidator",
+          "validate"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "bigdbm/validate/email.py",
+          "EmailValidator",
+          "__init__"
+        ],
+        [
+          "bigdbm/validate/email.py",
+          "EmailValidator",
+          "validate"
+        ],
+        [
+          "bigdbm/validate/phone.py",
+          "PhoneValidator",
+          "__init__"
+        ],
+        [
+          "bigdbm/validate/phone.py",
+          "PhoneValidator",
+          "validate"
+        ]
+      ],
+      "n_files": 22,
+      "n_syms": 189,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 2,
+          "wall_median": 0.0301,
+          "wall_p95": 0.0301,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4441,
+          "output_tokens_ceiling": 1882,
+          "candidate_bytes": 65055
+        }
+      }
+    },
+    {
+      "instance_id": "Standard-Labs__real-intent-102",
+      "partition": "train",
+      "repo": "Standard-Labs/real-intent",
+      "gold_files": [
+        "real_intent/deliver/followupboss/vanilla.py",
+        "real_intent/deliver/kvcore/__init__.py"
+      ],
+      "primary_files": [
+        "real_intent/deliver/followupboss/vanilla.py",
+        "real_intent/deliver/kvcore/__init__.py"
+      ],
+      "gold_funcs": [
+        [
+          "real_intent/deliver/followupboss/vanilla.py",
+          "FollowUpBossDeliverer",
+          "_deliver"
+        ],
+        [
+          "real_intent/deliver/kvcore/__init__.py",
+          "KVCoreDeliverer",
+          "_deliver"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "real_intent/deliver/followupboss/vanilla.py",
+          "FollowUpBossDeliverer",
+          "_deliver"
+        ],
+        [
+          "real_intent/deliver/kvcore/__init__.py",
+          "KVCoreDeliverer",
+          "_deliver"
+        ]
+      ],
+      "n_files": 40,
+      "n_syms": 413,
+      "arms": {
+        "for": {
+          "file_first": 15,
+          "file_worst": 16,
+          "all_file_worst": 16,
+          "func_first": 151,
+          "wall_median": 0.0319,
+          "wall_p95": 0.0319,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6190,
+          "output_tokens_ceiling": 2623,
+          "candidate_bytes": 75706
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-7874",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/core/scheduler.py"
+      ],
+      "primary_files": [
+        "vllm/core/scheduler.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/core/scheduler.py",
+          "Scheduler",
+          "_schedule_chunked_prefill"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/core/scheduler.py",
+          "Scheduler",
+          "_schedule_chunked_prefill"
+        ]
+      ],
+      "n_files": 911,
+      "n_syms": 20455,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 1,
+          "wall_median": 0.1473,
+          "wall_p95": 0.1473,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4057,
+          "output_tokens_ceiling": 1720,
+          "candidate_bytes": 77335
+        }
+      }
+    },
+    {
+      "instance_id": "cupy__cupy-3730",
+      "partition": "train",
+      "repo": "cupy/cupy",
+      "gold_files": [
+        "cupy/cuda/cufft.pyx",
+        "cupy/fft/_cache.pyx",
+        "cupy/fft/config.py",
+        "cupy/fft/fft.py",
+        "cupy_setup_build.py",
+        "cupyx/scipy/fftpack/_fft.py",
+        "docs/source/reference/fft.rst"
+      ],
+      "primary_files": [
+        "cupy/fft/config.py",
+        "cupy/fft/fft.py",
+        "cupy_setup_build.py",
+        "cupyx/scipy/fftpack/_fft.py"
+      ],
+      "gold_funcs": [
+        [
+          "cupy/fft/config.py",
+          "",
+          "set_cufft_gpus"
+        ],
+        [
+          "cupy/fft/fft.py",
+          "",
+          "_exec_fft"
+        ],
+        [
+          "cupy/fft/fft.py",
+          "",
+          "_get_cufft_plan_nd"
+        ],
+        [
+          "cupyx/scipy/fftpack/_fft.py",
+          "",
+          "get_fft_plan"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "cupy/fft/config.py",
+          "",
+          "set_cufft_gpus"
+        ],
+        [
+          "cupy/fft/fft.py",
+          "",
+          "_exec_fft"
+        ],
+        [
+          "cupy/fft/fft.py",
+          "",
+          "_get_cufft_plan_nd"
+        ],
+        [
+          "cupyx/scipy/fftpack/_fft.py",
+          "",
+          "get_fft_plan"
+        ]
+      ],
+      "n_files": 443,
+      "n_syms": 12016,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 59,
+          "all_file_worst": null,
+          "func_first": 0,
+          "wall_median": 0.0917,
+          "wall_p95": 0.0917,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7297,
+          "output_tokens_ceiling": 3092,
+          "candidate_bytes": 52973
+        }
+      }
+    },
+    {
+      "instance_id": "Qiskit__qiskit-13141",
+      "partition": "train",
+      "repo": "Qiskit/qiskit",
+      "gold_files": [
+        "crates/accelerate/src/euler_one_qubit_decomposer.rs",
+        "crates/accelerate/src/lib.rs",
+        "crates/accelerate/src/two_qubit_decompose.rs",
+        "crates/accelerate/src/unitary_synthesis.rs",
+        "crates/circuit/src/dag_circuit.rs",
+        "crates/circuit/src/imports.rs",
+        "crates/pyext/src/lib.rs",
+        "qiskit/__init__.py",
+        "qiskit/transpiler/passes/synthesis/unitary_synthesis.py"
+      ],
+      "primary_files": [
+        "crates/accelerate/src/euler_one_qubit_decomposer.rs",
+        "crates/accelerate/src/lib.rs",
+        "crates/accelerate/src/two_qubit_decompose.rs",
+        "crates/circuit/src/dag_circuit.rs",
+        "crates/circuit/src/imports.rs",
+        "crates/pyext/src/lib.rs",
+        "qiskit/__init__.py",
+        "qiskit/transpiler/passes/synthesis/unitary_synthesis.py"
+      ],
+      "gold_funcs": [
+        [
+          "qiskit/transpiler/passes/synthesis/unitary_synthesis.py",
+          "UnitarySynthesis",
+          "run"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "qiskit/transpiler/passes/synthesis/unitary_synthesis.py",
+          "UnitarySynthesis",
+          "run"
+        ]
+      ],
+      "n_files": 2858,
+      "n_syms": 23534,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 7,
+          "wall_median": 0.2405,
+          "wall_p95": 0.2405,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3125,
+          "output_tokens_ceiling": 1325,
+          "candidate_bytes": 81333
+        }
+      }
+    },
+    {
+      "instance_id": "Happy-Algorithms-League__hal-cgp-180",
+      "partition": "train",
+      "repo": "Happy-Algorithms-League/hal-cgp",
+      "gold_files": [
+        "cgp/genome.py",
+        "cgp/population.py"
+      ],
+      "primary_files": [
+        "cgp/genome.py",
+        "cgp/population.py"
+      ],
+      "gold_funcs": [
+        [
+          "cgp/genome.py",
+          "Genome",
+          "dna"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "mutate"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_mutate_output_region"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_mutate_hidden_region"
+        ],
+        [
+          "cgp/population.py",
+          "Population",
+          "__init__"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_is_hidden_input_gene"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_select_gene_indices_for_mutation"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_determine_alternative_permissible_values"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_determine_alternative_permissible_values_hidden_gene"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_determine_alternative_permissible_values_output_gene"
+        ]
+      ],
+      "covered": [
+        [
+          "cgp/genome.py",
+          "Genome",
+          "dna"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "mutate"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_mutate_output_region"
+        ],
+        [
+          "cgp/genome.py",
+          "Genome",
+          "_mutate_hidden_region"
+        ],
+        [
+          "cgp/population.py",
+          "Population",
+          "__init__"
+        ]
+      ],
+      "n_files": 33,
+      "n_syms": 480,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 0,
+          "wall_median": 0.0317,
+          "wall_p95": 0.0317,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3826,
+          "output_tokens_ceiling": 1622,
+          "candidate_bytes": 69460
+        }
+      }
+    },
+    {
+      "instance_id": "oppia__oppia-14784",
+      "partition": "train",
+      "repo": "oppia/oppia",
+      "gold_files": [
+        "core/domain/opportunity_services.py",
+        "core/domain/suggestion_services.py",
+        "core/storage/suggestion/gae_models.py",
+        "core/templates/pages/contributor-dashboard-page/opportunities-list-item/opportunities-list-item.component.html"
+      ],
+      "primary_files": [
+        "core/domain/opportunity_services.py",
+        "core/domain/suggestion_services.py",
+        "core/storage/suggestion/gae_models.py",
+        "core/templates/pages/contributor-dashboard-page/opportunities-list-item/opportunities-list-item.component.html"
+      ],
+      "gold_funcs": [
+        [
+          "core/domain/opportunity_services.py",
+          "",
+          "get_exp_opportunity_summary_with_in_review_translations_from_model"
+        ],
+        [
+          "core/domain/opportunity_services.py",
+          "",
+          "get_translation_opportunities"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "core/domain/opportunity_services.py",
+          "",
+          "_build_exp_id_to_translation_suggestion_in_review_count"
+        ],
+        [
+          "core/domain/suggestion_services.py",
+          "",
+          "get_translation_suggestions_in_review_by_exp_ids"
+        ],
+        [
+          "core/storage/suggestion/gae_models.py",
+          "GeneralSuggestionModel",
+          "get_in_review_translation_suggestions_by_exp_ids"
+        ]
+      ],
+      "covered": [
+        [
+          "core/domain/opportunity_services.py",
+          "",
+          "get_exp_opportunity_summary_with_in_review_translations_from_model"
+        ],
+        [
+          "core/domain/opportunity_services.py",
+          "",
+          "get_translation_opportunities"
+        ]
+      ],
+      "n_files": 2886,
+      "n_syms": 56170,
+      "arms": {
+        "for": {
+          "file_first": 17,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 30,
+          "wall_median": 0.3085,
+          "wall_p95": 0.3085,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3370,
+          "output_tokens_ceiling": 1428,
+          "candidate_bytes": 69181
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-3438",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "docs/troubleshooting.rst",
+        "modin/backends/pandas/parsers.py"
+      ],
+      "primary_files": [
+        "modin/backends/pandas/parsers.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/backends/pandas/parsers.py",
+          "PandasParser",
+          "get_dtypes"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/backends/pandas/parsers.py",
+          "PandasParser",
+          "get_dtypes"
+        ]
+      ],
+      "n_files": 301,
+      "n_syms": 6098,
+      "arms": {
+        "for": {
+          "file_first": 50,
+          "file_worst": 50,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.0729,
+          "wall_p95": 0.0729,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2268,
+          "output_tokens_ceiling": 962,
+          "candidate_bytes": 73685
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-4391",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "docs/release_notes/release_notes-0.16.0.rst",
+        "modin/core/dataframe/pandas/dataframe/dataframe.py",
+        "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+        "modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py"
+      ],
+      "primary_files": [
+        "modin/core/dataframe/pandas/dataframe/dataframe.py",
+        "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+        "modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "binary_op"
+        ],
+        [
+          "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+          "PandasDataframePartitionManager",
+          "binary_operation"
+        ],
+        [
+          "modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py",
+          "PandasOnRayDataframePartitionManager",
+          "binary_operation"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "binary_op"
+        ],
+        [
+          "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+          "PandasDataframePartitionManager",
+          "binary_operation"
+        ],
+        [
+          "modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py",
+          "PandasOnRayDataframePartitionManager",
+          "binary_operation"
+        ]
+      ],
+      "n_files": 355,
+      "n_syms": 6639,
+      "arms": {
+        "for": {
+          "file_first": 7,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.0818,
+          "wall_p95": 0.0818,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5449,
+          "output_tokens_ceiling": 2309,
+          "candidate_bytes": 75723
+        }
+      }
+    },
+    {
+      "instance_id": "zarr-developers__zarr-python-738",
+      "partition": "train",
+      "repo": "zarr-developers/zarr-python",
+      "gold_files": [
+        "docs/release.rst",
+        "zarr/core.py",
+        "zarr/creation.py",
+        "zarr/storage.py",
+        "zarr/util.py"
+      ],
+      "primary_files": [
+        "zarr/core.py",
+        "zarr/creation.py",
+        "zarr/storage.py",
+        "zarr/util.py"
+      ],
+      "gold_funcs": [
+        [
+          "zarr/core.py",
+          "Array",
+          "__init__"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_set_basic_selection_zd"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_chunk_setitems"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_chunk_setitem_nosync"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_process_for_setitem"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "__getstate__"
+        ],
+        [
+          "zarr/creation.py",
+          "",
+          "create"
+        ],
+        [
+          "zarr/creation.py",
+          "",
+          "open_array"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "zarr/core.py",
+          "Array",
+          "write_empty_chunks"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_chunk_delitems"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_chunk_delitem"
+        ],
+        [
+          "zarr/storage.py",
+          "FSStore",
+          "delitems"
+        ],
+        [
+          "zarr/util.py",
+          "",
+          "flatten"
+        ],
+        [
+          "zarr/util.py",
+          "",
+          "all_equal"
+        ]
+      ],
+      "covered": [
+        [
+          "zarr/core.py",
+          "Array",
+          "__init__"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_set_basic_selection_zd"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_chunk_setitems"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_chunk_setitem_nosync"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "_process_for_setitem"
+        ],
+        [
+          "zarr/core.py",
+          "Array",
+          "__getstate__"
+        ],
+        [
+          "zarr/creation.py",
+          "",
+          "create"
+        ],
+        [
+          "zarr/creation.py",
+          "",
+          "open_array"
+        ]
+      ],
+      "n_files": 59,
+      "n_syms": 1433,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 6,
+          "all_file_worst": null,
+          "func_first": 0,
+          "wall_median": 0.0454,
+          "wall_p95": 0.0454,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6475,
+          "output_tokens_ceiling": 2744,
+          "candidate_bytes": 67263
+        }
+      }
+    },
+    {
+      "instance_id": "paperless-ngx__paperless-ngx-1227",
+      "partition": "train",
+      "repo": "paperless-ngx/paperless-ngx",
+      "gold_files": [
+        "docs/configuration.rst",
+        "gunicorn.conf.py",
+        "src/paperless/settings.py"
+      ],
+      "primary_files": [
+        "gunicorn.conf.py",
+        "src/paperless/settings.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/paperless/settings.py",
+          "",
+          "default_task_workers"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/paperless/settings.py",
+          "",
+          "default_task_workers"
+        ]
+      ],
+      "n_files": 375,
+      "n_syms": 3044,
+      "arms": {
+        "for": {
+          "file_first": 40,
+          "file_worst": 92,
+          "all_file_worst": null,
+          "func_first": 191,
+          "wall_median": 0.0632,
+          "wall_p95": 0.0632,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5632,
+          "output_tokens_ceiling": 2387,
+          "candidate_bytes": 70201
+        }
+      }
+    },
+    {
+      "instance_id": "NatLibFi__Annif-610",
+      "partition": "train",
+      "repo": "NatLibFi/Annif",
+      "gold_files": [
+        "annif/project.py",
+        "annif/registry.py",
+        "annif/vocab.py"
+      ],
+      "primary_files": [
+        "annif/project.py",
+        "annif/registry.py",
+        "annif/vocab.py"
+      ],
+      "gold_funcs": [
+        [
+          "annif/project.py",
+          "AnnifProject",
+          "vocab"
+        ],
+        [
+          "annif/registry.py",
+          "AnnifRegistry",
+          "__init__"
+        ],
+        [
+          "annif/registry.py",
+          "AnnifRegistry",
+          "_create_projects"
+        ],
+        [
+          "annif/vocab.py",
+          "",
+          "get_vocab"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "annif/registry.py",
+          "AnnifRegistry",
+          "get_vocab"
+        ]
+      ],
+      "covered": [
+        [
+          "annif/project.py",
+          "AnnifProject",
+          "vocab"
+        ],
+        [
+          "annif/registry.py",
+          "AnnifRegistry",
+          "__init__"
+        ],
+        [
+          "annif/registry.py",
+          "AnnifRegistry",
+          "_create_projects"
+        ],
+        [
+          "annif/vocab.py",
+          "",
+          "get_vocab"
+        ]
+      ],
+      "n_files": 103,
+      "n_syms": 1050,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 13,
+          "all_file_worst": 13,
+          "func_first": 22,
+          "wall_median": 0.0374,
+          "wall_p95": 0.0374,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4024,
+          "output_tokens_ceiling": 1706,
+          "candidate_bytes": 63977
+        }
+      }
+    },
+    {
+      "instance_id": "alexa-pi__AlexaPi-188",
+      "partition": "train",
+      "repo": "alexa-pi/AlexaPi",
+      "gold_files": [
+        "CHANGELOG.md",
+        "src/alexapi/capture.py",
+        "src/main.py",
+        "src/requirements.txt"
+      ],
+      "primary_files": [
+        "CHANGELOG.md",
+        "src/alexapi/capture.py",
+        "src/main.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/alexapi/capture.py",
+          "Capture",
+          "silence_listener"
+        ],
+        [
+          "src/main.py",
+          "",
+          "alexa_speech_recognizer"
+        ],
+        [
+          "src/main.py",
+          "",
+          "process_response"
+        ],
+        [
+          "src/main.py",
+          "",
+          "trigger_process"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "src/main.py",
+          "",
+          "alexa_speech_recognizer_generate_data"
+        ]
+      ],
+      "covered": [
+        [
+          "src/alexapi/capture.py",
+          "Capture",
+          "silence_listener"
+        ],
+        [
+          "src/main.py",
+          "",
+          "alexa_speech_recognizer"
+        ],
+        [
+          "src/main.py",
+          "",
+          "process_response"
+        ],
+        [
+          "src/main.py",
+          "",
+          "trigger_process"
+        ]
+      ],
+      "n_files": 42,
+      "n_syms": 430,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 10,
+          "all_file_worst": null,
+          "func_first": 4,
+          "wall_median": 0.0331,
+          "wall_p95": 0.0331,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4651,
+          "output_tokens_ceiling": 1971,
+          "candidate_bytes": 64983
+        }
+      }
+    },
+    {
+      "instance_id": "Agenta-AI__agenta-1639",
+      "partition": "train",
+      "repo": "Agenta-AI/agenta",
+      "gold_files": [
+        "agenta-backend/agenta_backend/models/converters.py",
+        "agenta-backend/agenta_backend/routers/configs_router.py",
+        "agenta-backend/agenta_backend/services/db_manager.py"
+      ],
+      "primary_files": [
+        "agenta-backend/agenta_backend/models/converters.py",
+        "agenta-backend/agenta_backend/routers/configs_router.py",
+        "agenta-backend/agenta_backend/services/db_manager.py"
+      ],
+      "gold_funcs": [
+        [
+          "agenta-backend/agenta_backend/models/converters.py",
+          "",
+          "environment_db_to_output"
+        ],
+        [
+          "agenta-backend/agenta_backend/routers/configs_router.py",
+          "",
+          "get_config"
+        ],
+        [
+          "agenta-backend/agenta_backend/services/db_manager.py",
+          "",
+          "fetch_base_by_id"
+        ],
+        [
+          "agenta-backend/agenta_backend/services/db_manager.py",
+          "",
+          "list_variants_for_base"
+        ],
+        [
+          "agenta-backend/agenta_backend/services/db_manager.py",
+          "",
+          "add_variant_from_base_and_config"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "agenta-backend/agenta_backend/models/converters.py",
+          "",
+          "environment_db_to_output"
+        ],
+        [
+          "agenta-backend/agenta_backend/routers/configs_router.py",
+          "",
+          "get_config"
+        ],
+        [
+          "agenta-backend/agenta_backend/services/db_manager.py",
+          "",
+          "fetch_base_by_id"
+        ],
+        [
+          "agenta-backend/agenta_backend/services/db_manager.py",
+          "",
+          "list_variants_for_base"
+        ],
+        [
+          "agenta-backend/agenta_backend/services/db_manager.py",
+          "",
+          "add_variant_from_base_and_config"
+        ]
+      ],
+      "n_files": 449,
+      "n_syms": 6591,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": 14,
+          "wall_median": 0.0578,
+          "wall_p95": 0.0578,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7412,
+          "output_tokens_ceiling": 3141,
+          "candidate_bytes": 76559
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-16369",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/tasks.py"
+      ],
+      "primary_files": [
+        "src/prefect/tasks.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/tasks.py",
+          "Task",
+          "__init__"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/tasks.py",
+          "Task",
+          "__init__"
+        ]
+      ],
+      "n_files": 1631,
+      "n_syms": 32479,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 6,
+          "wall_median": 0.2254,
+          "wall_p95": 0.2254,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5135,
+          "output_tokens_ceiling": 2176,
+          "candidate_bytes": 86206
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-16328",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/task_engine.py"
+      ],
+      "primary_files": [
+        "src/prefect/task_engine.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/task_engine.py",
+          "SyncTaskRunEngine",
+          "handle_timeout"
+        ],
+        [
+          "src/prefect/task_engine.py",
+          "AsyncTaskRunEngine",
+          "handle_timeout"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/task_engine.py",
+          "SyncTaskRunEngine",
+          "handle_timeout"
+        ],
+        [
+          "src/prefect/task_engine.py",
+          "AsyncTaskRunEngine",
+          "handle_timeout"
+        ]
+      ],
+      "n_files": 1613,
+      "n_syms": 32354,
+      "arms": {
+        "for": {
+          "file_first": 18,
+          "file_worst": 18,
+          "all_file_worst": 18,
+          "func_first": 26,
+          "wall_median": 0.22,
+          "wall_p95": 0.22,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3720,
+          "output_tokens_ceiling": 1577,
+          "candidate_bytes": 87175
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-16145",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/task_engine.py"
+      ],
+      "primary_files": [
+        "src/prefect/task_engine.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/task_engine.py",
+          "SyncTaskRunEngine",
+          "set_state"
+        ],
+        [
+          "src/prefect/task_engine.py",
+          "AsyncTaskRunEngine",
+          "set_state"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/task_engine.py",
+          "SyncTaskRunEngine",
+          "set_state"
+        ],
+        [
+          "src/prefect/task_engine.py",
+          "AsyncTaskRunEngine",
+          "set_state"
+        ]
+      ],
+      "n_files": 1561,
+      "n_syms": 31675,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 97,
+          "wall_median": 0.2452,
+          "wall_p95": 0.2452,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5373,
+          "output_tokens_ceiling": 2277,
+          "candidate_bytes": 84978
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-16117",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/flows.py"
+      ],
+      "primary_files": [
+        "src/prefect/flows.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/flows.py",
+          "Flow",
+          "validate_parameters"
+        ],
+        [
+          "src/prefect/flows.py",
+          "",
+          "select_flow"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/flows.py",
+          "Flow",
+          "validate_parameters"
+        ],
+        [
+          "src/prefect/flows.py",
+          "",
+          "select_flow"
+        ]
+      ],
+      "n_files": 1822,
+      "n_syms": 35050,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.2355,
+          "wall_p95": 0.2355,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4275,
+          "output_tokens_ceiling": 1812,
+          "candidate_bytes": 85814
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-15909",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/integrations/prefect-dask/prefect_dask/task_runners.py"
+      ],
+      "primary_files": [
+        "src/integrations/prefect-dask/prefect_dask/task_runners.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/integrations/prefect-dask/prefect_dask/task_runners.py",
+          "DaskTaskRunner",
+          "submit"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/integrations/prefect-dask/prefect_dask/task_runners.py",
+          "DaskTaskRunner",
+          "submit"
+        ]
+      ],
+      "n_files": 1454,
+      "n_syms": 30771,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.2117,
+          "wall_p95": 0.2117,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5057,
+          "output_tokens_ceiling": 2143,
+          "candidate_bytes": 86312
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-15468",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/cli/deploy.py"
+      ],
+      "primary_files": [
+        "src/prefect/cli/deploy.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/cli/deploy.py",
+          "",
+          "deploy"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/cli/deploy.py",
+          "",
+          "deploy"
+        ]
+      ],
+      "n_files": 1406,
+      "n_syms": 30314,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.2104,
+          "wall_p95": 0.2104,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3951,
+          "output_tokens_ceiling": 1675,
+          "candidate_bytes": 85090
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-14693",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/integrations/prefect-docker/prefect_docker/worker.py"
+      ],
+      "primary_files": [
+        "src/integrations/prefect-docker/prefect_docker/worker.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/integrations/prefect-docker/prefect_docker/worker.py",
+          "DockerWorker",
+          "_build_container_settings"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/integrations/prefect-docker/prefect_docker/worker.py",
+          "DockerWorker",
+          "_build_container_settings"
+        ]
+      ],
+      "n_files": 1819,
+      "n_syms": 34889,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 4,
+          "wall_median": 0.2216,
+          "wall_p95": 0.2216,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3560,
+          "output_tokens_ceiling": 1509,
+          "candidate_bytes": 98071
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-14608",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/futures.py"
+      ],
+      "primary_files": [
+        "src/prefect/futures.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/futures.py",
+          "PrefectFutureList",
+          "wait"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/futures.py",
+          "PrefectFutureList",
+          "wait"
+        ]
+      ],
+      "n_files": 1788,
+      "n_syms": 30992,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 4,
+          "wall_median": 0.1937,
+          "wall_p95": 0.1937,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3517,
+          "output_tokens_ceiling": 1491,
+          "candidate_bytes": 85370
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-14259",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py"
+      ],
+      "primary_files": [
+        "src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py",
+          "SqlAlchemyConnector",
+          "execute"
+        ],
+        [
+          "src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py",
+          "SqlAlchemyConnector",
+          "execute_many"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py",
+          "SqlAlchemyConnector",
+          "execute"
+        ],
+        [
+          "src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py",
+          "SqlAlchemyConnector",
+          "execute_many"
+        ]
+      ],
+      "n_files": 1741,
+      "n_syms": 30527,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 7,
+          "wall_median": 0.1996,
+          "wall_p95": 0.1996,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3410,
+          "output_tokens_ceiling": 1445,
+          "candidate_bytes": 99280
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-13756",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/tasks.py"
+      ],
+      "primary_files": [
+        "src/prefect/tasks.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/tasks.py",
+          "Task",
+          "submit"
+        ],
+        [
+          "src/prefect/tasks.py",
+          "Task",
+          "map"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/tasks.py",
+          "Task",
+          "submit"
+        ],
+        [
+          "src/prefect/tasks.py",
+          "Task",
+          "map"
+        ]
+      ],
+      "n_files": 1295,
+      "n_syms": 28987,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.1912,
+          "wall_p95": 0.1912,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2773,
+          "output_tokens_ceiling": 1175,
+          "candidate_bytes": 87575
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-13367",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/cli/deployment.py"
+      ],
+      "primary_files": [
+        "src/prefect/cli/deployment.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/cli/deployment.py",
+          "",
+          "apply"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/cli/deployment.py",
+          "",
+          "apply"
+        ]
+      ],
+      "n_files": 1799,
+      "n_syms": 34468,
+      "arms": {
+        "for": {
+          "file_first": 18,
+          "file_worst": 18,
+          "all_file_worst": 18,
+          "func_first": 24,
+          "wall_median": 0.214,
+          "wall_p95": 0.214,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2349,
+          "output_tokens_ceiling": 996,
+          "candidate_bytes": 86316
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-13366",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/cli/deployment.py"
+      ],
+      "primary_files": [
+        "src/prefect/cli/deployment.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/cli/deployment.py",
+          "",
+          "build"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/cli/deployment.py",
+          "",
+          "build"
+        ]
+      ],
+      "n_files": 1817,
+      "n_syms": 34706,
+      "arms": {
+        "for": {
+          "file_first": 33,
+          "file_worst": 33,
+          "all_file_worst": 33,
+          "func_first": 51,
+          "wall_median": 0.214,
+          "wall_p95": 0.214,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2524,
+          "output_tokens_ceiling": 1070,
+          "candidate_bytes": 85787
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-13259",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/client/orchestration.py"
+      ],
+      "primary_files": [
+        "src/prefect/client/orchestration.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/client/orchestration.py",
+          "PrefectClient",
+          "update_deployment_schedule"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/client/orchestration.py",
+          "PrefectClient",
+          "update_deployment_schedule"
+        ]
+      ],
+      "n_files": 1811,
+      "n_syms": 34609,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.2263,
+          "wall_p95": 0.2263,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4761,
+          "output_tokens_ceiling": 2018,
+          "candidate_bytes": 87104
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-12410",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/cli/deploy.py"
+      ],
+      "primary_files": [
+        "src/prefect/cli/deploy.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/cli/deploy.py",
+          "",
+          "deploy"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/cli/deploy.py",
+          "",
+          "deploy"
+        ]
+      ],
+      "n_files": 1281,
+      "n_syms": 24259,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 1,
+          "wall_median": 0.157,
+          "wall_p95": 0.157,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2626,
+          "output_tokens_ceiling": 1113,
+          "candidate_bytes": 79471
+        }
+      }
+    },
+    {
+      "instance_id": "PrefectHQ__prefect-12045",
+      "partition": "train",
+      "repo": "PrefectHQ/prefect",
+      "gold_files": [
+        "src/prefect/utilities/dockerutils.py"
+      ],
+      "primary_files": [
+        "src/prefect/utilities/dockerutils.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/prefect/utilities/dockerutils.py",
+          "",
+          "docker_client"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/prefect/utilities/dockerutils.py",
+          "",
+          "docker_client"
+        ]
+      ],
+      "n_files": 1215,
+      "n_syms": 22887,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": null,
+          "wall_median": 0.1523,
+          "wall_p95": 0.1523,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4157,
+          "output_tokens_ceiling": 1762,
+          "candidate_bytes": 74904
+        }
+      }
+    },
+    {
+      "instance_id": "Delgan__loguru-1239",
+      "partition": "train",
+      "repo": "Delgan/loguru",
+      "gold_files": [
+        "loguru/_better_exceptions.py"
+      ],
+      "primary_files": [
+        "loguru/_better_exceptions.py"
+      ],
+      "gold_funcs": [
+        [
+          "loguru/_better_exceptions.py",
+          "ExceptionFormatter",
+          "_format_list"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "loguru/_better_exceptions.py",
+          "ExceptionFormatter",
+          "_format_list"
+        ]
+      ],
+      "n_files": 174,
+      "n_syms": 2059,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 7,
+          "wall_median": 0.0407,
+          "wall_p95": 0.0407,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5865,
+          "output_tokens_ceiling": 2486,
+          "candidate_bytes": 63269
+        }
+      }
+    },
+    {
+      "instance_id": "Lightning-AI__pytorch-lightning-20403",
+      "partition": "train",
+      "repo": "Lightning-AI/pytorch-lightning",
+      "gold_files": [
+        "src/lightning/pytorch/trainer/connectors/checkpoint_connector.py"
+      ],
+      "primary_files": [
+        "src/lightning/pytorch/trainer/connectors/checkpoint_connector.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/lightning/pytorch/trainer/connectors/checkpoint_connector.py",
+          "_CheckpointConnector",
+          "_restore_modules_and_callbacks"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/lightning/pytorch/trainer/connectors/checkpoint_connector.py",
+          "_CheckpointConnector",
+          "_restore_modules_and_callbacks"
+        ]
+      ],
+      "n_files": 650,
+      "n_syms": 11143,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": null,
+          "wall_median": 0.1082,
+          "wall_p95": 0.1082,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2851,
+          "output_tokens_ceiling": 1209,
+          "candidate_bytes": 88200
+        }
+      }
+    },
+    {
+      "instance_id": "getmoto__moto-8401",
+      "partition": "train",
+      "repo": "getmoto/moto",
+      "gold_files": [
+        "moto/dynamodb/models/utilities.py"
+      ],
+      "primary_files": [
+        "moto/dynamodb/models/utilities.py"
+      ],
+      "gold_funcs": [
+        [
+          "moto/dynamodb/models/utilities.py",
+          "DynamoJsonEncoder",
+          "default"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "moto/dynamodb/models/utilities.py",
+          "DynamoJsonEncoder",
+          "default"
+        ]
+      ],
+      "n_files": 1944,
+      "n_syms": 33583,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.2829,
+          "wall_p95": 0.2829,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5356,
+          "output_tokens_ceiling": 2270,
+          "candidate_bytes": 80830
+        }
+      }
+    },
+    {
+      "instance_id": "getmoto__moto-8390",
+      "partition": "train",
+      "repo": "getmoto/moto",
+      "gold_files": [
+        "moto/athena/responses.py"
+      ],
+      "primary_files": [
+        "moto/athena/responses.py"
+      ],
+      "gold_funcs": [
+        [
+          "moto/athena/responses.py",
+          "AthenaResponse",
+          "get_query_execution"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "moto/athena/responses.py",
+          "AthenaResponse",
+          "get_query_execution"
+        ]
+      ],
+      "n_files": 1940,
+      "n_syms": 33535,
+      "arms": {
+        "for": {
+          "file_first": 18,
+          "file_worst": 18,
+          "all_file_worst": 18,
+          "func_first": 146,
+          "wall_median": 0.2776,
+          "wall_p95": 0.2776,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4221,
+          "output_tokens_ceiling": 1789,
+          "candidate_bytes": 75848
+        }
+      }
+    },
+    {
+      "instance_id": "getmoto__moto-8365",
+      "partition": "train",
+      "repo": "getmoto/moto",
+      "gold_files": [
+        "moto/kms/responses.py"
+      ],
+      "primary_files": [
+        "moto/kms/responses.py"
+      ],
+      "gold_funcs": [
+        [
+          "moto/kms/responses.py",
+          "KmsResponse",
+          "get_public_key"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "moto/kms/responses.py",
+          "KmsResponse",
+          "get_public_key"
+        ]
+      ],
+      "n_files": 1939,
+      "n_syms": 33489,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 14,
+          "wall_median": 0.2775,
+          "wall_p95": 0.2775,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5265,
+          "output_tokens_ceiling": 2231,
+          "candidate_bytes": 76921
+        }
+      }
+    },
+    {
+      "instance_id": "getmoto__moto-8342",
+      "partition": "train",
+      "repo": "getmoto/moto",
+      "gold_files": [
+        "moto/iotdata/models.py"
+      ],
+      "primary_files": [
+        "moto/iotdata/models.py"
+      ],
+      "gold_funcs": [
+        [
+          "moto/iotdata/models.py",
+          "FakeShadow",
+          "parse_payload"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "moto/iotdata/models.py",
+          "FakeShadow",
+          "_resolve_nested_deltas"
+        ]
+      ],
+      "covered": [
+        [
+          "moto/iotdata/models.py",
+          "FakeShadow",
+          "parse_payload"
+        ]
+      ],
+      "n_files": 1938,
+      "n_syms": 33388,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 121,
+          "wall_median": 0.2782,
+          "wall_p95": 0.2782,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4426,
+          "output_tokens_ceiling": 1876,
+          "candidate_bytes": 77349
+        }
+      }
+    },
+    {
+      "instance_id": "getmoto__moto-8316",
+      "partition": "train",
+      "repo": "getmoto/moto",
+      "gold_files": [
+        "moto/ec2/responses/fleets.py"
+      ],
+      "primary_files": [
+        "moto/ec2/responses/fleets.py"
+      ],
+      "gold_funcs": [
+        [
+          "moto/ec2/responses/fleets.py",
+          "Fleets",
+          "create_fleet"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "moto/ec2/responses/fleets.py",
+          "Fleets",
+          "create_fleet"
+        ]
+      ],
+      "n_files": 1935,
+      "n_syms": 33305,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 8,
+          "wall_median": 0.2783,
+          "wall_p95": 0.2783,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4543,
+          "output_tokens_ceiling": 1925,
+          "candidate_bytes": 81547
+        }
+      }
+    },
+    {
+      "instance_id": "getmoto__moto-8315",
+      "partition": "train",
+      "repo": "getmoto/moto",
+      "gold_files": [
+        "moto/s3/responses.py"
+      ],
+      "primary_files": [
+        "moto/s3/responses.py"
+      ],
+      "gold_funcs": [
+        [
+          "moto/s3/responses.py",
+          "S3Response",
+          "get_object_attributes"
+        ],
+        [
+          "moto/s3/responses.py",
+          "S3Response",
+          "_get_key"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "moto/s3/responses.py",
+          "S3Response",
+          "get_object_attributes"
+        ],
+        [
+          "moto/s3/responses.py",
+          "S3Response",
+          "_get_key"
+        ]
+      ],
+      "n_files": 1935,
+      "n_syms": 33305,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 53,
+          "wall_median": 0.2813,
+          "wall_p95": 0.2813,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7763,
+          "output_tokens_ceiling": 3290,
+          "candidate_bytes": 81110
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-49236",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/dag/compiled_dag_node.py"
+      ],
+      "primary_files": [
+        "python/ray/dag/compiled_dag_node.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "CompiledDAG",
+          "__init__"
+        ],
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "CompiledDAG",
+          "_preprocess"
+        ],
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "CompiledDAG",
+          "_get_or_compile"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "CompiledDAG",
+          "_register_input_output_custom_serializer"
+        ]
+      ],
+      "covered": [
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "CompiledDAG",
+          "__init__"
+        ],
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "CompiledDAG",
+          "_preprocess"
+        ],
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "CompiledDAG",
+          "_get_or_compile"
+        ]
+      ],
+      "n_files": 5324,
+      "n_syms": 86301,
+      "arms": {
+        "for": {
+          "file_first": 5,
+          "file_worst": 5,
+          "all_file_worst": 5,
+          "func_first": 10,
+          "wall_median": 0.6161,
+          "wall_p95": 0.6161,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4360,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 82642
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-49221",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/data/dataset.py"
+      ],
+      "primary_files": [
+        "python/ray/data/dataset.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/data/dataset.py",
+          "Dataset",
+          "add_column"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/data/dataset.py",
+          "Dataset",
+          "add_column"
+        ]
+      ],
+      "n_files": 5323,
+      "n_syms": 86229,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": 6,
+          "all_file_worst": 6,
+          "func_first": 10,
+          "wall_median": 0.6151,
+          "wall_p95": 0.6151,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4263,
+          "output_tokens_ceiling": 1807,
+          "candidate_bytes": 79601
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-49118",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/dag/dag_node_operation.py"
+      ],
+      "primary_files": [
+        "python/ray/dag/dag_node_operation.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/dag/dag_node_operation.py",
+          "",
+          "_build_dag_node_operation_graph"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/dag/dag_node_operation.py",
+          "",
+          "_build_dag_node_operation_graph"
+        ]
+      ],
+      "n_files": 5342,
+      "n_syms": 86608,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.6147,
+          "wall_p95": 0.6147,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 8541,
+          "output_tokens_ceiling": 3620,
+          "candidate_bytes": 73743
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48957",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/experimental/channel/serialization_context.py"
+      ],
+      "primary_files": [
+        "python/ray/experimental/channel/serialization_context.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/experimental/channel/serialization_context.py",
+          "_SerializationContext",
+          "serialize_to_numpy"
+        ],
+        [
+          "python/ray/experimental/channel/serialization_context.py",
+          "_SerializationContext",
+          "deserialize_from_numpy"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/experimental/channel/serialization_context.py",
+          "_SerializationContext",
+          "serialize_to_numpy"
+        ],
+        [
+          "python/ray/experimental/channel/serialization_context.py",
+          "_SerializationContext",
+          "deserialize_from_numpy"
+        ]
+      ],
+      "n_files": 5342,
+      "n_syms": 86614,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 36,
+          "wall_median": 0.6211,
+          "wall_p95": 0.6211,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4797,
+          "output_tokens_ceiling": 2033,
+          "candidate_bytes": 80212
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48907",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/data/grouped_data.py"
+      ],
+      "primary_files": [
+        "python/ray/data/grouped_data.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/data/grouped_data.py",
+          "GroupedData",
+          "map_groups"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/data/grouped_data.py",
+          "GroupedData",
+          "map_groups"
+        ]
+      ],
+      "n_files": 5322,
+      "n_syms": 86560,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 1,
+          "wall_median": 0.6253,
+          "wall_p95": 0.6253,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4818,
+          "output_tokens_ceiling": 2042,
+          "candidate_bytes": 81284
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48782",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/dag/compiled_dag_node.py"
+      ],
+      "primary_files": [
+        "python/ray/dag/compiled_dag_node.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "",
+          "do_profile_tasks"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/dag/compiled_dag_node.py",
+          "",
+          "do_profile_tasks"
+        ]
+      ],
+      "n_files": 5313,
+      "n_syms": 86480,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 119,
+          "wall_median": 0.6206,
+          "wall_p95": 0.6206,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4791,
+          "output_tokens_ceiling": 2031,
+          "candidate_bytes": 81520
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48623",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/autoscaler/v2/scheduler.py"
+      ],
+      "primary_files": [
+        "python/ray/autoscaler/v2/scheduler.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/autoscaler/v2/scheduler.py",
+          "ResourceDemandScheduler",
+          "_enforce_idle_termination"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/autoscaler/v2/scheduler.py",
+          "ResourceDemandScheduler",
+          "_enforce_idle_termination"
+        ]
+      ],
+      "n_files": 5304,
+      "n_syms": 86303,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 21,
+          "wall_median": 0.6227,
+          "wall_p95": 0.6227,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5685,
+          "output_tokens_ceiling": 2409,
+          "candidate_bytes": 84742
+        }
+      }
+    },
+    {
+      "instance_id": "spotify__luigi-3308",
+      "partition": "train",
+      "repo": "spotify/luigi",
+      "gold_files": [
+        "luigi/lock.py"
+      ],
+      "primary_files": [
+        "luigi/lock.py"
+      ],
+      "gold_funcs": [
+        [
+          "luigi/lock.py",
+          "",
+          "acquire_for"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "luigi/lock.py",
+          "",
+          "acquire_for"
+        ]
+      ],
+      "n_files": 267,
+      "n_syms": 7083,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 2,
+          "wall_median": 0.0658,
+          "wall_p95": 0.0658,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4137,
+          "output_tokens_ceiling": 1753,
+          "candidate_bytes": 66573
+        }
+      }
+    },
+    {
+      "instance_id": "bridgecrewio__checkov-6909",
+      "partition": "train",
+      "repo": "bridgecrewio/checkov",
+      "gold_files": [
+        "checkov/serverless/graph_builder/local_graph.py"
+      ],
+      "primary_files": [
+        "checkov/serverless/graph_builder/local_graph.py"
+      ],
+      "gold_funcs": [
+        [
+          "checkov/serverless/graph_builder/local_graph.py",
+          "ServerlessLocalGraph",
+          "_create_vertex"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "checkov/serverless/graph_builder/local_graph.py",
+          "ServerlessLocalGraph",
+          "_create_vertex"
+        ]
+      ],
+      "n_files": 7204,
+      "n_syms": 49945,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.4071,
+          "wall_p95": 0.4071,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3903,
+          "output_tokens_ceiling": 1654,
+          "candidate_bytes": 89560
+        }
+      }
+    },
+    {
+      "instance_id": "bridgecrewio__checkov-6895",
+      "partition": "train",
+      "repo": "bridgecrewio/checkov",
+      "gold_files": [
+        "checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py"
+      ],
+      "primary_files": [
+        "checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py"
+      ],
+      "gold_funcs": [
+        [
+          "checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py",
+          "PostgreSQLFlexiServerGeoBackupEnabled",
+          "__init__"
+        ],
+        [
+          "checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py",
+          "PostgreSQLFlexiServerGeoBackupEnabled",
+          "get_inspected_key"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py",
+          "PostgreSQLFlexiServerGeoBackupEnabled",
+          "scan_resource_conf"
+        ]
+      ],
+      "covered": [
+        [
+          "checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py",
+          "PostgreSQLFlexiServerGeoBackupEnabled",
+          "__init__"
+        ],
+        [
+          "checkov/terraform/checks/resource/azure/PostgreSQLFlexiServerGeoBackupEnabled.py",
+          "PostgreSQLFlexiServerGeoBackupEnabled",
+          "get_inspected_key"
+        ]
+      ],
+      "n_files": 7202,
+      "n_syms": 49936,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 8,
+          "wall_median": 0.4125,
+          "wall_p95": 0.4125,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4807,
+          "output_tokens_ceiling": 2037,
+          "candidate_bytes": 98533
+        }
+      }
+    },
+    {
+      "instance_id": "bridgecrewio__checkov-6828",
+      "partition": "train",
+      "repo": "bridgecrewio/checkov",
+      "gold_files": [
+        "checkov/dockerfile/parser.py"
+      ],
+      "primary_files": [
+        "checkov/dockerfile/parser.py"
+      ],
+      "gold_funcs": [
+        [
+          "checkov/dockerfile/parser.py",
+          "",
+          "parse"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "checkov/dockerfile/parser.py",
+          "",
+          "convert_multiline_commands"
+        ]
+      ],
+      "covered": [
+        [
+          "checkov/dockerfile/parser.py",
+          "",
+          "parse"
+        ]
+      ],
+      "n_files": 7128,
+      "n_syms": 49265,
+      "arms": {
+        "for": {
+          "file_first": 10,
+          "file_worst": 10,
+          "all_file_worst": 10,
+          "func_first": 16,
+          "wall_median": 0.4159,
+          "wall_p95": 0.4159,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4278,
+          "output_tokens_ceiling": 1813,
+          "candidate_bytes": 89717
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10462",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/attention/backends/flashinfer.py"
+      ],
+      "primary_files": [
+        "vllm/attention/backends/flashinfer.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/attention/backends/flashinfer.py",
+          "FlashInferImpl",
+          "__init__"
+        ],
+        [
+          "vllm/attention/backends/flashinfer.py",
+          "",
+          "unified_flash_infer"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/attention/backends/flashinfer.py",
+          "FlashInferImpl",
+          "__init__"
+        ],
+        [
+          "vllm/attention/backends/flashinfer.py",
+          "",
+          "unified_flash_infer"
+        ]
+      ],
+      "n_files": 1144,
+      "n_syms": 24856,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 169,
+          "wall_median": 0.1813,
+          "wall_p95": 0.1813,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3780,
+          "output_tokens_ceiling": 1602,
+          "candidate_bytes": 81363
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10198",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/spec_decode/batch_expansion.py"
+      ],
+      "primary_files": [
+        "vllm/spec_decode/batch_expansion.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/spec_decode/batch_expansion.py",
+          "BatchExpansionTop1Scorer",
+          "_create_target_seq_group_metadata"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/spec_decode/batch_expansion.py",
+          "BatchExpansionTop1Scorer",
+          "_create_target_seq_group_metadata"
+        ]
+      ],
+      "n_files": 1167,
+      "n_syms": 25464,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1805,
+          "wall_p95": 0.1805,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3675,
+          "output_tokens_ceiling": 1558,
+          "candidate_bytes": 70273
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-9846",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "examples/offline_inference_vision_language.py"
+      ],
+      "primary_files": [
+        "examples/offline_inference_vision_language.py"
+      ],
+      "gold_funcs": [
+        [
+          "examples/offline_inference_vision_language.py",
+          "",
+          "run_qwen2_vl"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "examples/offline_inference_vision_language.py",
+          "",
+          "run_qwen2_vl"
+        ]
+      ],
+      "n_files": 1078,
+      "n_syms": 23446,
+      "arms": {
+        "for": {
+          "file_first": 44,
+          "file_worst": 44,
+          "all_file_worst": 44,
+          "func_first": null,
+          "wall_median": 0.1593,
+          "wall_p95": 0.1593,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6058,
+          "output_tokens_ceiling": 2567,
+          "candidate_bytes": 79923
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-7783",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/model_executor/models/phi3v.py"
+      ],
+      "primary_files": [
+        "vllm/model_executor/models/phi3v.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/model_executor/models/phi3v.py",
+          "",
+          "input_processor_for_phi3v"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/model_executor/models/phi3v.py",
+          "",
+          "input_processor_for_phi3v"
+        ]
+      ],
+      "n_files": 882,
+      "n_syms": 19746,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 5,
+          "wall_median": 0.1318,
+          "wall_p95": 0.1318,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2924,
+          "output_tokens_ceiling": 1239,
+          "candidate_bytes": 82512
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11751",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_parse_sig_js"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_parse_sig_js"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10251,
+      "arms": {
+        "for": {
+          "file_first": 7,
+          "file_worst": 7,
+          "all_file_worst": 7,
+          "func_first": null,
+          "wall_median": 0.1537,
+          "wall_p95": 0.1537,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4354,
+          "output_tokens_ceiling": 1845,
+          "candidate_bytes": 68846
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11750",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_extract_n_function_name"
+        ],
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_extract_n_function_code"
+        ],
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_extract_n_function_from_code"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_fixup_n_function_code"
+        ]
+      ],
+      "covered": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_extract_n_function_name"
+        ],
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_extract_n_function_code"
+        ],
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_extract_n_function_from_code"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10251,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": 6,
+          "all_file_worst": 6,
+          "func_first": null,
+          "wall_median": 0.1521,
+          "wall_p95": 0.1521,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4354,
+          "output_tokens_ceiling": 1845,
+          "candidate_bytes": 69261
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11438",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/aes.py"
+      ],
+      "primary_files": [
+        "yt_dlp/aes.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/aes.py",
+          "",
+          "aes_gcm_decrypt_and_verify"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/aes.py",
+          "",
+          "aes_gcm_decrypt_and_verify"
+        ]
+      ],
+      "n_files": 1177,
+      "n_syms": 10213,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1548,
+          "wall_p95": 0.1548,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4354,
+          "output_tokens_ceiling": 1845,
+          "candidate_bytes": 69044
+        }
+      }
+    },
+    {
+      "instance_id": "stanfordnlp__dspy-1741",
+      "partition": "train",
+      "repo": "stanfordnlp/dspy",
+      "gold_files": [
+        "dspy/predict/predict.py"
+      ],
+      "primary_files": [
+        "dspy/predict/predict.py"
+      ],
+      "gold_funcs": [
+        [
+          "dspy/predict/predict.py",
+          "Predict",
+          "load_state"
+        ],
+        [
+          "dspy/predict/predict.py",
+          "Predict",
+          "_load_state_legacy"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "dspy/predict/predict.py",
+          "Predict",
+          "load"
+        ]
+      ],
+      "covered": [
+        [
+          "dspy/predict/predict.py",
+          "Predict",
+          "load_state"
+        ],
+        [
+          "dspy/predict/predict.py",
+          "Predict",
+          "_load_state_legacy"
+        ]
+      ],
+      "n_files": 2365,
+      "n_syms": 14347,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 1,
+          "wall_median": 0.1088,
+          "wall_p95": 0.1088,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2665,
+          "output_tokens_ceiling": 1130,
+          "candidate_bytes": 74491
+        }
+      }
+    },
+    {
+      "instance_id": "Qiskit__qiskit-13436",
+      "partition": "train",
+      "repo": "Qiskit/qiskit",
+      "gold_files": [
+        "qiskit/quantum_info/states/statevector.py"
+      ],
+      "primary_files": [
+        "qiskit/quantum_info/states/statevector.py"
+      ],
+      "gold_funcs": [
+        [
+          "qiskit/quantum_info/states/statevector.py",
+          "Statevector",
+          "_expectation_value_pauli"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "qiskit/quantum_info/states/statevector.py",
+          "Statevector",
+          "_expectation_value_pauli"
+        ]
+      ],
+      "n_files": 2917,
+      "n_syms": 24410,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 2,
+          "wall_median": 0.241,
+          "wall_p95": 0.241,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3166,
+          "output_tokens_ceiling": 1342,
+          "candidate_bytes": 78193
+        }
+      }
+    },
+    {
+      "instance_id": "Qiskit__qiskit-12214",
+      "partition": "train",
+      "repo": "Qiskit/qiskit",
+      "gold_files": [
+        "qiskit/transpiler/preset_passmanagers/__init__.py"
+      ],
+      "primary_files": [
+        "qiskit/transpiler/preset_passmanagers/__init__.py"
+      ],
+      "gold_funcs": [
+        [
+          "qiskit/transpiler/preset_passmanagers/__init__.py",
+          "",
+          "generate_preset_pass_manager"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "qiskit/transpiler/preset_passmanagers/__init__.py",
+          "",
+          "generate_preset_pass_manager"
+        ]
+      ],
+      "n_files": 2637,
+      "n_syms": 21412,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 2,
+          "wall_median": 0.2203,
+          "wall_p95": 0.2203,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3143,
+          "output_tokens_ceiling": 1332,
+          "candidate_bytes": 79896
+        }
+      }
+    },
+    {
+      "instance_id": "scipy__scipy-21918",
+      "partition": "train",
+      "repo": "scipy/scipy",
+      "gold_files": [
+        "scipy/optimize/_minpack_py.py"
+      ],
+      "primary_files": [
+        "scipy/optimize/_minpack_py.py"
+      ],
+      "gold_funcs": [
+        [
+          "scipy/optimize/_minpack_py.py",
+          "",
+          "curve_fit"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "scipy/optimize/_minpack_py.py",
+          "",
+          "curve_fit"
+        ]
+      ],
+      "n_files": 1605,
+      "n_syms": 38392,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3327,
+          "wall_p95": 0.3327,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4042,
+          "output_tokens_ceiling": 1713,
+          "candidate_bytes": 63091
+        }
+      }
+    },
+    {
+      "instance_id": "scipy__scipy-21912",
+      "partition": "train",
+      "repo": "scipy/scipy",
+      "gold_files": [
+        "scipy/integrate/_quadrature.py"
+      ],
+      "primary_files": [
+        "scipy/integrate/_quadrature.py"
+      ],
+      "gold_funcs": [
+        [
+          "scipy/integrate/_quadrature.py",
+          "",
+          "trapezoid"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "scipy/integrate/_quadrature.py",
+          "",
+          "trapezoid"
+        ]
+      ],
+      "n_files": 1603,
+      "n_syms": 38328,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3292,
+          "wall_p95": 0.3292,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3518,
+          "output_tokens_ceiling": 1491,
+          "candidate_bytes": 56103
+        }
+      }
+    },
+    {
+      "instance_id": "scipy__scipy-21808",
+      "partition": "train",
+      "repo": "scipy/scipy",
+      "gold_files": [
+        "scipy/signal/_signaltools.py"
+      ],
+      "primary_files": [
+        "scipy/signal/_signaltools.py"
+      ],
+      "gold_funcs": [
+        [
+          "scipy/signal/_signaltools.py",
+          "",
+          "correlation_lags"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "scipy/signal/_signaltools.py",
+          "",
+          "correlation_lags"
+        ]
+      ],
+      "n_files": 1600,
+      "n_syms": 38199,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3255,
+          "wall_p95": 0.3255,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4430,
+          "output_tokens_ceiling": 1878,
+          "candidate_bytes": 58699
+        }
+      }
+    },
+    {
+      "instance_id": "scipy__scipy-21801",
+      "partition": "train",
+      "repo": "scipy/scipy",
+      "gold_files": [
+        "scipy/special/_basic.py"
+      ],
+      "primary_files": [
+        "scipy/special/_basic.py"
+      ],
+      "gold_funcs": [
+        [
+          "scipy/special/_basic.py",
+          "",
+          "_factorialx_array_approx"
+        ],
+        [
+          "scipy/special/_basic.py",
+          "",
+          "_factorialx_approx_core"
+        ],
+        [
+          "scipy/special/_basic.py",
+          "",
+          "factorial"
+        ],
+        [
+          "scipy/special/_basic.py",
+          "",
+          "factorial2"
+        ],
+        [
+          "scipy/special/_basic.py",
+          "",
+          "factorialk"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "scipy/special/_basic.py",
+          "",
+          "_gamma1p"
+        ]
+      ],
+      "covered": [
+        [
+          "scipy/special/_basic.py",
+          "",
+          "_factorialx_array_approx"
+        ],
+        [
+          "scipy/special/_basic.py",
+          "",
+          "_factorialx_approx_core"
+        ],
+        [
+          "scipy/special/_basic.py",
+          "",
+          "factorial"
+        ],
+        [
+          "scipy/special/_basic.py",
+          "",
+          "factorial2"
+        ],
+        [
+          "scipy/special/_basic.py",
+          "",
+          "factorialk"
+        ]
+      ],
+      "n_files": 1601,
+      "n_syms": 38248,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3278,
+          "wall_p95": 0.3278,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7038,
+          "output_tokens_ceiling": 2983,
+          "candidate_bytes": 59896
+        }
+      }
+    },
+    {
+      "instance_id": "py-pdf__pypdf-2964",
+      "partition": "train",
+      "repo": "py-pdf/pypdf",
+      "gold_files": [
+        "pypdf/_writer.py"
+      ],
+      "primary_files": [
+        "pypdf/_writer.py"
+      ],
+      "gold_funcs": [
+        [
+          "pypdf/_writer.py",
+          "PdfWriter",
+          "_insert_filtered_annotations"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "pypdf/_writer.py",
+          "PdfWriter",
+          "_insert_filtered_annotations"
+        ]
+      ],
+      "n_files": 140,
+      "n_syms": 3002,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": null,
+          "wall_median": 0.0687,
+          "wall_p95": 0.0687,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5102,
+          "output_tokens_ceiling": 2162,
+          "candidate_bytes": 75197
+        }
+      }
+    },
+    {
+      "instance_id": "py-pdf__pypdf-2934",
+      "partition": "train",
+      "repo": "py-pdf/pypdf",
+      "gold_files": [
+        "pypdf/_cmap.py"
+      ],
+      "primary_files": [
+        "pypdf/_cmap.py"
+      ],
+      "gold_funcs": [
+        [
+          "pypdf/_cmap.py",
+          "",
+          "_type1_alternative"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "pypdf/_cmap.py",
+          "",
+          "_type1_alternative"
+        ]
+      ],
+      "n_files": 140,
+      "n_syms": 2994,
+      "arms": {
+        "for": {
+          "file_first": 21,
+          "file_worst": 21,
+          "all_file_worst": 21,
+          "func_first": null,
+          "wall_median": 0.0681,
+          "wall_p95": 0.0681,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4703,
+          "output_tokens_ceiling": 1993,
+          "candidate_bytes": 75266
+        }
+      }
+    },
+    {
+      "instance_id": "py-pdf__pypdf-2656",
+      "partition": "train",
+      "repo": "py-pdf/pypdf",
+      "gold_files": [
+        "pypdf/_doc_common.py"
+      ],
+      "primary_files": [
+        "pypdf/_doc_common.py"
+      ],
+      "gold_funcs": [
+        [
+          "pypdf/_doc_common.py",
+          "PdfDocCommon",
+          "get_fields"
+        ],
+        [
+          "pypdf/_doc_common.py",
+          "PdfDocCommon",
+          "_build_field"
+        ],
+        [
+          "pypdf/_doc_common.py",
+          "PdfDocCommon",
+          "_check_kids"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "pypdf/_doc_common.py",
+          "PdfDocCommon",
+          "get_fields"
+        ],
+        [
+          "pypdf/_doc_common.py",
+          "PdfDocCommon",
+          "_build_field"
+        ],
+        [
+          "pypdf/_doc_common.py",
+          "PdfDocCommon",
+          "_check_kids"
+        ]
+      ],
+      "n_files": 136,
+      "n_syms": 2833,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 6,
+          "wall_median": 0.0662,
+          "wall_p95": 0.0662,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5570,
+          "output_tokens_ceiling": 2361,
+          "candidate_bytes": 77358
+        }
+      }
+    },
+    {
+      "instance_id": "py-pdf__pypdf-2644",
+      "partition": "train",
+      "repo": "py-pdf/pypdf",
+      "gold_files": [
+        "pypdf/filters.py"
+      ],
+      "primary_files": [
+        "pypdf/filters.py"
+      ],
+      "gold_funcs": [
+        [
+          "pypdf/filters.py",
+          "",
+          "decompress"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "pypdf/filters.py",
+          "",
+          "decompress"
+        ]
+      ],
+      "n_files": 136,
+      "n_syms": 2830,
+      "arms": {
+        "for": {
+          "file_first": 10,
+          "file_worst": 10,
+          "all_file_worst": 10,
+          "func_first": null,
+          "wall_median": 0.0674,
+          "wall_p95": 0.0674,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4822,
+          "output_tokens_ceiling": 2044,
+          "candidate_bytes": 76030
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-6128",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py"
+      ],
+      "primary_files": [
+        "prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py",
+          "iam_rotate_access_key_90_days",
+          "execute"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py",
+          "iam_rotate_access_key_90_days",
+          "execute"
+        ]
+      ],
+      "n_files": 3611,
+      "n_syms": 34839,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 3,
+          "wall_median": 0.269,
+          "wall_p95": 0.269,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3972,
+          "output_tokens_ceiling": 1684,
+          "candidate_bytes": 82308
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-6119",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/aws/services/wafv2/wafv2_service.py"
+      ],
+      "primary_files": [
+        "prowler/providers/aws/services/wafv2/wafv2_service.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/aws/services/wafv2/wafv2_service.py",
+          "WAFv2",
+          "_get_web_acl"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/aws/services/wafv2/wafv2_service.py",
+          "WAFv2",
+          "_get_web_acl"
+        ]
+      ],
+      "n_files": 3611,
+      "n_syms": 34836,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": null,
+          "wall_median": 0.2669,
+          "wall_p95": 0.2669,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3980,
+          "output_tokens_ceiling": 1687,
+          "candidate_bytes": 109429
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-6108",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py"
+      ],
+      "primary_files": [
+        "prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py",
+          "firehose_stream_encrypted_at_rest",
+          "execute"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py",
+          "firehose_stream_encrypted_at_rest",
+          "execute"
+        ]
+      ],
+      "n_files": 3609,
+      "n_syms": 34830,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 1,
+          "wall_median": 0.2631,
+          "wall_p95": 0.2631,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3717,
+          "output_tokens_ceiling": 1575,
+          "candidate_bytes": 97607
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-6004",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12.py"
+      ],
+      "primary_files": [
+        "prowler/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12.py",
+          "app_minimum_tls_version_12",
+          "execute"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12.py",
+          "app_minimum_tls_version_12",
+          "execute"
+        ]
+      ],
+      "n_files": 3602,
+      "n_syms": 34768,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 1,
+          "wall_median": 0.2647,
+          "wall_p95": 0.2647,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4601,
+          "output_tokens_ceiling": 1950,
+          "candidate_bytes": 117946
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-5933",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/lib/check/checks_loader.py"
+      ],
+      "primary_files": [
+        "prowler/lib/check/checks_loader.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/lib/check/checks_loader.py",
+          "",
+          "load_checks_to_execute"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/lib/check/checks_loader.py",
+          "",
+          "load_checks_to_execute"
+        ]
+      ],
+      "n_files": 3590,
+      "n_syms": 34667,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": 6,
+          "all_file_worst": 6,
+          "func_first": 9,
+          "wall_median": 0.2682,
+          "wall_p95": 0.2682,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5043,
+          "output_tokens_ceiling": 2137,
+          "candidate_bytes": 101631
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-5930",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/lib/check/models.py"
+      ],
+      "primary_files": [
+        "prowler/lib/check/models.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/lib/check/models.py",
+          "CheckMetadata",
+          "list_by_service"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/lib/check/models.py",
+          "CheckMetadata",
+          "list_by_service"
+        ]
+      ],
+      "n_files": 3590,
+      "n_syms": 34643,
+      "arms": {
+        "for": {
+          "file_first": 67,
+          "file_worst": 67,
+          "all_file_worst": 67,
+          "func_first": 123,
+          "wall_median": 0.2627,
+          "wall_p95": 0.2627,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2871,
+          "output_tokens_ceiling": 1217,
+          "candidate_bytes": 88786
+        }
+      }
+    },
+    {
+      "instance_id": "networkx__networkx-7729",
+      "partition": "train",
+      "repo": "networkx/networkx",
+      "gold_files": [
+        "networkx/classes/coreviews.py"
+      ],
+      "primary_files": [
+        "networkx/classes/coreviews.py"
+      ],
+      "gold_funcs": [
+        [
+          "networkx/classes/coreviews.py",
+          "FilterMultiInner",
+          "__getitem__"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "networkx/classes/coreviews.py",
+          "FilterMultiInner",
+          "__getitem__"
+        ]
+      ],
+      "n_files": 645,
+      "n_syms": 9096,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1064,
+          "wall_p95": 0.1064,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4797,
+          "output_tokens_ceiling": 2033,
+          "candidate_bytes": 61569
+        }
+      }
+    },
+    {
+      "instance_id": "networkx__networkx-7721",
+      "partition": "train",
+      "repo": "networkx/networkx",
+      "gold_files": [
+        "networkx/algorithms/approximation/traveling_salesman.py"
+      ],
+      "primary_files": [
+        "networkx/algorithms/approximation/traveling_salesman.py"
+      ],
+      "gold_funcs": [
+        [
+          "networkx/algorithms/approximation/traveling_salesman.py",
+          "",
+          "traveling_salesman_problem"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "networkx/algorithms/approximation/traveling_salesman.py",
+          "",
+          "traveling_salesman_problem"
+        ]
+      ],
+      "n_files": 645,
+      "n_syms": 9094,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.1068,
+          "wall_p95": 0.1068,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7391,
+          "output_tokens_ceiling": 3132,
+          "candidate_bytes": 63037
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-7189",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/config/envvars.py"
+      ],
+      "primary_files": [
+        "modin/config/envvars.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/config/envvars.py",
+          "LogMemoryInterval",
+          "get"
+        ],
+        [
+          "modin/config/envvars.py",
+          "LogFileSize",
+          "get"
+        ],
+        [
+          "modin/config/envvars.py",
+          "MinPartitionSize",
+          "get"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "modin/config/envvars.py",
+          "CpuCount",
+          "get"
+        ],
+        [
+          "modin/config/envvars.py",
+          "NPartitions",
+          "get"
+        ]
+      ],
+      "covered": [
+        [
+          "modin/config/envvars.py",
+          "LogMemoryInterval",
+          "get"
+        ],
+        [
+          "modin/config/envvars.py",
+          "LogFileSize",
+          "get"
+        ],
+        [
+          "modin/config/envvars.py",
+          "MinPartitionSize",
+          "get"
+        ]
+      ],
+      "n_files": 450,
+      "n_syms": 8536,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": null,
+          "wall_median": 0.0942,
+          "wall_p95": 0.0942,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4556,
+          "output_tokens_ceiling": 1931,
+          "candidate_bytes": 83907
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-7059",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/pandas/dataframe.py"
+      ],
+      "primary_files": [
+        "modin/pandas/dataframe.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/pandas/dataframe.py",
+          "DataFrame",
+          "insert"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/pandas/dataframe.py",
+          "DataFrame",
+          "insert"
+        ]
+      ],
+      "n_files": 451,
+      "n_syms": 8471,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 4,
+          "wall_median": 0.0924,
+          "wall_p95": 0.0924,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2182,
+          "output_tokens_ceiling": 925,
+          "candidate_bytes": 76288
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-7052",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/pandas/base.py"
+      ],
+      "primary_files": [
+        "modin/pandas/base.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/pandas/base.py",
+          "BasePandasDataset",
+          "astype"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/pandas/base.py",
+          "BasePandasDataset",
+          "astype"
+        ]
+      ],
+      "n_files": 451,
+      "n_syms": 8471,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 15,
+          "wall_median": 0.0939,
+          "wall_p95": 0.0939,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2615,
+          "output_tokens_ceiling": 1109,
+          "candidate_bytes": 85969
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-6995",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/pandas/series.py"
+      ],
+      "primary_files": [
+        "modin/pandas/series.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/pandas/series.py",
+          "Series",
+          "idxmax"
+        ],
+        [
+          "modin/pandas/series.py",
+          "Series",
+          "idxmin"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/pandas/series.py",
+          "Series",
+          "idxmax"
+        ],
+        [
+          "modin/pandas/series.py",
+          "Series",
+          "idxmin"
+        ]
+      ],
+      "n_files": 447,
+      "n_syms": 8426,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": null,
+          "wall_median": 0.0914,
+          "wall_p95": 0.0914,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 1627,
+          "output_tokens_ceiling": 690,
+          "candidate_bytes": 78765
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-6980",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/core/dataframe/pandas/dataframe/dataframe.py"
+      ],
+      "primary_files": [
+        "modin/core/dataframe/pandas/dataframe/dataframe.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "_get_lengths"
+        ],
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "_copartition"
+        ],
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "n_ary_op"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "_get_lengths"
+        ],
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "_copartition"
+        ],
+        [
+          "modin/core/dataframe/pandas/dataframe/dataframe.py",
+          "PandasDataframe",
+          "n_ary_op"
+        ]
+      ],
+      "n_files": 440,
+      "n_syms": 8387,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 3,
+          "wall_median": 0.0956,
+          "wall_p95": 0.0956,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4858,
+          "output_tokens_ceiling": 2059,
+          "candidate_bytes": 91539
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-6951",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/pandas/groupby.py"
+      ],
+      "primary_files": [
+        "modin/pandas/groupby.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/pandas/groupby.py",
+          "DataFrameGroupBy",
+          "aggregate"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/pandas/groupby.py",
+          "DataFrameGroupBy",
+          "aggregate"
+        ]
+      ],
+      "n_files": 439,
+      "n_syms": 8380,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": null,
+          "wall_median": 0.0938,
+          "wall_p95": 0.0938,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3821,
+          "output_tokens_ceiling": 1620,
+          "candidate_bytes": 87761
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-6912",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/core/dataframe/pandas/partitioning/partition_manager.py"
+      ],
+      "primary_files": [
+        "modin/core/dataframe/pandas/partitioning/partition_manager.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+          "PandasDataframePartitionManager",
+          "split_pandas_df_into_partitions"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/core/dataframe/pandas/partitioning/partition_manager.py",
+          "PandasDataframePartitionManager",
+          "split_pandas_df_into_partitions"
+        ]
+      ],
+      "n_files": 436,
+      "n_syms": 8321,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 3,
+          "wall_median": 0.092,
+          "wall_p95": 0.092,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2872,
+          "output_tokens_ceiling": 1217,
+          "candidate_bytes": 88467
+        }
+      }
+    },
+    {
+      "instance_id": "iterative__dvc-10641",
+      "partition": "train",
+      "repo": "iterative/dvc",
+      "gold_files": [
+        "dvc/repo/experiments/remove.py"
+      ],
+      "primary_files": [
+        "dvc/repo/experiments/remove.py"
+      ],
+      "gold_funcs": [
+        [
+          "dvc/repo/experiments/remove.py",
+          "",
+          "remove"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "dvc/repo/experiments/remove.py",
+          "",
+          "remove"
+        ]
+      ],
+      "n_files": 523,
+      "n_syms": 5776,
+      "arms": {
+        "for": {
+          "file_first": 7,
+          "file_worst": 7,
+          "all_file_worst": 7,
+          "func_first": 9,
+          "wall_median": 0.0772,
+          "wall_p95": 0.0772,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4124,
+          "output_tokens_ceiling": 1748,
+          "candidate_bytes": 67336
+        }
+      }
+    },
+    {
+      "instance_id": "matplotlib__matplotlib-29133",
+      "partition": "train",
+      "repo": "matplotlib/matplotlib",
+      "gold_files": [
+        "lib/matplotlib/axes/_axes.py"
+      ],
+      "primary_files": [
+        "lib/matplotlib/axes/_axes.py"
+      ],
+      "gold_funcs": [
+        [
+          "lib/matplotlib/axes/_axes.py",
+          "Axes",
+          "bar"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "lib/matplotlib/axes/_axes.py",
+          "Axes",
+          "_parse_bar_color_args"
+        ]
+      ],
+      "covered": [
+        [
+          "lib/matplotlib/axes/_axes.py",
+          "Axes",
+          "bar"
+        ]
+      ],
+      "n_files": 1239,
+      "n_syms": 31294,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 9,
+          "wall_median": 0.4157,
+          "wall_p95": 0.4157,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6886,
+          "output_tokens_ceiling": 2918,
+          "candidate_bytes": 75957
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-25787",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/lax/linalg.py"
+      ],
+      "primary_files": [
+        "jax/_src/lax/linalg.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/lax/linalg.py",
+          "",
+          "_tridiagonal_solve_transpose_rule"
+        ],
+        [
+          "jax/_src/lax/linalg.py",
+          "",
+          "_tridiagonal_solve_jax"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "jax/_src/lax/linalg.py",
+          "",
+          "_tridiagonal_product"
+        ],
+        [
+          "jax/_src/lax/linalg.py",
+          "",
+          "_tridiagonal_solve_jvp_rule"
+        ],
+        [
+          "jax/_src/lax/linalg.py",
+          "",
+          "_tridiagonal_solve_jax_impl"
+        ]
+      ],
+      "covered": [
+        [
+          "jax/_src/lax/linalg.py",
+          "",
+          "_tridiagonal_solve_transpose_rule"
+        ],
+        [
+          "jax/_src/lax/linalg.py",
+          "",
+          "_tridiagonal_solve_jax"
+        ]
+      ],
+      "n_files": 899,
+      "n_syms": 33492,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 5,
+          "wall_median": 0.3165,
+          "wall_p95": 0.3165,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5811,
+          "output_tokens_ceiling": 2463,
+          "candidate_bytes": 67208
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-25511",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/lax/control_flow/loops.py"
+      ],
+      "primary_files": [
+        "jax/_src/lax/control_flow/loops.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/lax/control_flow/loops.py",
+          "",
+          "_check_carry_type"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "jax/_src/lax/control_flow/loops.py",
+          "",
+          "_capitalize"
+        ]
+      ],
+      "covered": [
+        [
+          "jax/_src/lax/control_flow/loops.py",
+          "",
+          "_check_carry_type"
+        ]
+      ],
+      "n_files": 882,
+      "n_syms": 33069,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3059,
+          "wall_p95": 0.3059,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3539,
+          "output_tokens_ceiling": 1500,
+          "candidate_bytes": 65652
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-25239",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/numpy/lax_numpy.py"
+      ],
+      "primary_files": [
+        "jax/_src/numpy/lax_numpy.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/numpy/lax_numpy.py",
+          "",
+          "_index_to_gather"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/numpy/lax_numpy.py",
+          "",
+          "_index_to_gather"
+        ]
+      ],
+      "n_files": 870,
+      "n_syms": 32768,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 64,
+          "wall_median": 0.3088,
+          "wall_p95": 0.3088,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3566,
+          "output_tokens_ceiling": 1512,
+          "candidate_bytes": 61529
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-24823",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/lax/lax.py"
+      ],
+      "primary_files": [
+        "jax/_src/lax/lax.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/lax/lax.py",
+          "",
+          "_sort_jvp"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/lax/lax.py",
+          "",
+          "_sort_jvp"
+        ]
+      ],
+      "n_files": 854,
+      "n_syms": 32188,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.3009,
+          "wall_p95": 0.3009,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3771,
+          "output_tokens_ceiling": 1598,
+          "candidate_bytes": 67169
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-24814",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/numpy/lax_numpy.py"
+      ],
+      "primary_files": [
+        "jax/_src/numpy/lax_numpy.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/numpy/lax_numpy.py",
+          "",
+          "bincount"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/numpy/lax_numpy.py",
+          "",
+          "bincount"
+        ]
+      ],
+      "n_files": 852,
+      "n_syms": 32149,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3014,
+          "wall_p95": 0.3014,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3923,
+          "output_tokens_ceiling": 1663,
+          "candidate_bytes": 60622
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-24492",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/numpy/util.py"
+      ],
+      "primary_files": [
+        "jax/_src/numpy/util.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/numpy/util.py",
+          "",
+          "_parse_numpydoc"
+        ],
+        [
+          "jax/_src/numpy/util.py",
+          "",
+          "_parse_parameters"
+        ],
+        [
+          "jax/_src/numpy/util.py",
+          "",
+          "implements"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/numpy/util.py",
+          "",
+          "_parse_numpydoc"
+        ],
+        [
+          "jax/_src/numpy/util.py",
+          "",
+          "_parse_parameters"
+        ],
+        [
+          "jax/_src/numpy/util.py",
+          "",
+          "implements"
+        ]
+      ],
+      "n_files": 845,
+      "n_syms": 32130,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 1,
+          "wall_median": 0.304,
+          "wall_p95": 0.304,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6035,
+          "output_tokens_ceiling": 2558,
+          "candidate_bytes": 68946
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-23020",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/numpy/setops.py"
+      ],
+      "primary_files": [
+        "jax/_src/numpy/setops.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/numpy/setops.py",
+          "",
+          "setxor1d"
+        ],
+        [
+          "jax/_src/numpy/setops.py",
+          "",
+          "_intersect1d_size"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "jax/_src/numpy/setops.py",
+          "",
+          "_concat_unique"
+        ],
+        [
+          "jax/_src/numpy/setops.py",
+          "",
+          "_setxor1d_size"
+        ]
+      ],
+      "covered": [
+        [
+          "jax/_src/numpy/setops.py",
+          "",
+          "setxor1d"
+        ],
+        [
+          "jax/_src/numpy/setops.py",
+          "",
+          "_intersect1d_size"
+        ]
+      ],
+      "n_files": 811,
+      "n_syms": 30856,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 24,
+          "wall_median": 0.2876,
+          "wall_p95": 0.2876,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3480,
+          "output_tokens_ceiling": 1475,
+          "candidate_bytes": 68165
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-22897",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/numpy/lax_numpy.py"
+      ],
+      "primary_files": [
+        "jax/_src/numpy/lax_numpy.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/numpy/lax_numpy.py",
+          "",
+          "_expand_bool_indices"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/numpy/lax_numpy.py",
+          "",
+          "_expand_bool_indices"
+        ]
+      ],
+      "n_files": 800,
+      "n_syms": 30671,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 14,
+          "wall_median": 0.2844,
+          "wall_p95": 0.2844,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6023,
+          "output_tokens_ceiling": 2553,
+          "candidate_bytes": 66973
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-22049",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/experimental/shard_map.py"
+      ],
+      "primary_files": [
+        "jax/experimental/shard_map.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "shard_map"
+        ],
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_shard_map"
+        ],
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_check_specs_vs_args"
+        ],
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_iter_paths"
+        ],
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_shard_map_staging"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_expand_fail"
+        ]
+      ],
+      "covered": [
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "shard_map"
+        ],
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_shard_map"
+        ],
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_check_specs_vs_args"
+        ],
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_iter_paths"
+        ],
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_shard_map_staging"
+        ]
+      ],
+      "n_files": 789,
+      "n_syms": 30151,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 6,
+          "wall_median": 0.28,
+          "wall_p95": 0.28,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3596,
+          "output_tokens_ceiling": 1524,
+          "candidate_bytes": 69215
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-20862",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/numpy/lax_numpy.py"
+      ],
+      "primary_files": [
+        "jax/_src/numpy/lax_numpy.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/numpy/lax_numpy.py",
+          "",
+          "select"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/numpy/lax_numpy.py",
+          "",
+          "select"
+        ]
+      ],
+      "n_files": 764,
+      "n_syms": 29047,
+      "arms": {
+        "for": {
+          "file_first": 50,
+          "file_worst": 50,
+          "all_file_worst": 50,
+          "func_first": 86,
+          "wall_median": 0.2716,
+          "wall_p95": 0.2716,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4113,
+          "output_tokens_ceiling": 1743,
+          "candidate_bytes": 69111
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-19909",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/custom_derivatives.py"
+      ],
+      "primary_files": [
+        "jax/_src/custom_derivatives.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/custom_derivatives.py",
+          "",
+          "_flatten_bwd"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/custom_derivatives.py",
+          "",
+          "_flatten_bwd"
+        ]
+      ],
+      "n_files": 732,
+      "n_syms": 27461,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": 6,
+          "all_file_worst": 6,
+          "func_first": 146,
+          "wall_median": 0.2541,
+          "wall_p95": 0.2541,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3930,
+          "output_tokens_ceiling": 1666,
+          "candidate_bytes": 66734
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-19710",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/experimental/shard_map.py"
+      ],
+      "primary_files": [
+        "jax/experimental/shard_map.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_standard_collective_rewrite"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_standard_collective_rewrite"
+        ]
+      ],
+      "n_files": 735,
+      "n_syms": 27497,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": null,
+          "wall_median": 0.2603,
+          "wall_p95": 0.2603,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4243,
+          "output_tokens_ceiling": 1798,
+          "candidate_bytes": 69880
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-19601",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/experimental/shard_map.py"
+      ],
+      "primary_files": [
+        "jax/experimental/shard_map.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_standard_collective_rewrite"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/experimental/shard_map.py",
+          "",
+          "_standard_collective_rewrite"
+        ]
+      ],
+      "n_files": 733,
+      "n_syms": 27341,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": null,
+          "wall_median": 0.2564,
+          "wall_p95": 0.2564,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4486,
+          "output_tokens_ceiling": 1901,
+          "candidate_bytes": 68308
+        }
+      }
+    },
+    {
+      "instance_id": "sqlfluff__sqlfluff-6554",
+      "partition": "train",
+      "repo": "sqlfluff/sqlfluff",
+      "gold_files": [
+        "src/sqlfluff/rules/references/RF01.py"
+      ],
+      "primary_files": [
+        "src/sqlfluff/rules/references/RF01.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/sqlfluff/rules/references/RF01.py",
+          "Rule_RF01",
+          "_dialect_supports_dot_access"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/sqlfluff/rules/references/RF01.py",
+          "Rule_RF01",
+          "_dialect_supports_dot_access"
+        ]
+      ],
+      "n_files": 2375,
+      "n_syms": 33481,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": null,
+          "wall_median": 0.0998,
+          "wall_p95": 0.0998,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4269,
+          "output_tokens_ceiling": 1809,
+          "candidate_bytes": 79285
+        }
+      }
+    },
+    {
+      "instance_id": "sqlfluff__sqlfluff-6444",
+      "partition": "train",
+      "repo": "sqlfluff/sqlfluff",
+      "gold_files": [
+        "src/sqlfluff/utils/analysis/select.py"
+      ],
+      "primary_files": [
+        "src/sqlfluff/utils/analysis/select.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/sqlfluff/utils/analysis/select.py",
+          "",
+          "_get_lambda_argument_columns"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/sqlfluff/utils/analysis/select.py",
+          "",
+          "_get_lambda_argument_columns"
+        ]
+      ],
+      "n_files": 2350,
+      "n_syms": 32893,
+      "arms": {
+        "for": {
+          "file_first": 12,
+          "file_worst": 12,
+          "all_file_worst": 12,
+          "func_first": 152,
+          "wall_median": 0.0982,
+          "wall_p95": 0.0982,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4559,
+          "output_tokens_ceiling": 1932,
+          "candidate_bytes": 79977
+        }
+      }
+    },
+    {
+      "instance_id": "sqlfluff__sqlfluff-6391",
+      "partition": "train",
+      "repo": "sqlfluff/sqlfluff",
+      "gold_files": [
+        "src/sqlfluff/core/helpers/string.py"
+      ],
+      "primary_files": [
+        "src/sqlfluff/core/helpers/string.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/sqlfluff/core/helpers/string.py",
+          "",
+          "split_colon_separated_string"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "src/sqlfluff/core/helpers/string.py",
+          "",
+          "should_split_on_colon"
+        ]
+      ],
+      "covered": [
+        [
+          "src/sqlfluff/core/helpers/string.py",
+          "",
+          "split_colon_separated_string"
+        ]
+      ],
+      "n_files": 2332,
+      "n_syms": 32718,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.0941,
+          "wall_p95": 0.0941,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4575,
+          "output_tokens_ceiling": 1939,
+          "candidate_bytes": 81619
+        }
+      }
+    },
+    {
+      "instance_id": "sqlfluff__sqlfluff-6312",
+      "partition": "train",
+      "repo": "sqlfluff/sqlfluff",
+      "gold_files": [
+        "src/sqlfluff/cli/commands.py"
+      ],
+      "primary_files": [
+        "src/sqlfluff/cli/commands.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "lint"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "lint"
+        ]
+      ],
+      "n_files": 2317,
+      "n_syms": 32450,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.0966,
+          "wall_p95": 0.0966,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4229,
+          "output_tokens_ceiling": 1792,
+          "candidate_bytes": 79614
+        }
+      }
+    },
+    {
+      "instance_id": "sqlfluff__sqlfluff-5805",
+      "partition": "train",
+      "repo": "sqlfluff/sqlfluff",
+      "gold_files": [
+        "src/sqlfluff/cli/commands.py"
+      ],
+      "primary_files": [
+        "src/sqlfluff/cli/commands.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "core_options"
+        ],
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "lint"
+        ],
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "fix"
+        ],
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "cli_format"
+        ],
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "parse"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "core_options"
+        ],
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "lint"
+        ],
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "fix"
+        ],
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "cli_format"
+        ],
+        [
+          "src/sqlfluff/cli/commands.py",
+          "",
+          "parse"
+        ]
+      ],
+      "n_files": 1985,
+      "n_syms": 28058,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.0894,
+          "wall_p95": 0.0894,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3514,
+          "output_tokens_ceiling": 1489,
+          "candidate_bytes": 79954
+        }
+      }
+    },
+    {
+      "instance_id": "ranaroussi__yfinance-2139",
+      "partition": "train",
+      "repo": "ranaroussi/yfinance",
+      "gold_files": [
+        "yfinance/scrapers/history.py"
+      ],
+      "primary_files": [
+        "yfinance/scrapers/history.py"
+      ],
+      "gold_funcs": [
+        [
+          "yfinance/scrapers/history.py",
+          "PriceHistory",
+          "_fix_bad_div_adjust"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yfinance/scrapers/history.py",
+          "PriceHistory",
+          "_fix_bad_div_adjust"
+        ]
+      ],
+      "n_files": 128,
+      "n_syms": 880,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 56,
+          "wall_median": 0.0406,
+          "wall_p95": 0.0406,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6320,
+          "output_tokens_ceiling": 2678,
+          "candidate_bytes": 72768
+        }
+      }
+    },
+    {
+      "instance_id": "instructor-ai__instructor-1254",
+      "partition": "train",
+      "repo": "instructor-ai/instructor",
+      "gold_files": [
+        "instructor/retry.py"
+      ],
+      "primary_files": [
+        "instructor/retry.py"
+      ],
+      "gold_funcs": [
+        [
+          "instructor/retry.py",
+          "",
+          "initialize_usage"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "instructor/retry.py",
+          "",
+          "initialize_usage"
+        ]
+      ],
+      "n_files": 484,
+      "n_syms": 4628,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 3,
+          "wall_median": 0.0497,
+          "wall_p95": 0.0497,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4920,
+          "output_tokens_ceiling": 2085,
+          "candidate_bytes": 68766
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-6157",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py"
+      ],
+      "primary_files": [
+        "prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py",
+          "rds_instance_no_public_access",
+          "execute"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py",
+          "rds_instance_no_public_access",
+          "execute"
+        ]
+      ],
+      "n_files": 3620,
+      "n_syms": 34899,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 42,
+          "wall_median": 0.2708,
+          "wall_p95": 0.2708,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4603,
+          "output_tokens_ceiling": 1951,
+          "candidate_bytes": 115835
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-5961",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/aws/services/rds/rds_service.py"
+      ],
+      "primary_files": [
+        "prowler/providers/aws/services/rds/rds_service.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/aws/services/rds/rds_service.py",
+          "RDS",
+          "_describe_db_event_subscriptions"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/aws/services/rds/rds_service.py",
+          "RDS",
+          "_describe_db_event_subscriptions"
+        ]
+      ],
+      "n_files": 3593,
+      "n_syms": 34679,
+      "arms": {
+        "for": {
+          "file_first": 36,
+          "file_worst": 36,
+          "all_file_worst": 36,
+          "func_first": 199,
+          "wall_median": 0.2715,
+          "wall_p95": 0.2715,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6197,
+          "output_tokens_ceiling": 2626,
+          "candidate_bytes": 79932
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-5856",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/aws/services/ec2/lib/instance.py"
+      ],
+      "primary_files": [
+        "prowler/providers/aws/services/ec2/lib/instance.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/aws/services/ec2/lib/instance.py",
+          "",
+          "get_instance_public_status"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/aws/services/ec2/lib/instance.py",
+          "",
+          "get_instance_public_status"
+        ]
+      ],
+      "n_files": 3316,
+      "n_syms": 32776,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.2543,
+          "wall_p95": 0.2543,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3480,
+          "output_tokens_ceiling": 1475,
+          "candidate_bytes": 106177
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-5814",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/kubernetes/services/core/core_seccomp_profile_docker_default/core_seccomp_profile_docker_default.py"
+      ],
+      "primary_files": [
+        "prowler/providers/kubernetes/services/core/core_seccomp_profile_docker_default/core_seccomp_profile_docker_default.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/kubernetes/services/core/core_seccomp_profile_docker_default/core_seccomp_profile_docker_default.py",
+          "core_seccomp_profile_docker_default",
+          "execute"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/kubernetes/services/core/core_seccomp_profile_docker_default/core_seccomp_profile_docker_default.py",
+          "core_seccomp_profile_docker_default",
+          "execute"
+        ]
+      ],
+      "n_files": 3305,
+      "n_syms": 32656,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 1,
+          "wall_median": 0.2579,
+          "wall_p95": 0.2579,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4959,
+          "output_tokens_ceiling": 2102,
+          "candidate_bytes": 104401
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-5811",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/aws/services/wafv2/wafv2_service.py"
+      ],
+      "primary_files": [
+        "prowler/providers/aws/services/wafv2/wafv2_service.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/aws/services/wafv2/wafv2_service.py",
+          "WAFv2",
+          "_list_resources_for_web_acl"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/aws/services/wafv2/wafv2_service.py",
+          "WAFv2",
+          "_list_resources_for_web_acl"
+        ]
+      ],
+      "n_files": 3302,
+      "n_syms": 32627,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 87,
+          "wall_median": 0.2515,
+          "wall_p95": 0.2515,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5355,
+          "output_tokens_ceiling": 2270,
+          "candidate_bytes": 84106
+        }
+      }
+    },
+    {
+      "instance_id": "prowler-cloud__prowler-5653",
+      "partition": "train",
+      "repo": "prowler-cloud/prowler",
+      "gold_files": [
+        "prowler/providers/common/provider.py"
+      ],
+      "primary_files": [
+        "prowler/providers/common/provider.py"
+      ],
+      "gold_funcs": [
+        [
+          "prowler/providers/common/provider.py",
+          "Provider",
+          "init_global_provider"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "prowler/providers/common/provider.py",
+          "Provider",
+          "init_global_provider"
+        ]
+      ],
+      "n_files": 3271,
+      "n_syms": 32275,
+      "arms": {
+        "for": {
+          "file_first": 21,
+          "file_worst": 21,
+          "all_file_worst": 21,
+          "func_first": 79,
+          "wall_median": 0.2546,
+          "wall_p95": 0.2546,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5386,
+          "output_tokens_ceiling": 2283,
+          "candidate_bytes": 92549
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-11138",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/executor/ray_utils.py"
+      ],
+      "primary_files": [
+        "vllm/executor/ray_utils.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/executor/ray_utils.py",
+          "",
+          "initialize_ray_cluster"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/executor/ray_utils.py",
+          "",
+          "initialize_ray_cluster"
+        ]
+      ],
+      "n_files": 1217,
+      "n_syms": 26121,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.1895,
+          "wall_p95": 0.1895,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3966,
+          "output_tokens_ceiling": 1681,
+          "candidate_bytes": 78540
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-11073",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/entrypoints/openai/serving_completion.py"
+      ],
+      "primary_files": [
+        "vllm/entrypoints/openai/serving_completion.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/entrypoints/openai/serving_completion.py",
+          "OpenAIServingCompletion",
+          "request_output_to_completion_response"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/entrypoints/openai/serving_completion.py",
+          "OpenAIServingCompletion",
+          "request_output_to_completion_response"
+        ]
+      ],
+      "n_files": 1214,
+      "n_syms": 26025,
+      "arms": {
+        "for": {
+          "file_first": 11,
+          "file_worst": 11,
+          "all_file_worst": 11,
+          "func_first": 116,
+          "wall_median": 0.2028,
+          "wall_p95": 0.2028,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3974,
+          "output_tokens_ceiling": 1684,
+          "candidate_bytes": 76385
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10903",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/v1/worker/gpu_model_runner.py"
+      ],
+      "primary_files": [
+        "vllm/v1/worker/gpu_model_runner.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/v1/worker/gpu_model_runner.py",
+          "GPUModelRunner",
+          "_prepare_inputs"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/v1/worker/gpu_model_runner.py",
+          "GPUModelRunner",
+          "_prepare_inputs"
+        ]
+      ],
+      "n_files": 1193,
+      "n_syms": 25765,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1856,
+          "wall_p95": 0.1856,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3827,
+          "output_tokens_ceiling": 1622,
+          "candidate_bytes": 72100
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10809",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/engine/metrics.py"
+      ],
+      "primary_files": [
+        "vllm/engine/metrics.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/engine/metrics.py",
+          "LoggingStatLogger",
+          "log"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/engine/metrics.py",
+          "LoggingStatLogger",
+          "log"
+        ]
+      ],
+      "n_files": 1172,
+      "n_syms": 25517,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.1789,
+          "wall_p95": 0.1789,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3548,
+          "output_tokens_ceiling": 1504,
+          "candidate_bytes": 83558
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10778",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/model_executor/models/idefics3.py"
+      ],
+      "primary_files": [
+        "vllm/model_executor/models/idefics3.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/model_executor/models/idefics3.py",
+          "",
+          "input_processor_for_idefics3"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/model_executor/models/idefics3.py",
+          "",
+          "input_processor_for_idefics3"
+        ]
+      ],
+      "n_files": 1171,
+      "n_syms": 25496,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1813,
+          "wall_p95": 0.1813,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3589,
+          "output_tokens_ceiling": 1521,
+          "candidate_bytes": 71683
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10620",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/plugins/__init__.py"
+      ],
+      "primary_files": [
+        "vllm/plugins/__init__.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/plugins/__init__.py",
+          "",
+          "load_general_plugins"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/plugins/__init__.py",
+          "",
+          "load_general_plugins"
+        ]
+      ],
+      "n_files": 1158,
+      "n_syms": 25223,
+      "arms": {
+        "for": {
+          "file_first": 89,
+          "file_worst": 89,
+          "all_file_worst": 89,
+          "func_first": 174,
+          "wall_median": 0.1786,
+          "wall_p95": 0.1786,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3679,
+          "output_tokens_ceiling": 1559,
+          "candidate_bytes": 69981
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10536",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/model_executor/models/qwen2_audio.py"
+      ],
+      "primary_files": [
+        "vllm/model_executor/models/qwen2_audio.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/model_executor/models/qwen2_audio.py",
+          "",
+          "input_processor_for_qwen2_audio"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/model_executor/models/qwen2_audio.py",
+          "",
+          "input_processor_for_qwen2_audio"
+        ]
+      ],
+      "n_files": 1150,
+      "n_syms": 24909,
+      "arms": {
+        "for": {
+          "file_first": 77,
+          "file_worst": 77,
+          "all_file_worst": 77,
+          "func_first": null,
+          "wall_median": 0.1769,
+          "wall_p95": 0.1769,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3673,
+          "output_tokens_ceiling": 1557,
+          "candidate_bytes": 70586
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10398",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py"
+      ],
+      "primary_files": [
+        "vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py",
+          "Hermes2ProToolParser",
+          "extract_tool_calls_streaming"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py",
+          "Hermes2ProToolParser",
+          "extract_tool_calls_streaming"
+        ]
+      ],
+      "n_files": 1142,
+      "n_syms": 24775,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1798,
+          "wall_p95": 0.1798,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4009,
+          "output_tokens_ceiling": 1699,
+          "candidate_bytes": 72004
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10347",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/model_executor/models/falcon.py"
+      ],
+      "primary_files": [
+        "vllm/model_executor/models/falcon.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/model_executor/models/falcon.py",
+          "FalconDecoderLayer",
+          "__init__"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/model_executor/models/falcon.py",
+          "FalconDecoderLayer",
+          "__init__"
+        ]
+      ],
+      "n_files": 1139,
+      "n_syms": 24549,
+      "arms": {
+        "for": {
+          "file_first": 84,
+          "file_worst": 84,
+          "all_file_worst": 84,
+          "func_first": null,
+          "wall_median": 0.1752,
+          "wall_p95": 0.1752,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4155,
+          "output_tokens_ceiling": 1761,
+          "candidate_bytes": 71339
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10076",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/entrypoints/openai/serving_engine.py"
+      ],
+      "primary_files": [
+        "vllm/entrypoints/openai/serving_engine.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/entrypoints/openai/serving_engine.py",
+          "OpenAIServing",
+          "_preprocess_chat"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/entrypoints/openai/serving_engine.py",
+          "OpenAIServing",
+          "_preprocess_chat"
+        ]
+      ],
+      "n_files": 1091,
+      "n_syms": 23937,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1691,
+          "wall_p95": 0.1691,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3666,
+          "output_tokens_ceiling": 1554,
+          "candidate_bytes": 70976
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-10012",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/entrypoints/openai/api_server.py"
+      ],
+      "primary_files": [
+        "vllm/entrypoints/openai/api_server.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/entrypoints/openai/api_server.py",
+          "",
+          "run_server"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/entrypoints/openai/api_server.py",
+          "",
+          "run_server"
+        ]
+      ],
+      "n_files": 1084,
+      "n_syms": 23619,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 3,
+          "wall_median": 0.1673,
+          "wall_p95": 0.1673,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5249,
+          "output_tokens_ceiling": 2225,
+          "candidate_bytes": 65105
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-9974",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/platforms/openvino.py"
+      ],
+      "primary_files": [
+        "vllm/platforms/openvino.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/platforms/openvino.py",
+          "OpenVinoPlatform",
+          "is_pin_memory_available"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/platforms/openvino.py",
+          "OpenVinoPlatform",
+          "is_pin_memory_available"
+        ]
+      ],
+      "n_files": 1083,
+      "n_syms": 23603,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": null,
+          "wall_median": 0.1678,
+          "wall_p95": 0.1678,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3569,
+          "output_tokens_ceiling": 1513,
+          "candidate_bytes": 75844
+        }
+      }
+    },
+    {
+      "instance_id": "Zulko__moviepy-2253",
+      "partition": "train",
+      "repo": "Zulko/moviepy",
+      "gold_files": [
+        "moviepy/video/io/ffmpeg_reader.py"
+      ],
+      "primary_files": [
+        "moviepy/video/io/ffmpeg_reader.py"
+      ],
+      "gold_funcs": [
+        [
+          "moviepy/video/io/ffmpeg_reader.py",
+          "FFMPEG_VideoReader",
+          "__init__"
+        ],
+        [
+          "moviepy/video/io/ffmpeg_reader.py",
+          "FFmpegInfosParser",
+          "parse"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "moviepy/video/io/ffmpeg_reader.py",
+          "FFMPEG_VideoReader",
+          "__init__"
+        ],
+        [
+          "moviepy/video/io/ffmpeg_reader.py",
+          "FFmpegInfosParser",
+          "parse"
+        ]
+      ],
+      "n_files": 145,
+      "n_syms": 1118,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 39,
+          "wall_median": 0.0398,
+          "wall_p95": 0.0398,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5338,
+          "output_tokens_ceiling": 2262,
+          "candidate_bytes": 68149
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11827",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/update.py"
+      ],
+      "primary_files": [
+        "yt_dlp/update.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/update.py",
+          "Updater",
+          "cmd"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/update.py",
+          "Updater",
+          "cmd"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10257,
+      "arms": {
+        "for": {
+          "file_first": 9,
+          "file_worst": 9,
+          "all_file_worst": 9,
+          "func_first": null,
+          "wall_median": 0.1556,
+          "wall_p95": 0.1556,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4354,
+          "output_tokens_ceiling": 1845,
+          "candidate_bytes": 69120
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11821",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_extract_player_responses"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeIE",
+          "_extract_player_responses"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10257,
+      "arms": {
+        "for": {
+          "file_first": 7,
+          "file_worst": 7,
+          "all_file_worst": 7,
+          "func_first": 73,
+          "wall_median": 0.1575,
+          "wall_p95": 0.1575,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68334
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11819",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/update.py"
+      ],
+      "primary_files": [
+        "yt_dlp/update.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/update.py",
+          "",
+          "_get_variant_and_executable_path"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/update.py",
+          "",
+          "_get_variant_and_executable_path"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10257,
+      "arms": {
+        "for": {
+          "file_first": 8,
+          "file_worst": 8,
+          "all_file_worst": 8,
+          "func_first": null,
+          "wall_median": 0.1559,
+          "wall_p95": 0.1559,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4353,
+          "output_tokens_ceiling": 1845,
+          "candidate_bytes": 69067
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11818",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeBaseInfoExtractor",
+          "handle_or_none"
+        ],
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeBaseInfoExtractor",
+          "handle_from_url"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeBaseInfoExtractor",
+          "handle_or_none"
+        ],
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeBaseInfoExtractor",
+          "handle_from_url"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10257,
+      "arms": {
+        "for": {
+          "file_first": 8,
+          "file_worst": 8,
+          "all_file_worst": 8,
+          "func_first": null,
+          "wall_median": 0.154,
+          "wall_p95": 0.154,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4707,
+          "output_tokens_ceiling": 1995,
+          "candidate_bytes": 68114
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11782",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeTabBaseInfoExtractor",
+          "_extract_entries"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeTabBaseInfoExtractor",
+          "_extract_entries"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10254,
+      "arms": {
+        "for": {
+          "file_first": 7,
+          "file_worst": 7,
+          "all_file_worst": 7,
+          "func_first": null,
+          "wall_median": 0.1559,
+          "wall_p95": 0.1559,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68336
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11734",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/bilibili.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/bilibili.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/bilibili.py",
+          "BiliBiliIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/bilibili.py",
+          "BiliBiliIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10251,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1544,
+          "wall_p95": 0.1544,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4370,
+          "output_tokens_ceiling": 1852,
+          "candidate_bytes": 69274
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11711",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/bilibili.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/bilibili.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/bilibili.py",
+          "BiliBiliIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/bilibili.py",
+          "BiliBiliIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10246,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1556,
+          "wall_p95": 0.1556,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68030
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11683",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/mitele.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/mitele.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/mitele.py",
+          "MiTeleIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/mitele.py",
+          "MiTeleIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10247,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1526,
+          "wall_p95": 0.1526,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4738,
+          "output_tokens_ceiling": 2008,
+          "candidate_bytes": 68490
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11667",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/bilibili.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/bilibili.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/bilibili.py",
+          "BiliBiliIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/bilibili.py",
+          "BiliBiliIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10247,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.155,
+          "wall_p95": 0.155,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68180
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11645",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/tiktok.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/tiktok.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/tiktok.py",
+          "TikTokBaseIE",
+          "_parse_aweme_video_app"
+        ],
+        [
+          "yt_dlp/extractor/tiktok.py",
+          "TikTokBaseIE",
+          "_parse_aweme_video_web"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/tiktok.py",
+          "TikTokBaseIE",
+          "_parse_aweme_video_app"
+        ],
+        [
+          "yt_dlp/extractor/tiktok.py",
+          "TikTokBaseIE",
+          "_parse_aweme_video_web"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10246,
+      "arms": {
+        "for": {
+          "file_first": 48,
+          "file_worst": 48,
+          "all_file_worst": 48,
+          "func_first": null,
+          "wall_median": 0.154,
+          "wall_p95": 0.154,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68324
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11644",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/dacast.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/dacast.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/dacast.py",
+          "DacastVODIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "yt_dlp/extractor/dacast.py",
+          "DacastVODIE",
+          "_usp_signing_secret"
+        ]
+      ],
+      "covered": [
+        [
+          "yt_dlp/extractor/dacast.py",
+          "DacastVODIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10246,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1557,
+          "wall_p95": 0.1557,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68166
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11636",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/dropbox.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/dropbox.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/dropbox.py",
+          "DropboxIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/dropbox.py",
+          "DropboxIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10246,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1572,
+          "wall_p95": 0.1572,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4369,
+          "output_tokens_ceiling": 1852,
+          "candidate_bytes": 68439
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11624",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/chaturbate.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/chaturbate.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/chaturbate.py",
+          "ChaturbateIE",
+          "_extract_from_api"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/chaturbate.py",
+          "ChaturbateIE",
+          "_extract_from_api"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10246,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1557,
+          "wall_p95": 0.1557,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4360,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 69270
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11615",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/youtube.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeTabBaseInfoExtractor",
+          "_grid_entries"
+        ],
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeTabBaseInfoExtractor",
+          "_rich_entries"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeTabBaseInfoExtractor",
+          "_extract_lockup_view_model"
+        ]
+      ],
+      "covered": [
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeTabBaseInfoExtractor",
+          "_grid_entries"
+        ],
+        [
+          "yt_dlp/extractor/youtube.py",
+          "YoutubeTabBaseInfoExtractor",
+          "_rich_entries"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10245,
+      "arms": {
+        "for": {
+          "file_first": 8,
+          "file_worst": 8,
+          "all_file_worst": 8,
+          "func_first": null,
+          "wall_median": 0.1568,
+          "wall_p95": 0.1568,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68623
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11596",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/stripchat.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/stripchat.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/stripchat.py",
+          "StripchatIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/stripchat.py",
+          "StripchatIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10245,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1555,
+          "wall_p95": 0.1555,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4369,
+          "output_tokens_ceiling": 1852,
+          "candidate_bytes": 68212
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11555",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/chaturbate.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/chaturbate.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/chaturbate.py",
+          "ChaturbateIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "yt_dlp/extractor/chaturbate.py",
+          "ChaturbateIE",
+          "_extract_from_api"
+        ],
+        [
+          "yt_dlp/extractor/chaturbate.py",
+          "ChaturbateIE",
+          "_extract_from_webpage"
+        ]
+      ],
+      "covered": [
+        [
+          "yt_dlp/extractor/chaturbate.py",
+          "ChaturbateIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1179,
+      "n_syms": 10239,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1562,
+          "wall_p95": 0.1562,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4360,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68932
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11542",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/spankbang.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/spankbang.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/spankbang.py",
+          "SpankBangIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/spankbang.py",
+          "SpankBangIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1179,
+      "n_syms": 10239,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1563,
+          "wall_p95": 0.1563,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4364,
+          "output_tokens_ceiling": 1850,
+          "candidate_bytes": 68173
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11534",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/ctvnews.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/ctvnews.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/ctvnews.py",
+          "CTVNewsIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "yt_dlp/extractor/ctvnews.py",
+          "CTVNewsIE",
+          "_ninecninemedia_url_result"
+        ]
+      ],
+      "covered": [
+        [
+          "yt_dlp/extractor/ctvnews.py",
+          "CTVNewsIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1180,
+      "n_syms": 10236,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1564,
+          "wall_p95": 0.1564,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68411
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11530",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/patreon.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/patreon.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/patreon.py",
+          "PatreonIE",
+          "_get_comments"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/patreon.py",
+          "PatreonIE",
+          "_get_comments"
+        ]
+      ],
+      "n_files": 1179,
+      "n_syms": 10239,
+      "arms": {
+        "for": {
+          "file_first": 42,
+          "file_worst": 42,
+          "all_file_worst": 42,
+          "func_first": null,
+          "wall_median": 0.1584,
+          "wall_p95": 0.1584,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4358,
+          "output_tokens_ceiling": 1847,
+          "candidate_bytes": 68032
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11527",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/archiveorg.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/archiveorg.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/archiveorg.py",
+          "ArchiveOrgIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/archiveorg.py",
+          "ArchiveOrgIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1179,
+      "n_syms": 10239,
+      "arms": {
+        "for": {
+          "file_first": 60,
+          "file_worst": 60,
+          "all_file_worst": 60,
+          "func_first": null,
+          "wall_median": 0.1586,
+          "wall_p95": 0.1586,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4364,
+          "output_tokens_ceiling": 1850,
+          "candidate_bytes": 68589
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11513",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/facebook.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/facebook.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/facebook.py",
+          "FacebookIE",
+          "_extract_from_url"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/facebook.py",
+          "FacebookIE",
+          "_extract_from_url"
+        ]
+      ],
+      "n_files": 1179,
+      "n_syms": 10239,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1571,
+          "wall_p95": 0.1571,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4362,
+          "output_tokens_ceiling": 1849,
+          "candidate_bytes": 68143
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11478",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/cloudflarestream.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/cloudflarestream.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/cloudflarestream.py",
+          "CloudflareStreamIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/cloudflarestream.py",
+          "CloudflareStreamIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1179,
+      "n_syms": 10240,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1554,
+          "wall_p95": 0.1554,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4369,
+          "output_tokens_ceiling": 1852,
+          "candidate_bytes": 68158
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11472",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/adobepass.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/adobepass.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/adobepass.py",
+          "AdobePassIE",
+          "_download_webpage_handle"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yt_dlp/extractor/adobepass.py",
+          "AdobePassIE",
+          "_download_webpage_handle"
+        ]
+      ],
+      "n_files": 1178,
+      "n_syms": 10235,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1558,
+          "wall_p95": 0.1558,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4369,
+          "output_tokens_ceiling": 1852,
+          "candidate_bytes": 68396
+        }
+      }
+    },
+    {
+      "instance_id": "yt-dlp__yt-dlp-11466",
+      "partition": "train",
+      "repo": "yt-dlp/yt-dlp",
+      "gold_files": [
+        "yt_dlp/extractor/goplay.py"
+      ],
+      "primary_files": [
+        "yt_dlp/extractor/goplay.py"
+      ],
+      "gold_funcs": [
+        [
+          "yt_dlp/extractor/goplay.py",
+          "GoPlayIE",
+          "_real_extract"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "yt_dlp/extractor/goplay.py",
+          "GoPlayIE",
+          "_find_json"
+        ]
+      ],
+      "covered": [
+        [
+          "yt_dlp/extractor/goplay.py",
+          "GoPlayIE",
+          "_real_extract"
+        ]
+      ],
+      "n_files": 1178,
+      "n_syms": 10235,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1585,
+          "wall_p95": 0.1585,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4359,
+          "output_tokens_ceiling": 1848,
+          "candidate_bytes": 68368
+        }
+      }
+    },
+    {
+      "instance_id": "gaogaotiantian__viztracer-528",
+      "partition": "train",
+      "repo": "gaogaotiantian/viztracer",
+      "gold_files": [
+        "src/viztracer/main.py"
+      ],
+      "primary_files": [
+        "src/viztracer/main.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/viztracer/main.py",
+          "VizUI",
+          "exit_routine"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/viztracer/main.py",
+          "VizUI",
+          "exit_routine"
+        ]
+      ],
+      "n_files": 111,
+      "n_syms": 11213,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": null,
+          "wall_median": 0.0765,
+          "wall_p95": 0.0765,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5161,
+          "output_tokens_ceiling": 2187,
+          "candidate_bytes": 60677
+        }
+      }
+    },
+    {
+      "instance_id": "locustio__locust-2976",
+      "partition": "train",
+      "repo": "locustio/locust",
+      "gold_files": [
+        "locust/runners.py"
+      ],
+      "primary_files": [
+        "locust/runners.py"
+      ],
+      "gold_funcs": [
+        [
+          "locust/runners.py",
+          "MasterRunner",
+          "client_listener"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "locust/runners.py",
+          "MasterRunner",
+          "client_listener"
+        ]
+      ],
+      "n_files": 241,
+      "n_syms": 3497,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.0515,
+          "wall_p95": 0.0515,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5096,
+          "output_tokens_ceiling": 2160,
+          "candidate_bytes": 66338
+        }
+      }
+    },
+    {
+      "instance_id": "ranaroussi__yfinance-2173",
+      "partition": "train",
+      "repo": "ranaroussi/yfinance",
+      "gold_files": [
+        "yfinance/base.py"
+      ],
+      "primary_files": [
+        "yfinance/base.py"
+      ],
+      "gold_funcs": [
+        [
+          "yfinance/base.py",
+          "TickerBase",
+          "get_news"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yfinance/base.py",
+          "TickerBase",
+          "get_news"
+        ]
+      ],
+      "n_files": 131,
+      "n_syms": 893,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 2,
+          "wall_median": 0.0384,
+          "wall_p95": 0.0384,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7234,
+          "output_tokens_ceiling": 3066,
+          "candidate_bytes": 71584
+        }
+      }
+    },
+    {
+      "instance_id": "ranaroussi__yfinance-2122",
+      "partition": "train",
+      "repo": "ranaroussi/yfinance",
+      "gold_files": [
+        "yfinance/utils.py"
+      ],
+      "primary_files": [
+        "yfinance/utils.py"
+      ],
+      "gold_funcs": [
+        [
+          "yfinance/utils.py",
+          "",
+          "fix_Yahoo_returning_live_separate"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "yfinance/utils.py",
+          "",
+          "fix_Yahoo_returning_live_separate"
+        ]
+      ],
+      "n_files": 119,
+      "n_syms": 852,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 26,
+          "wall_median": 0.0388,
+          "wall_p95": 0.0388,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6782,
+          "output_tokens_ceiling": 2874,
+          "candidate_bytes": 74933
+        }
+      }
+    },
+    {
+      "instance_id": "scipy__scipy-22106",
+      "partition": "train",
+      "repo": "scipy/scipy",
+      "gold_files": [
+        "scipy/sparse/_construct.py"
+      ],
+      "primary_files": [
+        "scipy/sparse/_construct.py"
+      ],
+      "gold_funcs": [
+        [
+          "scipy/sparse/_construct.py",
+          "",
+          "eye_array"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "scipy/sparse/_construct.py",
+          "",
+          "eye_array"
+        ]
+      ],
+      "n_files": 1606,
+      "n_syms": 38641,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3404,
+          "wall_p95": 0.3404,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3766,
+          "output_tokens_ceiling": 1596,
+          "candidate_bytes": 57672
+        }
+      }
+    },
+    {
+      "instance_id": "scipy__scipy-22103",
+      "partition": "train",
+      "repo": "scipy/scipy",
+      "gold_files": [
+        "scipy/stats/_stats_py.py"
+      ],
+      "primary_files": [
+        "scipy/stats/_stats_py.py"
+      ],
+      "gold_funcs": [
+        [
+          "scipy/stats/_stats_py.py",
+          "",
+          "pearsonr"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "scipy/stats/_stats_py.py",
+          "",
+          "pearsonr"
+        ]
+      ],
+      "n_files": 1606,
+      "n_syms": 38641,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 1,
+          "wall_median": 0.3429,
+          "wall_p95": 0.3429,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6406,
+          "output_tokens_ceiling": 2715,
+          "candidate_bytes": 58988
+        }
+      }
+    },
+    {
+      "instance_id": "scipy__scipy-22052",
+      "partition": "train",
+      "repo": "scipy/scipy",
+      "gold_files": [
+        "scipy/sparse/linalg/_dsolve/linsolve.py"
+      ],
+      "primary_files": [
+        "scipy/sparse/linalg/_dsolve/linsolve.py"
+      ],
+      "gold_funcs": [
+        [
+          "scipy/sparse/linalg/_dsolve/linsolve.py",
+          "",
+          "splu"
+        ],
+        [
+          "scipy/sparse/linalg/_dsolve/linsolve.py",
+          "",
+          "spilu"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "scipy/sparse/linalg/_dsolve/linsolve.py",
+          "",
+          "splu"
+        ],
+        [
+          "scipy/sparse/linalg/_dsolve/linsolve.py",
+          "",
+          "spilu"
+        ]
+      ],
+      "n_files": 1603,
+      "n_syms": 38552,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 6,
+          "wall_median": 0.3379,
+          "wall_p95": 0.3379,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4731,
+          "output_tokens_ceiling": 2005,
+          "candidate_bytes": 58886
+        }
+      }
+    },
+    {
+      "instance_id": "certbot__certbot-10043",
+      "partition": "train",
+      "repo": "certbot/certbot",
+      "gold_files": [
+        "tools/finish_release.py"
+      ],
+      "primary_files": [
+        "tools/finish_release.py"
+      ],
+      "gold_funcs": [
+        [
+          "tools/finish_release.py",
+          "",
+          "get_snap_revisions"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "tools/finish_release.py",
+          "",
+          "get_snap_revisions"
+        ]
+      ],
+      "n_files": 351,
+      "n_syms": 7437,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 2,
+          "wall_median": 0.0737,
+          "wall_p95": 0.0737,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2532,
+          "output_tokens_ceiling": 1073,
+          "candidate_bytes": 63966
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-25487",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/random.py"
+      ],
+      "primary_files": [
+        "jax/_src/random.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/random.py",
+          "",
+          "_key_impl"
+        ],
+        [
+          "jax/_src/random.py",
+          "",
+          "key_impl"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "jax/_src/random.py",
+          "",
+          "_key_spec"
+        ]
+      ],
+      "covered": [
+        [
+          "jax/_src/random.py",
+          "",
+          "_key_impl"
+        ],
+        [
+          "jax/_src/random.py",
+          "",
+          "key_impl"
+        ]
+      ],
+      "n_files": 881,
+      "n_syms": 32980,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": null,
+          "wall_median": 0.3148,
+          "wall_p95": 0.3148,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3886,
+          "output_tokens_ceiling": 1647,
+          "candidate_bytes": 65812
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-24733",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/numpy/reductions.py"
+      ],
+      "primary_files": [
+        "jax/_src/numpy/reductions.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/numpy/reductions.py",
+          "",
+          "_quantile"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/numpy/reductions.py",
+          "",
+          "_quantile"
+        ]
+      ],
+      "n_files": 850,
+      "n_syms": 32035,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 6,
+          "wall_median": 0.3016,
+          "wall_p95": 0.3016,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7368,
+          "output_tokens_ceiling": 3123,
+          "candidate_bytes": 67075
+        }
+      }
+    },
+    {
+      "instance_id": "jax-ml__jax-24717",
+      "partition": "train",
+      "repo": "jax-ml/jax",
+      "gold_files": [
+        "jax/_src/scipy/stats/_core.py"
+      ],
+      "primary_files": [
+        "jax/_src/scipy/stats/_core.py"
+      ],
+      "gold_funcs": [
+        [
+          "jax/_src/scipy/stats/_core.py",
+          "",
+          "rankdata"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "jax/_src/scipy/stats/_core.py",
+          "",
+          "rankdata"
+        ]
+      ],
+      "n_files": 850,
+      "n_syms": 32005,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3077,
+          "wall_p95": 0.3077,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 7817,
+          "output_tokens_ceiling": 3313,
+          "candidate_bytes": 61428
+        }
+      }
+    },
+    {
+      "instance_id": "phidatahq__phidata-1589",
+      "partition": "train",
+      "repo": "phidatahq/phidata",
+      "gold_files": [
+        "phi/document/chunking/recursive.py"
+      ],
+      "primary_files": [
+        "phi/document/chunking/recursive.py"
+      ],
+      "gold_funcs": [
+        [
+          "phi/document/chunking/recursive.py",
+          "RecursiveChunking",
+          "chunk"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "phi/document/chunking/recursive.py",
+          "RecursiveChunking",
+          "chunk"
+        ]
+      ],
+      "n_files": 1165,
+      "n_syms": 7914,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": null,
+          "wall_median": 0.0854,
+          "wall_p95": 0.0854,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2506,
+          "output_tokens_ceiling": 1062,
+          "candidate_bytes": 76616
+        }
+      }
+    },
+    {
+      "instance_id": "phidatahq__phidata-1583",
+      "partition": "train",
+      "repo": "phidatahq/phidata",
+      "gold_files": [
+        "phi/memory/agent.py"
+      ],
+      "primary_files": [
+        "phi/memory/agent.py"
+      ],
+      "gold_funcs": [
+        [
+          "phi/memory/agent.py",
+          "AgentMemory",
+          "deep_copy"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "phi/memory/agent.py",
+          "AgentMemory",
+          "deep_copy"
+        ]
+      ],
+      "n_files": 1165,
+      "n_syms": 7913,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 7,
+          "wall_median": 0.088,
+          "wall_p95": 0.088,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4568,
+          "output_tokens_ceiling": 1936,
+          "candidate_bytes": 78812
+        }
+      }
+    },
+    {
+      "instance_id": "phidatahq__phidata-1582",
+      "partition": "train",
+      "repo": "phidatahq/phidata",
+      "gold_files": [
+        "phi/tools/function.py"
+      ],
+      "primary_files": [
+        "phi/tools/function.py"
+      ],
+      "gold_funcs": [
+        [
+          "phi/tools/function.py",
+          "Function",
+          "process_entrypoint"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "phi/tools/function.py",
+          "Function",
+          "process_entrypoint"
+        ]
+      ],
+      "n_files": 1165,
+      "n_syms": 7913,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.0881,
+          "wall_p95": 0.0881,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4346,
+          "output_tokens_ceiling": 1842,
+          "candidate_bytes": 80561
+        }
+      }
+    },
+    {
+      "instance_id": "phidatahq__phidata-1563",
+      "partition": "train",
+      "repo": "phidatahq/phidata",
+      "gold_files": [
+        "phi/tools/crawl4ai_tools.py"
+      ],
+      "primary_files": [
+        "phi/tools/crawl4ai_tools.py"
+      ],
+      "gold_funcs": [
+        [
+          "phi/tools/crawl4ai_tools.py",
+          "Crawl4aiTools",
+          "web_crawler"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "phi/tools/crawl4ai_tools.py",
+          "Crawl4aiTools",
+          "_async_web_crawler"
+        ]
+      ],
+      "covered": [
+        [
+          "phi/tools/crawl4ai_tools.py",
+          "Crawl4aiTools",
+          "web_crawler"
+        ]
+      ],
+      "n_files": 1157,
+      "n_syms": 7894,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 49,
+          "wall_median": 0.0877,
+          "wall_p95": 0.0877,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4020,
+          "output_tokens_ceiling": 1704,
+          "candidate_bytes": 76549
+        }
+      }
+    },
+    {
+      "instance_id": "phidatahq__phidata-1562",
+      "partition": "train",
+      "repo": "phidatahq/phidata",
+      "gold_files": [
+        "phi/model/google/gemini.py"
+      ],
+      "primary_files": [
+        "phi/model/google/gemini.py"
+      ],
+      "gold_funcs": [
+        [
+          "phi/model/google/gemini.py",
+          "Gemini",
+          "add_tool"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "phi/model/google/gemini.py",
+          "Gemini",
+          "_build_function_declaration"
+        ]
+      ],
+      "covered": [
+        [
+          "phi/model/google/gemini.py",
+          "Gemini",
+          "add_tool"
+        ]
+      ],
+      "n_files": 1157,
+      "n_syms": 7893,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 1,
+          "wall_median": 0.0884,
+          "wall_p95": 0.0884,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4589,
+          "output_tokens_ceiling": 1945,
+          "candidate_bytes": 78046
+        }
+      }
+    },
+    {
+      "instance_id": "nltk__nltk-3335",
+      "partition": "train",
+      "repo": "nltk/nltk",
+      "gold_files": [
+        "nltk/app/wordnet_app.py"
+      ],
+      "primary_files": [
+        "nltk/app/wordnet_app.py"
+      ],
+      "gold_funcs": [
+        [
+          "nltk/app/wordnet_app.py",
+          "",
+          "get_relations_data"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "nltk/app/wordnet_app.py",
+          "",
+          "get_relations_data"
+        ]
+      ],
+      "n_files": 355,
+      "n_syms": 7707,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 2,
+          "wall_median": 0.0805,
+          "wall_p95": 0.0805,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5223,
+          "output_tokens_ceiling": 2214,
+          "candidate_bytes": 64933
+        }
+      }
+    },
+    {
+      "instance_id": "kedro-org__kedro-4299",
+      "partition": "train",
+      "repo": "kedro-org/kedro",
+      "gold_files": [
+        "kedro/framework/cli/cli.py"
+      ],
+      "primary_files": [
+        "kedro/framework/cli/cli.py"
+      ],
+      "gold_funcs": [
+        [
+          "kedro/framework/cli/cli.py",
+          "KedroCLI",
+          "global_groups"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "kedro/framework/cli/cli.py",
+          "KedroCLI",
+          "global_groups"
+        ]
+      ],
+      "n_files": 335,
+      "n_syms": 4712,
+      "arms": {
+        "for": {
+          "file_first": 14,
+          "file_worst": 14,
+          "all_file_worst": 14,
+          "func_first": null,
+          "wall_median": 0.0568,
+          "wall_p95": 0.0568,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 1918,
+          "output_tokens_ceiling": 813,
+          "candidate_bytes": 70594
+        }
+      }
+    },
+    {
+      "instance_id": "albumentations-team__albumentations-2183",
+      "partition": "train",
+      "repo": "albumentations-team/albumentations",
+      "gold_files": [
+        "albumentations/augmentations/functional.py"
+      ],
+      "primary_files": [
+        "albumentations/augmentations/functional.py"
+      ],
+      "gold_funcs": [
+        [
+          "albumentations/augmentations/functional.py",
+          "",
+          "add_sun_flare_overlay"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "albumentations/augmentations/functional.py",
+          "",
+          "add_sun_flare_overlay"
+        ]
+      ],
+      "n_files": 95,
+      "n_syms": 2882,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.0468,
+          "wall_p95": 0.0468,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3424,
+          "output_tokens_ceiling": 1451,
+          "candidate_bytes": 86418
+        }
+      }
+    },
+    {
+      "instance_id": "bridgecrewio__checkov-6826",
+      "partition": "train",
+      "repo": "bridgecrewio/checkov",
+      "gold_files": [
+        "checkov/terraform/checks/resource/aws/EKSPlatformVersion.py"
+      ],
+      "primary_files": [
+        "checkov/terraform/checks/resource/aws/EKSPlatformVersion.py"
+      ],
+      "gold_funcs": [
+        [
+          "checkov/terraform/checks/resource/aws/EKSPlatformVersion.py",
+          "EKSPlatformVersion",
+          "get_expected_values"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "checkov/terraform/checks/resource/aws/EKSPlatformVersion.py",
+          "EKSPlatformVersion",
+          "get_expected_values"
+        ]
+      ],
+      "n_files": 7158,
+      "n_syms": 49496,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": null,
+          "wall_median": 0.4022,
+          "wall_p95": 0.4022,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3178,
+          "output_tokens_ceiling": 1347,
+          "candidate_bytes": 91994
+        }
+      }
+    },
+    {
+      "instance_id": "spotify__luigi-3324",
+      "partition": "train",
+      "repo": "spotify/luigi",
+      "gold_files": [
+        "luigi/contrib/postgres.py"
+      ],
+      "primary_files": [
+        "luigi/contrib/postgres.py"
+      ],
+      "gold_funcs": [
+        [
+          "luigi/contrib/postgres.py",
+          "CopyToTable",
+          "copy"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "luigi/contrib/postgres.py",
+          "CopyToTable",
+          "copy"
+        ]
+      ],
+      "n_files": 272,
+      "n_syms": 7150,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": null,
+          "wall_median": 0.0693,
+          "wall_p95": 0.0693,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4025,
+          "output_tokens_ceiling": 1706,
+          "candidate_bytes": 67521
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-49071",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "rllib/examples/rl_modules/classes/action_masking_rlm.py"
+      ],
+      "primary_files": [
+        "rllib/examples/rl_modules/classes/action_masking_rlm.py"
+      ],
+      "gold_funcs": [
+        [
+          "rllib/examples/rl_modules/classes/action_masking_rlm.py",
+          "ActionMaskingRLModule",
+          "__init__"
+        ],
+        [
+          "rllib/examples/rl_modules/classes/action_masking_rlm.py",
+          "ActionMaskingTorchRLModule",
+          "compute_values"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "rllib/examples/rl_modules/classes/action_masking_rlm.py",
+          "ActionMaskingRLModule",
+          "__init__"
+        ],
+        [
+          "rllib/examples/rl_modules/classes/action_masking_rlm.py",
+          "ActionMaskingTorchRLModule",
+          "compute_values"
+        ]
+      ],
+      "n_files": 5343,
+      "n_syms": 86587,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 71,
+          "wall_median": 0.6319,
+          "wall_p95": 0.6319,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4703,
+          "output_tokens_ceiling": 1993,
+          "candidate_bytes": 85200
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48891",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/scripts/scripts.py"
+      ],
+      "primary_files": [
+        "python/ray/scripts/scripts.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/scripts/scripts.py",
+          "",
+          "start"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/scripts/scripts.py",
+          "",
+          "start"
+        ]
+      ],
+      "n_files": 5318,
+      "n_syms": 86516,
+      "arms": {
+        "for": {
+          "file_first": 9,
+          "file_worst": 9,
+          "all_file_worst": 9,
+          "func_first": 14,
+          "wall_median": 0.6409,
+          "wall_p95": 0.6409,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6229,
+          "output_tokens_ceiling": 2640,
+          "candidate_bytes": 78094
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48793",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/setup-dev.py"
+      ],
+      "primary_files": [
+        "python/ray/setup-dev.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/setup-dev.py",
+          "",
+          "do_link"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/setup-dev.py",
+          "",
+          "do_link"
+        ]
+      ],
+      "n_files": 5317,
+      "n_syms": 86505,
+      "arms": {
+        "for": {
+          "file_first": 8,
+          "file_worst": 8,
+          "all_file_worst": 8,
+          "func_first": 16,
+          "wall_median": 0.6286,
+          "wall_p95": 0.6286,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2851,
+          "output_tokens_ceiling": 1209,
+          "candidate_bytes": 72327
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48790",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/serve/api.py"
+      ],
+      "primary_files": [
+        "python/ray/serve/api.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/serve/api.py",
+          "",
+          "_run"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/serve/api.py",
+          "",
+          "_run"
+        ]
+      ],
+      "n_files": 5313,
+      "n_syms": 86484,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": 2,
+          "wall_median": 0.6307,
+          "wall_p95": 0.6307,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4047,
+          "output_tokens_ceiling": 1715,
+          "candidate_bytes": 76106
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48786",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/autoscaler/_private/commands.py"
+      ],
+      "primary_files": [
+        "python/ray/autoscaler/_private/commands.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/autoscaler/_private/commands.py",
+          "",
+          "exec_cluster"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/autoscaler/_private/commands.py",
+          "",
+          "exec_cluster"
+        ]
+      ],
+      "n_files": 5318,
+      "n_syms": 86517,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.6393,
+          "wall_p95": 0.6393,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4370,
+          "output_tokens_ceiling": 1852,
+          "candidate_bytes": 78614
+        }
+      }
+    },
+    {
+      "instance_id": "ray-project__ray-48756",
+      "partition": "train",
+      "repo": "ray-project/ray",
+      "gold_files": [
+        "python/ray/dashboard/modules/metrics/install_and_start_prometheus.py"
+      ],
+      "primary_files": [
+        "python/ray/dashboard/modules/metrics/install_and_start_prometheus.py"
+      ],
+      "gold_funcs": [
+        [
+          "python/ray/dashboard/modules/metrics/install_and_start_prometheus.py",
+          "",
+          "get_system_info"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "python/ray/dashboard/modules/metrics/install_and_start_prometheus.py",
+          "",
+          "get_system_info"
+        ]
+      ],
+      "n_files": 5313,
+      "n_syms": 86484,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 24,
+          "wall_median": 0.6331,
+          "wall_p95": 0.6331,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3335,
+          "output_tokens_ceiling": 1414,
+          "candidate_bytes": 77529
+        }
+      }
+    },
+    {
+      "instance_id": "optuna__optuna-5828",
+      "partition": "train",
+      "repo": "optuna/optuna",
+      "gold_files": [
+        "optuna/cli.py"
+      ],
+      "primary_files": [
+        "optuna/cli.py"
+      ],
+      "gold_funcs": [
+        [
+          "optuna/cli.py",
+          "",
+          "_dump_table"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "optuna/cli.py",
+          "",
+          "_dump_table"
+        ]
+      ],
+      "n_files": 369,
+      "n_syms": 3973,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 92,
+          "wall_median": 0.0656,
+          "wall_p95": 0.0656,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5297,
+          "output_tokens_ceiling": 2245,
+          "candidate_bytes": 73156
+        }
+      }
+    },
+    {
+      "instance_id": "matplotlib__matplotlib-29265",
+      "partition": "train",
+      "repo": "matplotlib/matplotlib",
+      "gold_files": [
+        "lib/matplotlib/collections.py"
+      ],
+      "primary_files": [
+        "lib/matplotlib/collections.py"
+      ],
+      "gold_funcs": [
+        [
+          "lib/matplotlib/collections.py",
+          "LineCollection",
+          "__init__"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "lib/matplotlib/collections.py",
+          "LineCollection",
+          "__init__"
+        ]
+      ],
+      "n_files": 1240,
+      "n_syms": 31336,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3767,
+          "wall_p95": 0.3767,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5605,
+          "output_tokens_ceiling": 2375,
+          "candidate_bytes": 74508
+        }
+      }
+    },
+    {
+      "instance_id": "matplotlib__matplotlib-29254",
+      "partition": "train",
+      "repo": "matplotlib/matplotlib",
+      "gold_files": [
+        "lib/matplotlib/figure.py"
+      ],
+      "primary_files": [
+        "lib/matplotlib/figure.py"
+      ],
+      "gold_funcs": [
+        [
+          "lib/matplotlib/figure.py",
+          "FigureBase",
+          "align_xlabels"
+        ],
+        [
+          "lib/matplotlib/figure.py",
+          "FigureBase",
+          "align_ylabels"
+        ],
+        [
+          "lib/matplotlib/figure.py",
+          "FigureBase",
+          "align_titles"
+        ],
+        [
+          "lib/matplotlib/figure.py",
+          "FigureBase",
+          "align_labels"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "lib/matplotlib/figure.py",
+          "FigureBase",
+          "align_xlabels"
+        ],
+        [
+          "lib/matplotlib/figure.py",
+          "FigureBase",
+          "align_ylabels"
+        ],
+        [
+          "lib/matplotlib/figure.py",
+          "FigureBase",
+          "align_titles"
+        ],
+        [
+          "lib/matplotlib/figure.py",
+          "FigureBase",
+          "align_labels"
+        ]
+      ],
+      "n_files": 1240,
+      "n_syms": 31342,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.3811,
+          "wall_p95": 0.3811,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4800,
+          "output_tokens_ceiling": 2034,
+          "candidate_bytes": 68378
+        }
+      }
+    },
+    {
+      "instance_id": "matplotlib__matplotlib-29236",
+      "partition": "train",
+      "repo": "matplotlib/matplotlib",
+      "gold_files": [
+        "lib/matplotlib/animation.py"
+      ],
+      "primary_files": [
+        "lib/matplotlib/animation.py"
+      ],
+      "gold_funcs": [
+        [
+          "lib/matplotlib/animation.py",
+          "PillowWriter",
+          "grab_frame"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "lib/matplotlib/animation.py",
+          "PillowWriter",
+          "grab_frame"
+        ]
+      ],
+      "n_files": 1239,
+      "n_syms": 31306,
+      "arms": {
+        "for": {
+          "file_first": 9,
+          "file_worst": 9,
+          "all_file_worst": 9,
+          "func_first": null,
+          "wall_median": 0.3824,
+          "wall_p95": 0.3824,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4213,
+          "output_tokens_ceiling": 1786,
+          "candidate_bytes": 71051
+        }
+      }
+    },
+    {
+      "instance_id": "flet-dev__flet-4554",
+      "partition": "train",
+      "repo": "flet-dev/flet",
+      "gold_files": [
+        "sdk/python/packages/flet-cli/src/flet_cli/utils/project_dependencies.py"
+      ],
+      "primary_files": [
+        "sdk/python/packages/flet-cli/src/flet_cli/utils/project_dependencies.py"
+      ],
+      "gold_funcs": [
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/utils/project_dependencies.py",
+          "",
+          "get_poetry_dependencies"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/utils/project_dependencies.py",
+          "",
+          "get_poetry_dependencies"
+        ]
+      ],
+      "n_files": 434,
+      "n_syms": 30775,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 9,
+          "wall_median": 0.0865,
+          "wall_p95": 0.0865,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 6470,
+          "output_tokens_ceiling": 2742,
+          "candidate_bytes": 74816
+        }
+      }
+    },
+    {
+      "instance_id": "flet-dev__flet-4452",
+      "partition": "train",
+      "repo": "flet-dev/flet",
+      "gold_files": [
+        "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py"
+      ],
+      "primary_files": [
+        "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py"
+      ],
+      "gold_funcs": [
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "package_python_app"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "package_python_app"
+        ]
+      ],
+      "n_files": 434,
+      "n_syms": 30753,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": null,
+          "wall_median": 0.0854,
+          "wall_p95": 0.0854,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4696,
+          "output_tokens_ceiling": 1990,
+          "candidate_bytes": 76872
+        }
+      }
+    },
+    {
+      "instance_id": "flet-dev__flet-4425",
+      "partition": "train",
+      "repo": "flet-dev/flet",
+      "gold_files": [
+        "sdk/python/packages/flet/src/flet/core/date_picker.py"
+      ],
+      "primary_files": [
+        "sdk/python/packages/flet/src/flet/core/date_picker.py"
+      ],
+      "gold_funcs": [
+        [
+          "sdk/python/packages/flet/src/flet/core/date_picker.py",
+          "DatePicker",
+          "before_update"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sdk/python/packages/flet/src/flet/core/date_picker.py",
+          "DatePicker",
+          "before_update"
+        ]
+      ],
+      "n_files": 435,
+      "n_syms": 30738,
+      "arms": {
+        "for": {
+          "file_first": 7,
+          "file_worst": 7,
+          "all_file_worst": 7,
+          "func_first": 16,
+          "wall_median": 0.1027,
+          "wall_p95": 0.1027,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3951,
+          "output_tokens_ceiling": 1675,
+          "candidate_bytes": 75650
+        }
+      }
+    },
+    {
+      "instance_id": "flet-dev__flet-4388",
+      "partition": "train",
+      "repo": "flet-dev/flet",
+      "gold_files": [
+        "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py"
+      ],
+      "primary_files": [
+        "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py"
+      ],
+      "gold_funcs": [
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "__init__"
+        ],
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "handle"
+        ],
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "add_arguments"
+        ],
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "cleanup"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "__init__"
+        ],
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "handle"
+        ],
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "add_arguments"
+        ],
+        [
+          "sdk/python/packages/flet-cli/src/flet_cli/commands/build.py",
+          "Command",
+          "cleanup"
+        ]
+      ],
+      "n_files": 427,
+      "n_syms": 30634,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.0879,
+          "wall_p95": 0.0879,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4371,
+          "output_tokens_ceiling": 1853,
+          "candidate_bytes": 73228
+        }
+      }
+    },
+    {
+      "instance_id": "flet-dev__flet-4384",
+      "partition": "train",
+      "repo": "flet-dev/flet",
+      "gold_files": [
+        "sdk/python/packages/flet/src/flet/core/icon.py"
+      ],
+      "primary_files": [
+        "sdk/python/packages/flet/src/flet/core/icon.py"
+      ],
+      "gold_funcs": [
+        [
+          "sdk/python/packages/flet/src/flet/core/icon.py",
+          "Icon",
+          "before_update"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sdk/python/packages/flet/src/flet/core/icon.py",
+          "Icon",
+          "before_update"
+        ]
+      ],
+      "n_files": 427,
+      "n_syms": 30634,
+      "arms": {
+        "for": {
+          "file_first": 8,
+          "file_worst": 8,
+          "all_file_worst": 8,
+          "func_first": null,
+          "wall_median": 0.1003,
+          "wall_p95": 0.1003,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3947,
+          "output_tokens_ceiling": 1673,
+          "candidate_bytes": 79586
+        }
+      }
+    },
+    {
+      "instance_id": "flet-dev__flet-4373",
+      "partition": "train",
+      "repo": "flet-dev/flet",
+      "gold_files": [
+        "sdk/python/packages/flet/src/flet/core/markdown.py"
+      ],
+      "primary_files": [
+        "sdk/python/packages/flet/src/flet/core/markdown.py"
+      ],
+      "gold_funcs": [
+        [
+          "sdk/python/packages/flet/src/flet/core/markdown.py",
+          "Markdown",
+          "before_update"
+        ],
+        [
+          "sdk/python/packages/flet/src/flet/core/markdown.py",
+          "Markdown",
+          "code_theme"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sdk/python/packages/flet/src/flet/core/markdown.py",
+          "Markdown",
+          "before_update"
+        ],
+        [
+          "sdk/python/packages/flet/src/flet/core/markdown.py",
+          "Markdown",
+          "code_theme"
+        ]
+      ],
+      "n_files": 427,
+      "n_syms": 30634,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.0863,
+          "wall_p95": 0.0863,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4494,
+          "output_tokens_ceiling": 1905,
+          "candidate_bytes": 76785
+        }
+      }
+    },
+    {
+      "instance_id": "flet-dev__flet-4340",
+      "partition": "train",
+      "repo": "flet-dev/flet",
+      "gold_files": [
+        "sdk/python/packages/flet/src/flet/core/colors.py"
+      ],
+      "primary_files": [
+        "sdk/python/packages/flet/src/flet/core/colors.py"
+      ],
+      "gold_funcs": [
+        [
+          "sdk/python/packages/flet/src/flet/core/colors.py",
+          "colors",
+          "with_opacity"
+        ],
+        [
+          "sdk/python/packages/flet/src/flet/core/colors.py",
+          "Colors",
+          "with_opacity"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sdk/python/packages/flet/src/flet/core/colors.py",
+          "colors",
+          "with_opacity"
+        ],
+        [
+          "sdk/python/packages/flet/src/flet/core/colors.py",
+          "Colors",
+          "with_opacity"
+        ]
+      ],
+      "n_files": 427,
+      "n_syms": 30586,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 8,
+          "wall_median": 0.086,
+          "wall_p95": 0.086,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4317,
+          "output_tokens_ceiling": 1830,
+          "candidate_bytes": 80682
+        }
+      }
+    },
+    {
+      "instance_id": "flet-dev__flet-4314",
+      "partition": "train",
+      "repo": "flet-dev/flet",
+      "gold_files": [
+        "sdk/python/packages/flet/src/flet/core/segmented_button.py"
+      ],
+      "primary_files": [
+        "sdk/python/packages/flet/src/flet/core/segmented_button.py"
+      ],
+      "gold_funcs": [
+        [
+          "sdk/python/packages/flet/src/flet/core/segmented_button.py",
+          "SegmentedButton",
+          "before_update"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "sdk/python/packages/flet/src/flet/core/segmented_button.py",
+          "SegmentedButton",
+          "before_update"
+        ]
+      ],
+      "n_files": 426,
+      "n_syms": 30515,
+      "arms": {
+        "for": {
+          "file_first": 18,
+          "file_worst": 18,
+          "all_file_worst": 18,
+          "func_first": 70,
+          "wall_median": 0.0864,
+          "wall_p95": 0.0864,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4304,
+          "output_tokens_ceiling": 1824,
+          "candidate_bytes": 82405
+        }
+      }
+    },
+    {
+      "instance_id": "explodinggradients__ragas-1627",
+      "partition": "train",
+      "repo": "explodinggradients/ragas",
+      "gold_files": [
+        "src/ragas/metrics/_noise_sensitivity.py"
+      ],
+      "primary_files": [
+        "src/ragas/metrics/_noise_sensitivity.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/ragas/metrics/_noise_sensitivity.py",
+          "NoiseSensitivity",
+          "_decompose_answer_into_statements"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/ragas/metrics/_noise_sensitivity.py",
+          "NoiseSensitivity",
+          "_decompose_answer_into_statements"
+        ]
+      ],
+      "n_files": 222,
+      "n_syms": 2131,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 2,
+          "wall_median": 0.043,
+          "wall_p95": 0.043,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4405,
+          "output_tokens_ceiling": 1867,
+          "candidate_bytes": 86494
+        }
+      }
+    },
+    {
+      "instance_id": "Lightning-AI__pytorch-lightning-20484",
+      "partition": "train",
+      "repo": "Lightning-AI/pytorch-lightning",
+      "gold_files": [
+        "src/lightning/pytorch/loops/prediction_loop.py"
+      ],
+      "primary_files": [
+        "src/lightning/pytorch/loops/prediction_loop.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/lightning/pytorch/loops/prediction_loop.py",
+          "_PredictionLoop",
+          "_predict_step"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "src/lightning/pytorch/loops/prediction_loop.py",
+          "_PredictionLoop",
+          "_predict_step"
+        ]
+      ],
+      "n_files": 654,
+      "n_syms": 11190,
+      "arms": {
+        "for": {
+          "file_first": 3,
+          "file_worst": 3,
+          "all_file_worst": 3,
+          "func_first": 5,
+          "wall_median": 0.1138,
+          "wall_p95": 0.1138,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4093,
+          "output_tokens_ceiling": 1735,
+          "candidate_bytes": 89443
+        }
+      }
+    },
+    {
+      "instance_id": "Lightning-AI__pytorch-lightning-20420",
+      "partition": "train",
+      "repo": "Lightning-AI/pytorch-lightning",
+      "gold_files": [
+        "examples/fabric/build_your_own_trainer/run.py"
+      ],
+      "primary_files": [
+        "examples/fabric/build_your_own_trainer/run.py"
+      ],
+      "gold_funcs": [
+        [
+          "examples/fabric/build_your_own_trainer/run.py",
+          "MNISTModule",
+          "configure_optimizers"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "examples/fabric/build_your_own_trainer/run.py",
+          "MNISTModule",
+          "configure_optimizers"
+        ]
+      ],
+      "n_files": 650,
+      "n_syms": 11143,
+      "arms": {
+        "for": {
+          "file_first": 4,
+          "file_worst": 4,
+          "all_file_worst": 4,
+          "func_first": 7,
+          "wall_median": 0.1133,
+          "wall_p95": 0.1133,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4366,
+          "output_tokens_ceiling": 1850,
+          "candidate_bytes": 90196
+        }
+      }
+    },
+    {
+      "instance_id": "Lightning-AI__pytorch-lightning-20401",
+      "partition": "train",
+      "repo": "Lightning-AI/pytorch-lightning",
+      "gold_files": [
+        "src/lightning/pytorch/cli.py"
+      ],
+      "primary_files": [
+        "src/lightning/pytorch/cli.py"
+      ],
+      "gold_funcs": [
+        [
+          "src/lightning/pytorch/cli.py",
+          "LightningCLI",
+          "__init__"
+        ]
+      ],
+      "added_funcs": [
+        [
+          "src/lightning/pytorch/cli.py",
+          "LightningCLI",
+          "after_instantiate_classes"
+        ]
+      ],
+      "covered": [
+        [
+          "src/lightning/pytorch/cli.py",
+          "LightningCLI",
+          "__init__"
+        ]
+      ],
+      "n_files": 650,
+      "n_syms": 11149,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.1122,
+          "wall_p95": 0.1122,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4226,
+          "output_tokens_ceiling": 1791,
+          "candidate_bytes": 89523
+        }
+      }
+    },
+    {
+      "instance_id": "wandb__wandb-9011",
+      "partition": "train",
+      "repo": "wandb/wandb",
+      "gold_files": [
+        "wandb/apis/public/runs.py"
+      ],
+      "primary_files": [
+        "wandb/apis/public/runs.py"
+      ],
+      "gold_funcs": [
+        [
+          "wandb/apis/public/runs.py",
+          "Runs",
+          "histories"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "wandb/apis/public/runs.py",
+          "Runs",
+          "histories"
+        ]
+      ],
+      "n_files": 1148,
+      "n_syms": 24986,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": 1,
+          "wall_median": 0.1511,
+          "wall_p95": 0.1511,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3373,
+          "output_tokens_ceiling": 1430,
+          "candidate_bytes": 65016
+        }
+      }
+    },
+    {
+      "instance_id": "wandb__wandb-8931",
+      "partition": "train",
+      "repo": "wandb/wandb",
+      "gold_files": [
+        "wandb/sdk/data_types/video.py"
+      ],
+      "primary_files": [
+        "wandb/sdk/data_types/video.py"
+      ],
+      "gold_funcs": [
+        [
+          "wandb/sdk/data_types/video.py",
+          "Video",
+          "encode"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "wandb/sdk/data_types/video.py",
+          "Video",
+          "encode"
+        ]
+      ],
+      "n_files": 1150,
+      "n_syms": 24950,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.1507,
+          "wall_p95": 0.1507,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2571,
+          "output_tokens_ceiling": 1090,
+          "candidate_bytes": 67922
+        }
+      }
+    },
+    {
+      "instance_id": "fortra__impacket-1860",
+      "partition": "train",
+      "repo": "fortra/impacket",
+      "gold_files": [
+        "impacket/examples/secretsdump.py"
+      ],
+      "primary_files": [
+        "impacket/examples/secretsdump.py"
+      ],
+      "gold_funcs": [
+        [
+          "impacket/examples/secretsdump.py",
+          "SAMHashes",
+          "dump"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "impacket/examples/secretsdump.py",
+          "SAMHashes",
+          "dump"
+        ]
+      ],
+      "n_files": 295,
+      "n_syms": 23149,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 0,
+          "wall_median": 0.1348,
+          "wall_p95": 0.1348,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4425,
+          "output_tokens_ceiling": 1875,
+          "candidate_bytes": 74929
+        }
+      }
+    },
+    {
+      "instance_id": "fortra__impacket-1858",
+      "partition": "train",
+      "repo": "fortra/impacket",
+      "gold_files": [
+        "impacket/dhcp.py"
+      ],
+      "primary_files": [
+        "impacket/dhcp.py"
+      ],
+      "gold_funcs": [
+        [
+          "impacket/dhcp.py",
+          "DhcpPacket",
+          "unpackOptions"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "impacket/dhcp.py",
+          "DhcpPacket",
+          "unpackOptions"
+        ]
+      ],
+      "n_files": 295,
+      "n_syms": 23148,
+      "arms": {
+        "for": {
+          "file_first": 1,
+          "file_worst": 1,
+          "all_file_worst": 1,
+          "func_first": null,
+          "wall_median": 0.122,
+          "wall_p95": 0.122,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4666,
+          "output_tokens_ceiling": 1978,
+          "candidate_bytes": 72122
+        }
+      }
+    },
+    {
+      "instance_id": "modin-project__modin-7400",
+      "partition": "train",
+      "repo": "modin-project/modin",
+      "gold_files": [
+        "modin/pandas/dataframe.py"
+      ],
+      "primary_files": [
+        "modin/pandas/dataframe.py"
+      ],
+      "gold_funcs": [
+        [
+          "modin/pandas/dataframe.py",
+          "DataFrame",
+          "squeeze"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "modin/pandas/dataframe.py",
+          "DataFrame",
+          "squeeze"
+        ]
+      ],
+      "n_files": 415,
+      "n_syms": 7958,
+      "arms": {
+        "for": {
+          "file_first": 2,
+          "file_worst": 2,
+          "all_file_worst": 2,
+          "func_first": null,
+          "wall_median": 0.0958,
+          "wall_p95": 0.0958,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3257,
+          "output_tokens_ceiling": 1381,
+          "candidate_bytes": 87748
+        }
+      }
+    },
+    {
+      "instance_id": "Qiskit__qiskit-13554",
+      "partition": "train",
+      "repo": "Qiskit/qiskit",
+      "gold_files": [
+        "qiskit/circuit/parameterexpression.py"
+      ],
+      "primary_files": [
+        "qiskit/circuit/parameterexpression.py"
+      ],
+      "gold_funcs": [
+        [
+          "qiskit/circuit/parameterexpression.py",
+          "ParameterExpression",
+          "_apply_operation"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "qiskit/circuit/parameterexpression.py",
+          "ParameterExpression",
+          "_apply_operation"
+        ]
+      ],
+      "n_files": 2847,
+      "n_syms": 24352,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 4,
+          "wall_median": 0.2519,
+          "wall_p95": 0.2519,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2162,
+          "output_tokens_ceiling": 917,
+          "candidate_bytes": 80609
+        }
+      }
+    },
+    {
+      "instance_id": "Qiskit__qiskit-13552",
+      "partition": "train",
+      "repo": "Qiskit/qiskit",
+      "gold_files": [
+        "qiskit/circuit/parameterexpression.py"
+      ],
+      "primary_files": [
+        "qiskit/circuit/parameterexpression.py"
+      ],
+      "gold_funcs": [
+        [
+          "qiskit/circuit/parameterexpression.py",
+          "ParameterExpression",
+          "_apply_operation"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "qiskit/circuit/parameterexpression.py",
+          "ParameterExpression",
+          "_apply_operation"
+        ]
+      ],
+      "n_files": 2928,
+      "n_syms": 24474,
+      "arms": {
+        "for": {
+          "file_first": 0,
+          "file_worst": 0,
+          "all_file_worst": 0,
+          "func_first": 4,
+          "wall_median": 0.2432,
+          "wall_p95": 0.2432,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 2162,
+          "output_tokens_ceiling": 917,
+          "candidate_bytes": 80616
+        }
+      }
+    },
+    {
+      "instance_id": "langchain-ai__langgraph-2735",
+      "partition": "train",
+      "repo": "langchain-ai/langgraph",
+      "gold_files": [
+        "libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py"
+      ],
+      "primary_files": [
+        "libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py"
+      ],
+      "gold_funcs": [
+        [
+          "libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py",
+          "",
+          "_msgpack_ext_hook"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py",
+          "",
+          "_msgpack_ext_hook"
+        ]
+      ],
+      "n_files": 529,
+      "n_syms": 6238,
+      "arms": {
+        "for": {
+          "file_first": 53,
+          "file_worst": 53,
+          "all_file_worst": 53,
+          "func_first": null,
+          "wall_median": 0.0693,
+          "wall_p95": 0.0693,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4348,
+          "output_tokens_ceiling": 1843,
+          "candidate_bytes": 89719
+        }
+      }
+    },
+    {
+      "instance_id": "langchain-ai__langgraph-2724",
+      "partition": "train",
+      "repo": "langchain-ai/langgraph",
+      "gold_files": [
+        "libs/langgraph/langgraph/prebuilt/tool_node.py"
+      ],
+      "primary_files": [
+        "libs/langgraph/langgraph/prebuilt/tool_node.py"
+      ],
+      "gold_funcs": [
+        [
+          "libs/langgraph/langgraph/prebuilt/tool_node.py",
+          "ToolNode",
+          "_run_one"
+        ],
+        [
+          "libs/langgraph/langgraph/prebuilt/tool_node.py",
+          "ToolNode",
+          "_arun_one"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "libs/langgraph/langgraph/prebuilt/tool_node.py",
+          "ToolNode",
+          "_run_one"
+        ],
+        [
+          "libs/langgraph/langgraph/prebuilt/tool_node.py",
+          "ToolNode",
+          "_arun_one"
+        ]
+      ],
+      "n_files": 526,
+      "n_syms": 6190,
+      "arms": {
+        "for": {
+          "file_first": 12,
+          "file_worst": 12,
+          "all_file_worst": 12,
+          "func_first": 99,
+          "wall_median": 0.0706,
+          "wall_p95": 0.0706,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 4695,
+          "output_tokens_ceiling": 1990,
+          "candidate_bytes": 93663
+        }
+      }
+    },
+    {
+      "instance_id": "langchain-ai__langgraph-2571",
+      "partition": "train",
+      "repo": "langchain-ai/langgraph",
+      "gold_files": [
+        "libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py"
+      ],
+      "primary_files": [
+        "libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py"
+      ],
+      "gold_funcs": [
+        [
+          "libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py",
+          "AsyncPostgresSaver",
+          "setup"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py",
+          "AsyncPostgresSaver",
+          "setup"
+        ]
+      ],
+      "n_files": 513,
+      "n_syms": 5860,
+      "arms": {
+        "for": {
+          "file_first": 6,
+          "file_worst": 6,
+          "all_file_worst": 6,
+          "func_first": 25,
+          "wall_median": 0.0659,
+          "wall_p95": 0.0659,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5127,
+          "output_tokens_ceiling": 2173,
+          "candidate_bytes": 90539
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-11275",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/executor/ray_gpu_executor.py"
+      ],
+      "primary_files": [
+        "vllm/executor/ray_gpu_executor.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/executor/ray_gpu_executor.py",
+          "RayGPUExecutor",
+          "_init_workers_ray"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/executor/ray_gpu_executor.py",
+          "RayGPUExecutor",
+          "_init_workers_ray"
+        ]
+      ],
+      "n_files": 1243,
+      "n_syms": 26571,
+      "arms": {
+        "for": {
+          "file_first": 7,
+          "file_worst": 7,
+          "all_file_worst": 7,
+          "func_first": 153,
+          "wall_median": 0.1895,
+          "wall_p95": 0.1895,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 3675,
+          "output_tokens_ceiling": 1558,
+          "candidate_bytes": 69339
+        }
+      }
+    },
+    {
+      "instance_id": "vllm-project__vllm-9617",
+      "partition": "train",
+      "repo": "vllm-project/vllm",
+      "gold_files": [
+        "vllm/engine/llm_engine.py"
+      ],
+      "primary_files": [
+        "vllm/engine/llm_engine.py"
+      ],
+      "gold_funcs": [
+        [
+          "vllm/engine/llm_engine.py",
+          "LLMEngine",
+          "_get_stats"
+        ]
+      ],
+      "added_funcs": [],
+      "covered": [
+        [
+          "vllm/engine/llm_engine.py",
+          "LLMEngine",
+          "_get_stats"
+        ]
+      ],
+      "n_files": 1064,
+      "n_syms": 23163,
+      "arms": {
+        "for": {
+          "file_first": null,
+          "file_worst": null,
+          "all_file_worst": null,
+          "func_first": null,
+          "wall_median": 0.1591,
+          "wall_p95": 0.1591,
+          "cold_wall": 0.0,
+          "index_wall": 0.0,
+          "output_bytes": 5776,
+          "output_tokens_ceiling": 2448,
+          "candidate_bytes": 84196
+        }
+      }
+    }
+  ]
+}

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -1182,18 +1182,67 @@ full one — "is gold inside the top-`maxLifted` of the candidate *ordering*" �
 train for free before a single cell runs, and whose 0/97 would have killed this round before the
 grid.
 
-Two shaped directions survive, each recorded here with its measured obstacle rather than as a plan:
-ordering the fired set by name-match specificity (matched-token IDF or name coverage) — but q07
-shows full-coverage favors generic short names like `View`; and **file-level evidence pooling**,
-which sidesteps per-symbol choice entirely and is the strongest hypothesis anyone has for the
-multi-file stratum. It has now been flagged as the leading candidate by three consecutive rounds and
-**remains UNSPENT — it is recorded as open headroom, not as scheduled work**, and no measurement in
-this document should be read as evidence for or against it.
+Two shaped directions survived this round's post-mortem: ordering the fired set by name-match
+specificity (matched-token IDF or name coverage) — but q07 shows full-coverage favors generic short
+names like `View`; and file-level evidence pooling. **CORRECTION (2026-08-11, same day this entry
+landed): the original text here called pooling "UNSPENT — open headroom". That was false when it was
+written.** Pooling had already been pre-registered, gridded, and **rejected on held-out at +0.00pp**
+five days earlier (2026-08-06, `bench/locbench/results/r5_pooling/gate_verdict.txt`), and its
+successor r6 (structural expansion) had already closed the stratum to ranking-side mechanisms the
+same evening (`r6_expansion/gate_verdict.txt`). Neither verdict had been carried into this document —
+this entry was written from the nameboost archive without checking whether its "surviving directions"
+had since been spent. Both rejections are now recorded in the two entries that follow.
 
 Evidence is archived, not deleted: branch `claude/loving-fermat-6e9614` (tip `ed952ed`) retains the
 pre-registration, the verdict table, the flip ledger, the two targeting-audit dumps, the per-cell
 train scores, the candidate header, and its red-first gate under
 `bench/locbench/results/r5_nameboost/`. None of it is on `main` and no default was flipped.
+
+**File-level evidence pooling does not lift the multi-file stratum — rejected on held-out at +0.00pp
+as a constrained mechanism (2026-08-06), and re-refuted as an unconstrained upper bound before it
+could be re-attempted (2026-08-11).** The constrained round (`bench/locbench/results/r5_pooling/`,
+registered 2026-08-06) implemented `poolScore(f) = Σ top-K symbol scores`, promote-only on the
+mention slot ladder, env-gated as `RIPWIRE_POOL` (scaffolding still on main in `src/filepool.h`,
+inert). Its identity control reproduced baseline exactly, two train cells advanced under its frozen
+rule, and the single permitted held-out run came back **+0.00pp on every stratum** — the entire train
+signal was ONE instance (`UXARRAY__uxarray-1117`). Its verdict also records a methodological defect
+adopted by everything after it: a ±2pp bar on a 43-instance stratum is below single-instance
+granularity, so **stratum thresholds must be stated in instances, floor ≥ 3**.
+
+The 2026-08-11 re-check (VT-2 round, `bench/locbench/results/vt2_pooling_freestat/`) exists because
+this document's stale "UNSPENT" line above nearly caused the idea to be re-attempted from scratch —
+the exact failure §5's "publish the negative results" is meant to prevent. Per the §7 rule the
+nameboost round earned, it computed the free end-to-end statistic FIRST: the full pooled FILE
+ordering (no ladder, no blend — the unconstrained best case any pooling mechanism could emit) from
+the complete routed `--for` scored candidate export, for a fixed family of pooling functions, on the
+A7 train split (n=254; single 203 / multi 51; baseline re-measured on the current binary at 61.0%
+overall, 70.9% single, 21.6% multi — drift from the recorded 61.81/70.73/24.49 explained by the
+resolver and noise-gate work since kParserVer 50, two instances migrated strata). The control
+(`max`, today's behavior) reproduced the recorded per-instance baseline on all 254 instances — then
+no candidate cleared, and most did active harm:
+
+| pooling fn | multi-file strict@10 (n=51) | single-file strict@10 (n=203) | multi net | single net |
+| --- | ---: | ---: | ---: | ---: |
+| `max` (control = shipped) | 11 (21.6%) | 144 (70.9%) | — | — |
+| `sum` (all positive members) | 8 (15.7%) | 81 (39.9%) | **−3** | **−63** |
+| `top2sum` | 11 (21.6%) | 140 (69.0%) | 0 | −4 |
+| `top3sum` | 11 (21.6%) | 142 (70.0%) | 0 | −2 |
+| `count-weighted` (max·(1+log₂(1+n))) | 9 (17.6%) | 128 (63.1%) | −2 | −16 |
+
+The pre-fixed bar (net ≥ +3 multi-file instances, ≤ 2 single-file losses) was never approached; no
+function nets even +1. `sum` is the instructive row: unbounded pooling makes file size the ranking
+signal and destroys the single-file stratum wholesale. And the only recurring multi-file "gain"
+(`sum`/`top3sum`) is `UXARRAY__uxarray-1117` — **the same single instance that laundered the
+constrained round's train advance**, now identified as such on a second instrument. Stage
+attribution, per the rule above: the failure is in the EVIDENCE, not the trigger and not the choice —
+pooling can only aggregate the query-derived per-symbol scores that already buried the sibling
+files, so it either moves nothing (`top2sum`/`top3sum`) or imports the file-size confound
+(`sum`/`cw`). This is the unconstrained confirmation of the constrained round's own diagnosis, and
+of the r6 closure: **the multi-file stratum is closed to ranking-side mechanisms** — five
+pre-registered rounds (anchorhop ×2, siblift, pooling, expansion) plus this upper-bound check, three
+seeds and three edges between them, all rejected. What remains open is candidate GENERATION (11 of
+22 decomposed held-out failures: the sibling never enters the candidate set), query understanding
+(4), and non-symbol gold (3) — different subsystems, recorded in `r6_expansion/gate_verdict.txt`.
 
 **Stripping question words out of prose queries does not fix prose-query recall.** The r7 loss-first
 round (2026-08-08, question sets committed in `bench/r7/`) measured natural-language queries at

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -124,6 +124,14 @@ because a tool that only publishes its wins has not told you how to use it.
 A negative result recorded is worth more than a feature shipped on a hunch — and it is the only
 thing that stops the same idea being re-attempted every six months.
 
+**And it must be recorded in the ledger everyone reads, in the same commit as the result.** A
+verdict that lives only in a results directory is a verdict that drifts: this repo once left a
+held-out REJECT in `bench/…/gate_verdict.txt`, never carried it into `docs/EVALS.md`, and five days
+later re-commissioned the same mechanism as "unspent headroom" on the strength of the stale prose —
+caught only because the new round's own §7 free-statistic contradicted the premise before anything
+was spent. The rule: a round's verdict lands in `docs/EVALS.md` in the SAME commit as its results
+directory, or the round is not finished.
+
 ---
 
 ## 6. What the honesty vocabulary buys


### PR DESCRIPTION
Docs + bench only, no binary change.

**The finding**: E6 (file-level pooling) was commissioned on a false premise — the mechanism was already gridded and REJECTED on held-out at +0.00pp (2026-08-06, `r5_pooling`), with a same-evening fifth rejection closing the multi-file stratum to ranking-side mechanisms — but neither verdict ever reached EVALS, and today's nameboost write-up repeated the stale "remains UNSPENT" line. VT-2's own §7 free-statistic caught it before any spend: the unconstrained pooled-file ordering's upper bound is NEGATIVE (best function nets 0 multi-file gains, −2 single-file), the prior +0.00 was the promote-only ladder suppressing harm. Baseline reproduced at kParserVer 60 with drift explained (multi 21.6%, single 70.9%). One poisoned instance (`UXARRAY__uxarray-1117`) identified as the recurring train-advance launderer on a second instrument. Stage attribution per §7: the failure is EVIDENCE-stage; open headroom is candidate generation and query understanding, not aggregation.

**What lands**: the EVALS §7 correction + the two missing negative records; the free-statistic record + reusable env-parameterized script under `bench/locbench/results/vt2_pooling_freestat/`; METHODOLOGY §5 gains the drift rule — a round's verdict lands in EVALS in the SAME commit as its results directory, or the round is not finished.

Doc gates green; determinism/xmllint/quality-delta clean; no gate-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)