### PR TITLE
fix(deck): the slide-count arm reads the deck itself — the row citing this gate was stale

### DIFF
--- a/present/deck5_ripwire_build.js
+++ b/present/deck5_ripwire_build.js
@@ -904,7 +904,7 @@ function row(s, y, h, cols, opts={}){
   kicker(s, "// do not take any of it on trust", AMBER);
   title(s, "Every claim, and the command that re-derives it");
   const claims = [
-    ["174 long flags · 26 slides",        "bash test/deckclaimcheck.sh"],
+    ["174 long flags · 27 slides",        "bash test/deckclaimcheck.sh"],
     ["every --flag named here exists",    "bash test/deckcheck.sh"],
     ["81.4% fewer element bytes",         "bash test/showcasecapturecheck.sh"],
     ["451 gate scripts",                  "bash test/manifestcheck.sh"],

--- a/test/deckclaimcheck.sh
+++ b/test/deckclaimcheck.sh
@@ -8,6 +8,10 @@
 #          table and present/README.md's opening line) with nothing deriving it from the generator, so
 #          a deck that grew or shrank falsified both silently. It grew from 18 to 23 in the refresh
 #          that added this arm; without (B) both sentences would still read "18".
+#          Widened 2026-08-31 to THREE sites and TWO demands: the generator itself joined the two
+#          READMEs (its self-verification row states the counts and names this gate as their
+#          evidence, yet only its flag half was ever read), and each site must now both avoid a
+#          wrong count (B1) and carry a right one (B2) — a claim deleted is a claim drifted.
 #
 # Both arms are DERIVE-then-COMPARE, never a pinned constant: the instrument is the artifact itself
 # (the binary's --help, the generator's addSlide calls), so the gate cannot drift out of date on its
@@ -46,12 +50,35 @@ slides="$( grep -oF 'p.addSlide()' "$GEN" | wc -l | tr -d ' ' )"
     printf '        (B) counts occurrences of the literal: p.addSlide()\n'
     exit 2; }
 
-# Prose that states a slide count, and must agree with it. Both files ship publicly; both stated 18
-# while the generator built 18, and both would have kept stating it at 23. Every drifted site is
-# reported, not just the first — the same courtesy deckcheck.sh pays with its file:line list, and the
-# reason this arm accumulates instead of exiting on the first mismatch.
+# Prose that states a slide count, and must agree with it. All three files ship publicly; the two
+# READMEs stated 18 while the generator built 18, and both would have kept stating it at 23.
+#
+# $GEN joined the list on 2026-08-31, for exactly the reason arm (A) scans it. The deck's own
+# self-verification slide ("Every claim, and the command that re-derives it") states BOTH counts in
+# one row and names THIS gate as the command that re-derives them — but $GEN was scanned only for
+# `[0-9]+ long flags`, so the row's flag half was derived and its slide half was merely remembered.
+# The remembered half duly went stale: the generator built 27 slides while the row read 26, green,
+# under a claim citing this gate as its evidence. A claim about the deck is not exempt from the arm
+# for living inside the deck; the generator is prose here as much as either README is.
+#
+# ONE list, declared once, driving BOTH demands below: every site is scanned for a count that
+# disagrees, and required to carry one that agrees. The list is single-sourced because a duplicated
+# one is the very bug this arm keeps being widened to fix — arm (A) scanned $GEN and arm (B) did
+# not, and the fact that nothing tied the two lists together is why that went unnoticed through a
+# stale release. A fourth site added here is scanned AND required, with no second edit to forget.
+# The text after the first colon is what a maintainer sees when that site goes quiet.
+claimSites=(
+    "README.md:the documentation-table row lost its count"
+    "present/README.md:the opening line lost its count"
+    "${GEN#$ROOT/}:the deck's own self-verification row lost its count"
+)
+
+# (B1) SCAN — no site may state a count that disagrees. Every drifted site is reported, not just the
+# first: the same courtesy deckcheck.sh pays with its file:line list, and the reason this arm
+# accumulates instead of exiting on the first mismatch.
 slideClaimFail=0
-for f in "$ROOT/README.md" "$ROOT/present/README.md"; do
+for site in "${claimSites[@]}"; do
+    f="$ROOT/${site%%:*}"
     [ -f "$f" ] || continue
     while IFS=: read -r lineNo claim; do
         [ -z "$claim" ] && continue
@@ -63,11 +90,18 @@ for f in "$ROOT/README.md" "$ROOT/present/README.md"; do
     done <<< "$( grep -noE '[0-9]+ slides' "$f" || true )"
 done
 
-# A claim that vanished is as much a drift as a claim that is wrong: the documentation table's slide
-# count is how a reader sizes the deck before clicking it. Require at least one prose site to state it.
-grep -qE "$slides slides" "$ROOT/README.md" || {
-    printf 'deckclaimcheck: README.md no longer states the deck size (%s slides) — the documentation-table row lost its count\n' "$slides"
-    slideClaimFail=1; }
+# (B2) REQUIRE — every site must STATE the count, not merely avoid contradicting it. A claim that
+# vanished is as much a drift as a claim that is wrong: the count is how a reader sizes the deck
+# before clicking it, and deletion is the easier way out for whoever a (B1) red lands on. Note the
+# deliberate difference from (B1): a MISSING file is skipped there and fails here, because "no
+# wrong count" is vacuously true of a file that does not exist and "states the count" is not.
+for site in "${claimSites[@]}"; do
+    reqFile="${site%%:*}"
+    grep -qE "$slides slides" "$ROOT/$reqFile" || {
+        printf 'deckclaimcheck: %s no longer states the deck size (%s slides) — %s\n' \
+            "$reqFile" "$slides" "${site#*:}"
+        slideClaimFail=1; }
+done
 
 # TERMINAL REGION — deliberately the last read of slideClaimFail, and deliberately self-contained.
 # test/gateexitcheck.sh arm (B) slices from an accumulator's final read to EOF and RUNS that slice in


### PR DESCRIPTION
## What was wrong

The deck's self-verification slide — *"Every claim, and the command that re-derives it"* — stated `173 long flags · 26 slides` and named `bash test/deckclaimcheck.sh` as its own evidence. The generator builds **27**. The gate was green.

Arm (A) had scanned the generator for `[0-9]+ long flags` since it was written; arm (B) scanned only `README.md` and `present/README.md` for `[0-9]+ slides`. The two halves of one row therefore had different provenance — the flag half derived, the slide half remembered — and the remembered half drifted, under a claim citing the gate that was not reading it.

## What changed

Arm (B) is widened to **three sites and two demands**:

| | |
| --- | --- |
| **(B1) SCAN** | No site may state a count that disagrees. The generator joins the two READMEs — a claim about the deck is not exempt from the arm for living inside the deck. |
| **(B2) REQUIRE** | Every site must *state* the count, not merely avoid contradicting it. Deletion is the easier way out for whoever a (B1) red lands on, and a claim that vanished is as much a drift as a claim that is wrong. Arm (A) has required exactly this of the generator since it was written; the slide half of that one row was the asymmetry. |

Both loops read **one** list, declared once. That is not tidiness — a duplicated list is the bug being fixed here. Arm (A) scanned the generator and arm (B) did not, and nothing tied the two lists together, which is why the row read `26 slides` through a release. A fourth site added to `claimSites` is scanned *and* required, with no second edit to forget.

The loops keep one deliberate difference, documented in place: a **missing** file is skipped by (B1) and fails (B2) — "states no wrong count" is vacuously true of a file that does not exist; "states the count" is not.

## Evidence

Gate before code, red before green. The (B1) widening reported this **before the number was touched**:

```
deckclaimcheck: present/deck5_ripwire_build.js:907 states "26 slides" — the generator builds 27
```

Then mutation-tested from a correct tree, since a missing-claim defect has to be synthesized:

- deck row stale → red
- deck row's slide half deleted, flag half kept → red
- each README's count deleted → red, named individually
- all three deleted at once → all three named, not just the first
- a **wrong** count in `present/README.md` → fires (B1) at `:3` *and* (B2)

That last one is the one that matters: it proves the shared list feeds both loops, not only the one each site was added to.

The file header is updated in the same commit — it described arm (B) as scanning "TWO prose files", which is the drift this gate exists to prevent.

## Verification

- Full suite: **509 gates, 506 pass, 3 skip, 0 fail**, on a tree byte-identical to this commit.
- `gateexitcheck` — which slices this file's terminal region and runs it in isolation — ALL PASS. Both loops write the accumulator above its final read, never in a subshell.
- The 3 skips are the standing environment ones (`editchecknotecheck` / `argvdiffcheck` want a reference binary, `g1freshcheck` wants an `asan/` tree).

## Why a PR rather than a direct landing

CI is `push: branches: [main]` + `pull_request:`, so a pushed branch gets no CI. This change has been verified on exactly one leg — macOS AppleClang, plain build. Since what changed is *a gate*, it executes in all six release legs and the ubi9 leg on every future change; a portability slip in it turns the suite red downstream rather than failing quietly. The narrow untested surface is the new `claimSites` bash array and its `${site%%:*}` splitting under GNU grep instead of BSD grep. The Release/NDEBUG and ASan axes are noise for this one — no C++ is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)