### PR TITLE
test: isolate installer fixtures from inherited agent homes

### DIFF
--- a/test/installer_isolation.py
+++ b/test/installer_isolation.py
@@ -2,6 +2,7 @@
 """Run installer gates with inherited agent homes outside their temporary fixtures."""
 import os
 from pathlib import Path
+import stat
 import subprocess
 import sys
 import tempfile
@@ -9,11 +10,11 @@ import tempfile
 
 def snapshot(root):
     return {
-        str(path.relative_to(root)): (
+        str(path.relative_to(root)): (stat.S_IMODE(path.lstat().st_mode), (
             ("link", os.readlink(path)) if path.is_symlink()
             else ("directory",) if path.is_dir()
             else ("file", path.read_bytes())
-        )
+        ))
         for path in root.rglob("*")
     }
 
@@ -38,6 +39,15 @@ with tempfile.TemporaryDirectory(prefix="ripwire-installer-sentinels-") as tempo
     (claude / "settings.json").write_text('{"sentinel": true}\n')
     (outside / "CODEX_HOME" / "hooks.json").write_text('{"sentinel": true}\n')
     before = snapshot(outside)
+    sentinel = outside / "CODEX_HOME" / "hooks.json"
+    mode = stat.S_IMODE(sentinel.lstat().st_mode)
+    sentinel.chmod(mode ^ stat.S_IXUSR)
+    if snapshot(outside) == before:
+        sys.exit("  FAIL  snapshot missed a permission-only sentinel change")
+    sentinel.chmod(mode)
+    if snapshot(outside) != before:
+        sys.exit("  FAIL  sentinel permissions were not restored")
+    print("  PASS  snapshot detects permission-only changes")
     failed = False
     for gate, argument in (("skillinstallcheck.sh", str(binary)),
                            ("releaseinstallcheck.sh", "--isolation-child")):

--- a/test/installer_isolation.py
+++ b/test/installer_isolation.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Run installer gates with inherited agent homes outside their temporary fixtures."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def snapshot(root):
+    return {
+        str(path.relative_to(root)): (
+            ("link", os.readlink(path)) if path.is_symlink()
+            else ("directory",) if path.is_dir()
+            else ("file", path.read_bytes())
+        )
+        for path in root.rglob("*")
+    }
+
+
+root = Path(__file__).resolve().parent.parent
+binary = Path(sys.argv[1])
+if not binary.is_absolute():
+    binary = root / binary
+binary = binary.resolve()
+if not binary.is_file() or not os.access(binary, os.X_OK):
+    sys.exit(f"missing executable ripwire binary: {binary}")
+with tempfile.TemporaryDirectory(prefix="ripwire-installer-sentinels-") as temporary:
+    outside = Path(temporary)
+    environment = os.environ.copy()
+    for variable in ("HOME", "CODEX_HOME", "AGENTS_HOME", "HERMES_HOME"):
+        home = outside / variable
+        home.mkdir()
+        (home / "sentinel").write_text("leave unchanged\n")
+        environment[variable] = str(home)
+    claude = outside / "HOME" / ".claude"
+    claude.mkdir()
+    (claude / "settings.json").write_text('{"sentinel": true}\n')
+    (outside / "CODEX_HOME" / "hooks.json").write_text('{"sentinel": true}\n')
+    before = snapshot(outside)
+    failed = False
+    for gate, argument in (("skillinstallcheck.sh", str(binary)),
+                           ("releaseinstallcheck.sh", "--isolation-child")):
+        result = subprocess.run(
+            ["bash", str(root / "test" / gate), argument],
+            cwd=root, env=environment, capture_output=True, text=True,
+        )
+        if result.returncode:
+            print(result.stdout)
+            print(result.stderr, file=sys.stderr)
+            print(f"  FAIL  {gate} with inherited agent homes")
+            failed = True
+        if snapshot(outside) != before:
+            print(f"  FAIL  {gate} changed an outside sentinel home")
+            failed = True
+        else:
+            print(f"  PASS  {gate} left outside sentinel homes unchanged")
+    sys.exit(1 if failed else 0)

--- a/test/releaseinstallcheck.sh
+++ b/test/releaseinstallcheck.sh
@@ -11,6 +11,8 @@ ok(){ printf '  PASS  %s\n' "$*"; }
 no(){ printf '  FAIL  %s\n' "$*"; fail=1; }
 
 TMP="$( mktemp -d )"; trap 'rm -rf "$TMP"' EXIT
