### PR TITLE
feat(skills): add Hermes-format skill under skills/hermes/, extend vetting sweeps to cover it

### DIFF
--- a/skills/hermes/README.md
+++ b/skills/hermes/README.md
@@ -1,0 +1,13 @@
+# Hermes skills
+
+Hermes-format counterpart to the `ripwire-*` skill family. Kept in its own namespace (not
+`skills/ripwire-*`) so `skills/install.sh` — which symlinks every `ripwire-*` directory into
+Claude Code / Codex skill roots — never installs it into those agents.
+
+Install into a Hermes profile:
+
+```bash
+cp -r skills/hermes/ripwire-repo-map ~/.hermes/skills/software-development/
+```
+
+Requires the `ripwire` binary on PATH (upstream release tarball, see repo README).

--- a/skills/hermes/ripwire-repo-map/SKILL.md
+++ b/skills/hermes/ripwire-repo-map/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ripwire-repo-map
+description: "Use ripwire CLI to map a repo before reading it."
+version: 1.0.0
+author: Ashutosh Singh
+license: Apache-2.0
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [ripwire, repo-map, call-graph, context-engineering, code-navigation, static-analysis]
+    related_skills: [systematic-debugging, codebase-inspection]
+prerequisites:
+  commands: [ripwire]
+---
+
+# ripwire — deterministic repo map before reading code
+
+`ripwire` (v0.4.x at authoring time; the release binary must be on PATH) is a zero-dependency C++23
+CLI that builds a ranked, deterministic call graph of any repo in ~1s (parses once, then auto-caches
+warm). It answers "what to touch, what it breaks, which tests to run" for a fraction of the tokens of
+grep + whole-file reads. No API key, no daemon, no index server, offline. Invoke it via the terminal
+tool.
+
+## When to reach for it (instead of blind grep / whole-file reads)
+
+- Landing cold in a repo or subsystem — "what's here, how is it organized, what matters"
+- "Where is the code for X" — a task, feature, or concept in your own words
+- A change is proposed — what breaks, who calls it, which tests must run
+- Resuming work after compaction / a new session on in-flight work
+- Reviewing code you did not write (fresh eyes), or pre-commit change vetting
+
+Do NOT use for trivial single-file lookups (plain `rg`/search_files wins) or broad common-word
+questions — ripwire shines on specific technical asks.
+
+## Core verbs (all take a repo dir; `--help` is authoritative)
+
+```bash
+ripwire <dir> --report            # architecture summary: modules, god-files, cycles, top symbols
+ripwire <dir> --for="<task in your own words>"   # ranked task lens: what to touch first, with 1-hop edges
+ripwire <dir> --callers=someFunc  # who calls it (blast radius)
+ripwire <dir> --test-gate         # which tests must run before committing
+ripwire <dir> --tree              # file-by-file: top symbols per file
+ripwire <dir> --hotspots          # files ranked by churn × complexity
+ripwire <dir> --communities       # cohesive modules (Louvain) + bridges — where a new feature belongs
+ripwire <dir> --situ              # what the working tree already changed + its blast radius (resuming work)
+ripwire <dir> --notes             # pinned gotchas from past sessions (field notes)
+ripwire <git-url>                 # orient in a remote repo (shallow-clones into a cached temp dir; --refetch refreshes)
+```
+
+Read the map, then open only the files it surfaces (god-files and hotspots first). For a body of one
+ranked symbol: `ripwire <dir> --for="..." --expand=path:name` (paste `p=`/`n=` off the row).
+
+## Honesty signals — read them before trusting a result
+
+- The `--for` lens reports `confidence=`/`margin_pct=` on its result root and the output carries
+  `est_tokens=` — `confidence="low"` or a flat ranking means treat the set as a starting point, not an answer.
+- `--for` bundles: `bodies="0"` = no full bodies shipped (`reason="compact-route"`; `--auto-bodies`
+  restores them. A `reason="budget"` means the caller's token budget cut them — raise the budget instead).
+- `--skipped` lists files the index dropped (oversize, or `.gitignore`d — default ignored; `--no-ignore`
+  restores the full walk). A "not found" is only trustworthy after checking this.
+- `amb="K"` on a symbol means K of its outbound calls matched several possible definitions — the
+  resolver split the weight instead of choosing one. Read the source if the target matters.
+  (`lpin=` is a separate, disclosed guess the resolver made; same remedy.)
+
+## Pitfalls
+
+1. **First call on a tree parses** (~1s at 1,500+ files; measured ≈1.2s wall for a 2,355-file /
+   77k-edge checkout on Apple M2). Later calls are warm and near-instant — chain verbs freely.
+2. `--top-k` is NOT read by `--for`'s own bundle (it shapes the default map and `--query`; it still
+   applies to `--format=candidates` with `--for`).
+3. Markdown/docs-only or shell-only repos yield few call-graph edges — `--report` is still useful, edges are not.
+4. The tool indexes signatures, not necessarily full bodies, by default on conceptual queries — `--expand`
+   or `--auto-bodies` when you need the body.
+5. Cache/notes live in the repo tree (`.ripwire_notes` for `--note-add`); the notes file is meant to be committed.
+6. ripwire output can be large on big repos — budget with `--max-tokens=8000` / `--top-k=50` where supported.
+
+## Reference links
+
+- Upstream: https://github.com/redhat-et/ripwire (Apache-2.0; releases ship prebuilt macOS/Linux binaries + SHA-256)
+- The project ships 18 agent skills (Claude Code/Codex format) under `skills/` in its repo — this Hermes
+  skill is the distilled Hermes-format counterpart to that family (`ripwire-orient` is the closest base);
+  read those upstream for deeper flows.

