### PR TITLE
release: bump version to 0.3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 # The version string lives in exactly ONE place — this project() call. --version (main.cpp)
 # reads it via the generated version.h below; test/versioncheck.sh asserts the two never drift.
-project(ripwire VERSION 0.3.6 LANGUAGES C CXX)
+project(ripwire VERSION 0.3.8 LANGUAGES C CXX)
 
 # ---- language standards (C++23 for our own code / C11 for the vendored C dependencies) ----
 set(CMAKE_CXX_STANDARD 23)


### PR DESCRIPTION
The v0.3.7 release run failed on the Package step's version guard (binary still reported 0.3.6 — the taskroute round landed without the bump). Straight to 0.3.8 since the dead v0.3.7 tag can't be reused without a remote tag deletion (surfaced as an owner item). One-line CMakeLists change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)