### PR TITLE
ci: macOS plain leg skips four platform-independent gates; main runs are not cancelled by the next push

### DIFF
--- a/.github/pargates-macos-plain-skip.txt
+++ b/.github/pargates-macos-plain-skip.txt
@@ -1,0 +1,9 @@
+# Gates the macOS PLAIN release leg does not run (test/pargates.py --exclude-list). Every gate here still
+# runs on the macOS Release leg and on all four Linux legs; each asserts nothing platform-specific. The leg
+# is an -O0 binary on a 3-core runner and was the workflow's critical path (33-37 min, run 34155361413);
+# these four were its slowest gates (545 / 391 / 383 / 349 s there). Measured, not assumed -- re-measure
+# before adding to this list, and remove an entry the moment the gate grows an OS-specific arm.
+binoverridecheck.sh     # meta-gate: re-runs the suite against a stub binary to prove every gate honours RIPWIRE_BIN
+knownitemcheck.sh       # --eval-retrieval known-item recall over a fixed corpus; ranker math, no platform surface
+ripwirepubliccheck.sh   # sweeps tracked files for identifiers/dangling refs; reads the repo, not the binary's OS
+xmlwellformed.sh        # G4 well-formedness sweep of the map; the leg's own det-gate/G4 steps still xmllint its output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,11 @@ on:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel a superseded run on a PULL REQUEST only. On main every push is a distinct commit that deserves its
+  # own verdict: on 2026-09-07 three consecutive main runs were cancelled by unrelated pushes inside the
+  # ~26-min window, with zero failures among the 45 jobs that had completed — the signal was thrown away, not
+  # superseded. A queued main run costs runner minutes; a cancelled one costs the answer.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Never RIPWIRE_NATIVE in CI: -march=native would bake in whatever ISA the CI runner's host happens to
 # expose that week, defeating the entire point of testing the portable default.
@@ -146,8 +150,8 @@ jobs:
         include:
           - { os: macos-14,     flavor: Release, cc: appleclang, shard: 1, shards: 2 }
           - { os: macos-14,     flavor: Release, cc: appleclang, shard: 2, shards: 2 }
-          - { os: macos-14,     flavor: plain,   cc: appleclang, shard: 1, shards: 2 }
-          - { os: macos-14,     flavor: plain,   cc: appleclang, shard: 2, shards: 2 }
+          - { os: macos-14,     flavor: plain,   cc: appleclang, shard: 1, shards: 2, skiplist: .github/pargates-macos-plain-skip.txt }
+          - { os: macos-14,     flavor: plain,   cc: appleclang, shard: 2, shards: 2, skiplist: .github/pargates-macos-plain-skip.txt }
           - { os: ubuntu-24.04, flavor: Release, cc: gcc,   shard: 1, shards: 4 }
           - { os: ubuntu-24.04, flavor: Release, cc: gcc,   shard: 2, shards: 4 }
           - { os: ubuntu-24.04, flavor: Release, cc: gcc,   shard: 3, shards: 4 }
@@ -217,7 +221,9 @@ jobs:
         # --budget-scale 4: the harness's flat 300 s default is a hang tripwire calibrated on an idle dev machine;
         # here -j 3 on a 4-vCPU runner is a 3-8x multiplier (two gates hit rc=124 at exactly 300 s in the first
         # sharded runs). The scale applies to the default only; GATE_BUDGET_SEC's explicit entries stay as declared.
-        run: python3 test/pargates.py . build/ripwire -j 3 --shard ${{ matrix.shard }}/${{ matrix.shards }} --budget-scale 4
+        # `skiplist` (macOS plain only): a committed list of platform-independent gates this leg does not run —
+        # see .github/pargates-macos-plain-skip.txt for the measurement and the per-gate reason.
+        run: python3 test/pargates.py . build/ripwire -j 3 --shard ${{ matrix.shard }}/${{ matrix.shards }} --budget-scale 4 ${{ matrix.skiplist && format('--exclude-list {0}', matrix.skiplist) || '' }}
 
       - name: det-gate — 2-run byte-identical diff
         run: |

--- a/test/pargates.py
+++ b/test/pargates.py
@@ -6,7 +6,7 @@ exceeds the agent harness time ceiling. This runs the same scripts concurrently 
 full verification fits in one window. It does NOT modify regression.sh.
 
 usage: pargates.py <repo-root> <ripwire-bin> [-j N] [--only substr] [--json out.json]