--- a/test/deckcheck.sh
+++ b/test/deckcheck.sh
@@ -185,6 +185,7 @@ for f in "$ROOT"/docs/*.md; do
 done
 for f in "$ROOT"/skills/*/SKILL.md;         do addSource "$f" skills; done
 for f in "$ROOT"/skills/*/*.md;             do addSource "$f" skills; done
+for f in "$ROOT"/skills/*/*/SKILL.md;       do addSource "$f" skills; done
 for f in "$ROOT"/prompts/*.md;              do addSource "$f" prompts; done
 for f in "$ROOT"/paper/*.md;                do addSource "$f" paper;   done
 for f in "$ROOT"/present/*.js;              do addSource "$f" present; done

--- a/test/skillscan.sh
+++ b/test/skillscan.sh
@@ -73,8 +73,10 @@ if [ "$rc" = "2" ]; then ok "evade_fenced.md exits 2 (bare-fence evasion caught)
 #    path as a clean scan — the check silently asserted nothing for a round. Now: sweep every shipped
 #    skill, assert rc == 0 EXPLICITLY (readable AND clean — rc=3 "cannot read" fails loudly), and an
 #    empty glob is itself a failure (trap ledger #7: an input that can go missing must FAIL, not skip).
+#    The second glob pattern covers namespaced skills (skills/hermes/*/SKILL.md), so a Hermes-format
+#    skill added under an agent-name directory is swept like the flat set — not silently skipped.
 own_skill_count=0
-for own_skill in "$ROOT"/skills/*/SKILL.md; do
+for own_skill in "$ROOT"/skills/*/SKILL.md "$ROOT"/skills/*/*/SKILL.md; do
     [ -f "$own_skill" ] || continue
     own_skill_count=$(( own_skill_count + 1 ))
     rc="$( scan_exit "--scan-skill=$own_skill" )"


### PR DESCRIPTION
## Summary

Adds a **Hermes-format skill** for ripwire — a distilled Hermes-native counterpart to the `ripwire-orient` family — and extends the two vetting sweeps so a namespaced skill like it is scanned like the flat set, not silently skipped.

No C++ or behavior change. Diff: 2 new files + 2 sweep-glob lines.

## Why a Hermes skill

[Hermes Agent](https://hermes-agent.nousresearch.com) is a shell-capable coding agent ("if your agent can run shell commands, it is set up"): its skills are agentskills.io-style `SKILL.md` files under `~/.hermes/skills/`. The added skill teaches a Hermes agent **when** to reach for ripwire instead of grep-and-read: orienting in an unfamiliar repo, the `--for` task lens, `--callers` blast radius, `--test-gate` before committing, resuming work after context compaction. Its honesty-signals section mirrors ripwire's own disclosure model (`confidence=`/`margin_pct=`, `--skipped`, `amb=`) so an agent reads a map the way the tool wants it read.

## Why `skills/hermes/` and not `skills/ripwire-*`

`skills/install.sh` symlinks **every** `skills/ripwire-*` directory into Claude Code / Codex skill roots. A Hermes-format file must not be auto-installed into those agents — wrong frontmatter dialect for them, and it would pollute the routed `ripwire-*` set. The `hermes/` namespace is invisible to that glob (verified: `for d in "$src"/ripwire-*/`), so Claude/Codex installs are untouched.

## Sweep coverage (the second half of this PR)

`skillscan.sh` check 9 and `deckcheck.sh` globbed only `skills/*/SKILL.md`, so `skills/hermes/ripwire-repo-map/SKILL.md` would have **silently escaped both gates** — the green-while-inert shape `deckcheck.sh`'s own header exists to prevent. Both now include the depth-3 pattern `skills/*/*/SKILL.md`.

Verified locally against a plain cmake build (macOS arm64):
- `bash test/skillscan.sh` → **ALL PASS**, `19/19 shipped skills scan clean` — the new file is swept and scans attack-clean.
- `bash test/deckcheck.sh` → **ALL PASS** — 55 prose sources, 272 distinct `--flag` tokens, 0 fabricated, 0 bad values.

## Notes for review

- The frontmatter `description` is intentionally one line: Hermes indexes skill descriptions into every session's system prompt, so the trigger matrix lives in the body. `allowed-tools` is omitted for the same reason — Hermes validates against a fixed frontmatter key set.
- Not added to the release-tarball packaging (the release lane copies `ripwire-*` only); Hermes users install from the repo as documented in `skills/hermes/README.md`. Happy to include it in the tarball if you'd prefer.
