### PR TITLE
docs+test: "Fewer Tokens" in the headline, and readmeexamplecheck stops pinning README to live line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Runtime dependencies](https://img.shields.io/badge/runtime%20dependencies-none-blue.svg)](THIRD_PARTY.md)
 [![Slides](https://img.shields.io/badge/slides-the%20showcase%20deck-56d6e8.svg)](present/ripwire-showcase.pdf)
 
-# Rip'n Fast. Less Tokens. Better Code.
+# Rip'n Fast. Fewer Tokens. Better Code.
 
 ## Give your coding agent a map before it reads the repo.
 

--- a/README.md
+++ b/README.md
@@ -1122,7 +1122,9 @@ trailing `…`.
 <summary><code>--callers</code> — a call graph built on the spot, and why <code>count="6"</code> ships labelled a floor</summary>
 
 **Ten seconds, no index server, no embeddings, no API key** — a parse and a call graph, built on the
-spot:
+spot. The rows below are a real capture: the callers and their files are gate-held current
+(`test/readmeexamplecheck.sh`), the `:line` suffixes were true when captured and drift as the files
+grow — nothing can keep a line number true in a document, so it is not claimed here.
 
 ```
 $ ripwire . --callers=rankGraphTeleport

--- a/test/readmeexamplecheck.sh
+++ b/test/readmeexamplecheck.sh
@@ -16,13 +16,26 @@ import sys
 
 readme = open(sys.argv[1], encoding="utf-8").read()
 live = open(sys.argv[2], encoding="utf-8").read()
+# The `p=` attribute is `path:line`, so comparing it whole pinned README to LIVE LINE NUMBERS in
+# src/graph.h — and this gate's own header says its subject is the binary's PATHS. Any insertion
+# above a documented caller reddened it: it fired twice on 2026-09-09 alone, both times on two-line
+# edits that had nothing to do with the documented rows. The example's claim is WHICH callers exist
+# and WHICH FILE each lives in; a caller sliding down its own file is not a change to that claim, and
+# a gate that cannot tell the two apart trains people to re-capture on reflex. The trailing `:N` is
+# therefore stripped from BOTH sides before comparison — only a trailing colon-digits run, so a path
+# that legitimately contains a colon is untouched. What still reds, and must: a caller that has
+# vanished, been renamed, or MOVED TO A DIFFERENT FILE. README's printed line numbers are a capture
+# and say so above the block; they are not asserted here because nothing can keep them true.
+LINE_SUFFIX = re.compile(r":\d+$")
+
 rows = re.findall(r'<s t="[^"]+" n="([^"]+)" p="([^"]+)"/>', live)
 assert rows, "live callers command returned no rows"
+readme_rows = { ( n, LINE_SUFFIX.sub( "", p ) )
+                for n, p in re.findall(r'<s t="[^"]+" n="([^"]+)" p="([^"]+)"/>', readme) }
 missing = []
 for name, path in rows:
-    rendered = f'<s t="fn" n="{name}" p="{path}"/>'
-    if rendered not in readme:
-        missing.append(rendered)
-assert not missing, "README callers example has stale/missing rows:\n" + "\n".join(missing)
+    if ( name, LINE_SUFFIX.sub( "", path ) ) not in readme_rows:
+        missing.append(f'<s t="fn" n="{name}" p="{path}"/>')
+assert not missing, "README callers example has stale/missing rows (name+file compared, line ignored):\n" + "\n".join(missing)
 print("readmeexamplecheck: ALL PASS")
 PY


### PR DESCRIPTION
Two small, independent fixes. Neither adds a gate, neither touches a published count, so this lands in any gap in the delivery queue without disturbing it.

**1. The headline's middle beat was the one ungrammatical claim on the page.** `Less` takes a mass noun; tokens are countable. It is the first line a reader sees, and on a repo whose audience is engineers a prescriptive slip in the H1 reads as sloppiness rather than voice.

`Fewer` rather than `Save` because the three beats are parallel **states**, not instructions — *Rip'n Fast / Fewer Tokens / Better Code* — and `less` and `better` were both comparatives, which is part of why the line worked. `Save Tokens` would have kept the stress pattern exactly (SAVE-TO-kens for LESS-TO-kens) but turned the middle beat into the only imperative verb phrase among three descriptions; and *save* means store for later, when the claim is that you spend fewer. It costs one unstressed syllable, and `FEW-er TO-kens` stays trochaic and chimes with `BET-ter CODE` in a way `LESS TO-kens` did not.

Nothing pins the tagline: `readmedriftcheck`'s `head -1` is on the "N long flags advertised" sentence, not the H1, and `showcasecapturecheck` tests the capture generator's own formatting helpers. The three `docs/captures/` occurrences are historical records of what was extracted on those dates and are left alone.

**2. `readmeexamplecheck` said PATHS and pinned line numbers.** The gate's own header states its subject: *"README's advertised callers example must match the current binary's PATHS."* It then compared the whole `p=` attribute, and `p=` is `path:line`:

```
<s t="fn" n="rankGraph" p="src/graph.h:2984"/>
```

So it pinned the README to live line numbers in `src/graph.h`. Any insertion above a documented caller reddened it for a reason unrelated to the claim the example makes. **It fired twice on 2026-09-09 alone**, both times on two-line edits to `graph.h` that touched none of the documented rows — once when `ChaConeMemo` was inserted, again when that memo's `Cone` was changed from a pointer to an index. A gate that cannot distinguish *"this caller moved to another file"* from *"this caller slid down its own file"* trains people to re-capture on reflex, which is how a real red eventually gets waved through.

The trailing `:N` is now stripped from both sides before comparison — only a trailing colon-digits run, so a path that legitimately contains a colon is untouched. Verified from bash, all three ways:

| mutation | result | |
| --- | --- | --- |
| line `2984` → `9999` | **GREEN** | tolerated — the point of the change |
| `src/graph.h` → `src/pagerank.cpp` | **RED** | a caller in the wrong file |
| `anchoredLexicalRank` renamed | **RED** | a caller that no longer exists |

That trade would have left the README's printed line numbers drifting unwatched, so they are no longer presented as a live claim: the block now says the rows are a capture, that the callers and their files are gate-held, and that the `:line` suffixes were true when captured. Honesty by disclosure rather than by fabricating a row the tool never emits (stripping `:N` from the document) or by regenerating the block on every unrelated edit to `graph.h`.

CI: [run 34381907817](https://github.com/redhat-et/ripwire/actions/runs/34381907817) — 26/26 green on `055cb100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
