### PR TITLE
docs(readme): the surf line gets the brand cyan and a board at each end

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 deterministic call graph — what to touch, what it breaks, which tests to run — instead of grepping
 around and reading whole files.
 
-***Paddle out with a map.***
+<p align="center"><img src="docs/assets/paddle-out.svg" alt="Paddle out with a map." width="470"></p>
 
 ### The goal: one question, one complete answer.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Fourteen entries, each written for one reader. Start with the row that matches w
 | **[`LINEAGE.md`](LINEAGE.md)** | Anyone asking what is actually new here | Every idea folded into the tool, row by row: the paper, specification or repository it came from, the one-line lesson taken, and the flag or source file where that lesson lives — plus the labelled survey of the wider field, kept explicitly separate from what was borrowed. |
 | **[`docs_commands_build.py`](docs_commands_build.py)** | Maintainers | The generator behind `COMMANDS.md`. Reads the binary's `--help` and a recorded showcase capture; `--check` is the drift comparison that `test/docscommandscheck.sh` runs. |
 | **[`lineage-paper-dates.tsv`](lineage-paper-dates.tsv)** | Maintainers | arXiv id -> publication date for every 2026 paper in `LINEAGE.md`. The ID stem does not track the date (`2607.09691` was published 2026-06-19), so the README's recency claim is re-derived from this file by `readmedriftcheck.sh` arm (H2) rather than from the ids. Adding a 2026 paper without a date row fails that arm. |
-| **[`assets/`](assets/)** | The front page | The README banner artwork (SVG, self-contained). |
+| **[`assets/`](assets/)** | The front page | The README banner and tagline artwork (SVG, self-contained). |
 | **[`captures/`](captures/)** | Maintainers, and the curious | One recorded run of every verb against a real repository — the source of `COMMANDS.md`'s sample output, and the harvest source for the differential argv harness. |
 
 Outside this directory:

--- a/docs/assets/paddle-out.svg
+++ b/docs/assets/paddle-out.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="470" height="52" viewBox="0 0 470 52" role="img" aria-label="Paddle out with a map.">
+  <title>Paddle out with a map.</title>
+  <g transform="translate(18 26) rotate(-24)">
+    <ellipse cx="0" cy="0" rx="19" ry="6.4" fill="#56D6E8"/>
+    <path d="M -19 0 L 19 0" stroke="#0D1117" stroke-width="1.1" opacity="0.55"/>
+    <path d="M 12 3.2 L 15 8.4" stroke="#F2B84B" stroke-width="2.2" stroke-linecap="round"/>
+  </g>
+  <text x="235" y="34" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif"
+        font-size="30" font-style="italic" font-weight="600" fill="#56D6E8">Paddle out with a map.</text>
+  <g transform="translate(452 26) scale(-1 1) rotate(-24)">
+    <ellipse cx="0" cy="0" rx="19" ry="6.4" fill="#56D6E8"/>
+    <path d="M -19 0 L 19 0" stroke="#0D1117" stroke-width="1.1" opacity="0.55"/>
+    <path d="M 12 3.2 L 15 8.4" stroke="#F2B84B" stroke-width="2.2" stroke-linecap="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
`README:18` carried `***Paddle out with a map.***` in default body text, while the banner three lines above rendered the same words in `#56D6E8` italic. It is the closing beat of the pitch and read like an afterthought.

It is now an SVG asset at 30px — nearly double the banner's 16 — in the banner's own cyan, with a surfboard at each end. The right board is a true mirror (`scale(-1 1)`) rather than a rotated copy, so both fins point outward and the pair brackets the line instead of drifting the same way. The fin picks up the banner's amber (`#F2B84B`), so the mark uses all three brand colours and introduces none.

**An image rather than markup, because GitHub sanitises inline `style` out of a README.** `<span style="color:…">` does nothing there, so colour means an image or the LaTeX-math trick — and the repo already embeds `banner.svg` exactly this way.

**Vector, not an emoji.** Emoji inside SVG renders through the host's font and goes inconsistent across platforms; a path always renders.

**Transparent background**, so it reads on both GitHub themes. The banner is a fixed dark plate; this does not need to be.

**Costs, stated rather than discovered later:** the text is no longer selectable, and plain-text renderers that strip images lose the line. `<title>` and `aria-label` carry it for screen readers. That is the price of colour on this surface — there is no way to have both.

The banner keeps its own small version deliberately: different size, same words, read as a motif rather than a repeat.

`docs/README.md` indexes `assets/` as a directory, so `ripwirepubliccheck` arm 6b is satisfied without a new row — its description moves from "banner artwork" to "banner and tagline artwork" so the index does not quietly become wrong.

CI: [run 34425989276](https://github.com/redhat-et/ripwire/actions/runs/34425989276) — 26/26 green on `9fd034c6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