+# Detection and activation must use only the per-invocation homes below.
+unset CODEX_HOME AGENTS_HOME HERMES_HOME RIPWIRE_NO_ACTIVATE
 FAKE="$TMP/fake"; mkdir -p "$FAKE" "$TMP/assets/ripwire-0.3.6-macos-arm64/skills/ripwire-router" "$TMP/assets/ripwire-0.3.6-macos-arm64/hooks"
 
 printf '#!/bin/sh\necho "ripwire 0.3.6 (Release, Test)"\n' >"$TMP/assets/ripwire-0.3.6-macos-arm64/ripwire"
@@ -239,6 +241,11 @@ if grep -qE 'cp[^|;]*"\$binDir/ripwire"' "$INSTALL"; then
     no "(F3) something still cp's directly onto \$binDir/ripwire — the overwrite path is reachable"
 else
     ok "(F3) nothing cp's onto the destination path; the temp file is the only thing copied"
+fi
+
+if [ "${1:-}" != "--isolation-child" ]; then
+    python3 "$ROOT/test/installer_isolation.py" "${RIPWIRE_BIN:-$ROOT/build/ripwire}" \
+        || no "installer gates escaped their fixture homes or failed with inherited overrides"
 fi
 
 [ "$fail" -eq 0 ] && echo "ALL PASS" || { echo "SOME CHECKS FAILED"; exit 1; }

--- a/test/skillinstallcheck.sh
+++ b/test/skillinstallcheck.sh
@@ -18,6 +18,8 @@ no(){ echo "  FAIL  $1"; fail=1; }
 [ -f "$SK/install.sh" ] || { echo "no skills/install.sh"; exit 2; }
 
 TMP="$( mktemp -d )"; trap 'rm -rf "$TMP"' EXIT
+# Each invocation below owns its HOME; inherited agent overrides must not escape it.
+unset CODEX_HOME AGENTS_HOME HERMES_HOME
 DST="$TMP/skills"
 
 # ---- 1) install.sh deploys EVERY user-facing shipped skill (the deployment-drift catch) ----


### PR DESCRIPTION
## Summary

Keep installer gates inside their temporary fixtures even when launched from an agent session with `CODEX_HOME` or `AGENTS_HOME` set.

`skillinstallcheck.sh` previously registered Codex hooks in the inherited home instead of its fixture. `releaseinstallcheck.sh` could detect/activate the inherited Codex installation and leave the intended fixture inactive. Overriding `HOME` alone did not isolate either gate.

Both gates now clear agent-home overrides before setting their own fixture paths. The release gate also clears inherited `RIPWIRE_NO_ACTIVATE` so its activation arms actually exercise activation.

## Regression proof

A helper runs both gates with disposable **outside** Claude/Codex/Agents/Hermes sentinel homes and checks file contents, directory entries, symlink targets and permission modes before/after. It also requires the requested binary to exist and preserves repository-relative binary paths. A chmod-only control proves permission changes are detected, then restores the original mode before exercising the installers. No real agent homes are used by this reproduction.

- Before: both gates failed their fixture assertions and changed outside sentinel homes.
- After: both gates pass and leave the outside sentinels unchanged.
- The helper is called by the existing release gate, so no new top-level gate/count updates are needed.
- The relevant installer/test changes from #51 apply cleanly and pass the same sentinel check when combined with this patch. This is overlap proof, not validation of the entire Hermes PR.

## Validation

- Development, Release and ASan builds succeed (vendored, disconnected CMake builds).
- `python3 test/installer_isolation.py build/ripwire` passes; also passes against `release/ripwire` and `asan/ripwire`.
- `python3 test/pargates.py . ./build/ripwire -j 4`: 571 gates, 567 pass, 3 skip, 1 host-dependent failure. `legendcoveragecheck.sh` includes installed host skills in its bare scan; it passes with a disposable empty home. No legend baseline or host skills were modified.
- The skipped formatting gate was rerun with `CLANG_FORMAT=<clang-format-22>`: all pass, including its mutation controls. Two optional pre-change-binary comparison gates remain skipped, as in the normal no-reference-binary workflow.
- Full-tree ASan scan exits 0 with empty stderr. Three uncached maps and three cache-backed maps are byte-identical and valid XML.
- Independent source review complete; diff and shell checks clean.

## Scope

Test environment ownership only; no runtime installer behavior, automatic hooks, installed skills, defaults, or dependency changes. Three files, one independently reversible test fix. Reverting the commit restores the old test behavior.

AI-assisted implementation and independent source review; review's relative-binary-path finding and CodeRabbit's permission-mode finding were fixed and independently rechecked. The chmod-only control was observed red before adding mode capture and green afterward.