-                   [--shard K/N] [--shard-plan] [--budget-scale F]
+                   [--shard K/N] [--shard-plan] [--budget-scale F] [--exclude-list FILE]
 """
 import concurrent.futures as cf
 import hashlib
@@ -26,6 +26,7 @@ jsonout = None
 shard = None          # (k, n): run only the k-th of n deterministic slices of the gate list
 shard_plan = False    # print every slice's membership and predicted weight, run nothing
 budget_scale = 1.0    # multiply the DEFAULT per-gate budget (never the explicit overrides) -- CI passes >1
+exclude_list = None   # a committed file naming gates this leg does not run (one per line, # comments)
 args = sys.argv[3:]
 for i, a in enumerate(args):
     if a == "-j":
@@ -41,6 +42,8 @@ for i, a in enumerate(args):
             sys.exit(f"--shard K/N needs 1 <= K <= N, got {args[i + 1]}")
     elif a == "--shard-plan":
         shard_plan = True
+    elif a == "--exclude-list":
+        exclude_list = args[i + 1]
     elif a == "--budget-scale":
         budget_scale = float(args[i + 1])
         if budget_scale <= 0:
@@ -56,6 +59,26 @@ skip = {"regression.sh"}
 gates = [g for g in gates if g not in skip]
 if only:
     gates = [g for g in gates if only in g]
+
+# --exclude-list: a leg may decline a NAMED set of gates, and only by pointing at a committed file whose
+# every line says which gate and why. The use it exists for (2026-09-07): the macOS plain leg -- an -O0
+# binary on a 3-core runner -- was the critical path of the whole workflow at 33-37 min, and its four
+# slowest gates (binoverridecheck, knownitemcheck, ripwirepubliccheck, xmlwellformed) assert nothing
+# platform-specific and run unchanged on the macOS Release leg and all four Linux legs. Applied BEFORE the
+# shard split so the remaining gates rebalance; the count is printed so a log reader sees the omission
+# instead of inferring it from a shorter gate total. A name in the file that matches no gate is an error:
+# a stale exclusion silently excluding nothing is how a list like this rots.
+excluded = []
+if exclude_list:
+    with open(os.path.join(root, exclude_list)) as fh:
+        wanted = [ln.split("#", 1)[0].strip() for ln in fh]
+    wanted = [w for w in wanted if w]
+    unknown = [w for w in wanted if w not in gates and not (only and only not in w)]
+    if unknown and not only:
+        sys.exit(f"--exclude-list {exclude_list} names gates that do not exist: {' '.join(unknown)}")
+    excluded = [g for g in gates if g in wanted]
+    gates = [g for g in gates if g not in wanted]
+    print(f"exclude-list {exclude_list}: {len(excluded)} gate(s) not run on this leg: {' '.join(excluded)}")
 
 # --- longest-first (LPT) scheduling -----------------------------------------------------------
 # A greedy scheduler minimizes wall time by handing the slowest jobs to workers FIRST -- a long

--- a/test/queryfilescancheck.sh
+++ b/test/queryfilescancheck.sh
@@ -128,7 +128,12 @@ for m in re.finditer(r'<f p="([^"]*)" why="unsupported-ext" bytes="(\d+)"', text
     path, nbytes = m.group(1), int(m.group(2))
     if nbytes > maxbytes:
         continue
-    fp = path if path.startswith('/') else root + '/' + path.lstrip('./')
+    # NOT path.lstrip('./'): lstrip strips a CHARACTER SET, so it also ate the leading dot of a dot-directory
+    # (.github/x.txt -> github/x.txt), the open failed, and the row was silently dropped from the recount --
+    # found 2026-09-07 the first time a tracked unsupported-ext file lived under a dot-dir (issue: an
+    # off-by-one 2b that no filter explained). Strip exactly one './' prefix.
+    rel = path[2:] if path.startswith('./') else path
+    fp = path if path.startswith('/') else root + '/' + rel
     try:
         with open(fp, 'rb') as fh:
             head = fh.read(4096)


### PR DESCRIPTION
## What this changes

1. `test/pargates.py --exclude-list FILE`: a leg may decline a named set of gates, only via a committed file with one gate and its reason per line; applied before the shard split so the shards rebalance; a stale name is a hard error; the omission is printed in the log. The macOS **plain** leg skips `binoverridecheck`, `knownitemcheck`, `ripwirepubliccheck`, `xmlwellformed` (`.github/pargates-macos-plain-skip.txt`) — all four still run on the macOS Release leg and all four Linux legs, and none asserts anything platform-specific.
2. `cancel-in-progress` is scoped to pull requests. On main each push is a distinct commit that deserves its own verdict: three consecutive main runs on 2026-09-07 were cancelled by unrelated pushes with zero failures among the 45 jobs that had completed.
3. `test/queryfilescancheck.sh`: the recount used `path.lstrip('./')`, which strips a character set and turned `.github/x.txt` into `github/x.txt`; the open failed and the row was silently dropped (arm 2b off by one on every leg of this PR's first run). Latent until the first tracked unsupported-ext file under a dot-directory. Now strips exactly one `./`.

## Measurement

| | main run 34155361413 (first full sharded run) | this PR, run 34161127612 |
| --- | --- | --- |
| workflow wall | 37 min | **27 min** |
| macOS plain shards | 33 / 37 min | 26.8 / 27.5 min |
| macOS Release shards | 25 / 26 min | 25.9 / 27.8 min |
| Linux shards | ≤ 23 min | ≤ 22.7 min |
| conclusion | success | success (all 25 jobs) |

The critical path is now the macOS runners as a class (both flavours within 2 min of each other), not the plain leg alone. macOS runner variance is real (the same Release shard 2/2 measured 19.6, 25.9, 40 and 27.8 min across four runs), so treat the wall as ~26–30 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
