### PR TITLE
docs(readme): state the goal — one question, one complete answer, and the two stair-steps toward it

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ around and reading whole files.
 
 ***Paddle out with a map.***
 
+### The goal: one question, one complete answer.
+
+**Terminality is the objective.** Ask the codebase a question and the answer should carry everything
+you need — no follow-on grep, no three more whole-file reads to fill in what it left out. A call
+followed by three greps is the same search paid for twice: it does not save you tokens and it does
+not make the coding faster.
+
+**Two things make that reachable in practice, and neither is the destination.** Answers are honest
+about their own limits — a count that cannot be a total is labelled a floor, a zero means "none
+found" and never "none exists", every truncation is disclosed — so an answer never looks more
+complete than it is, and the map never degrades the code by guessing. And an answer can be given a
+token budget, so what one costs is something you ask for rather than discover; where a complete
+answer will not fit, it says it went over rather than silently dropping the row you needed.
+
+Those two are the stair-steps: honest about what is missing, priced in what it spends. The step they
+climb toward is a question fully answered in one call, which is not always trivial to reach — and
+where it is not, the output says so rather than pretending otherwise.
+
 <details>
 <summary><b>Fifty years of software-engineering results, and research from last month.</b> 46 repositories and 69 papers folded — McCabe (1976) through to <b>seven papers published in the last two months</b> — each row in <a href="docs/LINEAGE.md"><b>docs/LINEAGE.md</b></a> naming the lesson taken and the file it lives in, all of it put into a single blazing-fast compiled executable</summary>
 


### PR DESCRIPTION
The page said what ripwire *does* and never said what it is *for*. This is the objective in a reader's terms rather than a maintainer's — terminality, and the two properties that make it reachable in practice — placed above the fold, after the pitch and before the lineage block.

```
### The goal: one question, one complete answer.

**Terminality is the objective.** Ask the codebase a question and the answer should carry everything
you need — no follow-on grep, no three more whole-file reads to fill in what it left out. A call
followed by three greps is the same search paid for twice: it does not save you tokens and it does
not make the coding faster.

**Two things make that reachable in practice, and neither is the destination.** Answers are honest
about their own limits — a count that cannot be a total is labelled a floor, a zero means "none
found" and never "none exists", every truncation is disclosed — so an answer never looks more
complete than it is, and the map never degrades the code by guessing. And an answer can be given a
token budget, so what one costs is something you ask for rather than discover; where a complete
answer will not fit, it says it went over rather than silently dropping the row you needed.

Those two are the stair-steps: honest about what is missing, priced in what it spends. The step they
climb toward is a question fully answered in one call, which is not always trivial to reach — and
where it is not, the output says so rather than pretending otherwise.
```

**Deliberately not written as a hard cap.** An earlier draft said *"answers are bounded, so a complete answer cannot cost you the context it was supposed to protect"*, which is false by the tool's own design: `docs/METHODOLOGY.md` §9 principle 2 exceeds the ceiling with `over_ceiling="1"` rather than drop the row that would have terminated the search. A hard-cap claim would also have undercut the terminality paragraph directly above it. It reads instead as a budget you ask for with disclosed overshoot — true, and the stronger form of the point.

**Two other claims pulled back to what is actually true.** *"An answer never looks more complete than it is"* rather than *"never a confident wrong one"* — the honesty attributes stop an answer overstating itself; they do not make the resolver infallible, which is what `amb="K"` exists to disclose. And *"an answer **can** be given a token budget"* rather than every answer being bounded, since the flag table carries `honorsMaxTokens` per verb.

**Sequenced behind #61.** The overshoot sentence is the contract and `over_ceiling` ships, but #61 was an open bug against that contract on the `--for --detail` path — `max_tokens` was named and applied to the bodies only. This lane was held until [#77](https://github.com/redhat-et/ripwire/pull/77) landed and #61 closed, so the claim is true of the shipped tool rather than aspirational.

No counts, no flag names, no published number — nothing here collides with a gate-count site or the absorb line.

CI: [run 34413952370](https://github.com/redhat-et/ripwire/actions/runs/34413952370) — 26/26 green on `86612185`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
