### PR TITLE
Fix main CI: bodydialectcheck gets its honest 900s budget

### DIFF
--- a/test/pargates.py
+++ b/test/pargates.py
@@ -112,6 +112,9 @@ GATE_BUDGET_SEC = {
     "pyimportprecisecheck.sh":    900,
     "rustimportprecisecheck.sh":  900,
     "tsimportprecisecheck.sh":    900,
+    "bodydialectcheck.sh":        900,   # T3 gave --for/--pack-task real body assembly (v0.3.5/6);
+                                         # ~160 s CPU -- a plain -O0 CI runner overruns the flat cap
+                                         # while a healthy local run takes ~17 s wall.
     "cppbenchcheck.sh":          1200,
     "regexbombcheck.sh":         1200,
 }

--- a/test/pargatescheck.sh
+++ b/test/pargatescheck.sh
@@ -44,6 +44,10 @@ grep -qE '"cppbenchcheck\.sh":\s*1200' "$PARGATES" \
     && ok "static: cppbenchcheck.sh has an honest 1200s budget" \
     || no "static: cppbenchcheck.sh missing (or wrong) from GATE_BUDGET_SEC"
 
+grep -qE '"bodydialectcheck\.sh":\s*900' "$PARGATES" \
+    && ok "static: bodydialectcheck.sh has an honest 900s budget (T3 body assembly outgrew the flat cap on plain CI builds)" \
+    || no "static: bodydialectcheck.sh missing (or wrong) from GATE_BUDGET_SEC"
+
 grep -qE '"regexbombcheck\.sh":\s*1200' "$PARGATES" \
     && ok "static: regexbombcheck.sh has an honest 1200s budget" \
     || no "static: regexbombcheck.sh missing (or wrong) from GATE_BUDGET_SEC"


### PR DESCRIPTION
Both `release (ubuntu-24.04, plain, gcc/clang)` jobs on main fail with `bodydialectcheck.sh rc=124 at 300.0s` — the harness cap, not a regression: T3's body assembly (v0.3.5/6) made the gate ~160s of CPU, healthy at ~17s wall locally but over the flat cap on a plain-build 4-core runner. The per-gate budget mechanism exists for exactly this; bodydialectcheck joins the table at 900s with its reason inline, and pargatescheck gains the pinning arm (verified red against the pre-fix table).

Full local suite ALL PASS with the new budget active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)