### PR TITLE
perf(2b): the include closure's sort goes radix — and three sites that must not

### DIFF
--- a/bench/PROFILE.md
+++ b/bench/PROFILE.md
@@ -1370,3 +1370,158 @@ build_prof/ripwire <scratch>/rails --callers=main >/dev/null 2>prime.err   # war
 pack — about 12 hours — and was abandoned. Every number above is from a corpus that fits the link. The
 consequence is stated rather than buried: R1's refutation is proved up to 15,868 files and an 8×-multiplicity
 14,072-file tree, and not beyond.
+
+## 2026-09-09 — the 2b closure sort goes radix: one site converted, three refused, and the crossover that does not transfer
+
+LEDGER rows, never a gate (the no-perf-budget rule). The correctness gate this round landed is four new
+arms in `test/includeprecisecheck.sh`; they assert sets and invariants, never seconds.
+
+This picks up open item 1 from the loop-hoist sweep above: **`buildGraph/2b` at 61.9 ms on `rails`, of
+which 38.7 ms is `std::sort`**, over 3,916 closures averaging 1,020 ids, with a `std::unique` that removed
+0 duplicates. The owner's read was that those sorts should be radix. They should — at exactly one of the
+four sites that looked like candidates, and the three refusals are the more useful half of the result.
+
+### The recorded crossover is 2048, and honouring it literally would have forfeited the entire win
+
+`src/infra/sortutil.h` already carries a measured threshold — `kRadixThreshold = 2048` — on both
+`radixSortByFromTo` and `radixSortByScoreDescId`. The 2b closures top out at **n = 1,420**. Routed through
+that number, every single one takes the `std::sort` branch and the change does nothing.
+
+That 2048 is not wrong; it describes **different work**. `radixSortByFromTo` moves 12-byte `Edge` RECORDS
+through two full key passes. `radixSortByScoreDescId` pays a `scores[id]` GATHER, up to two `sortKeySmall`
+calls and three O(n) prechecks. 2b sorts a `std::vector<NodeId>` — one 4-byte item, one direct key — and
+because file ids span 12 bits on `rails`, the no-op pass skip in `sortKeySmall` collapses it to **two
+passes, not four**. Re-measured for that shape (`-O2 -mcpu=apple-m1 -ffast-math`, medians of 15 interleaved
+reps, random keys, ratio = radix / std::sort, <1 means radix faster):
+
+| key range | n=32 | n=64 | n=128 | n=256 | n=1024 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 12-bit (`rails`, F=3,916) | 2.31x | 0.86x | 0.47x | 0.21x | 0.18x |
+| 14-bit (`go`, F=15,868) | 1.71x | 0.85x | 0.46x | 0.31x | 0.17x |
+| 16-bit | 1.79x | 0.85x | 0.47x | 0.26x | 0.18x |
+| 20-bit | 2.46x | 1.22x | 0.64x | 0.40x | 0.23x |
+| 32-bit (full) | 4.16x | 1.50x | 0.73x | 0.45x | 0.25x |
+
+The crossover for this shape is **64 for narrow keys and 128 for a full 32-bit range**. The new entry point
+`rw::sortutil::radixSortIdsAscending` takes **128** — the crossover of the widest range measured, so the
+door holds whichever way the id range turns out — and its comment says at length why it is not 2048, so
+nobody unifies the two numbers later.
+
+### The threshold is what makes the change safe, not a nicety
+
+Replaying the REAL captured closures (every `trans[s]` written to disk, replayed against both sorts,
+medians of 15 interleaved reps). "radix always" is the unthresholded conversion:
+
+| corpus | Σ closure | max n | std::sort | radix T=128 | radix ALWAYS |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `rails` | 3,994,331 | 1,420 | 42.01 ms | **11.44 ms (0.272x)** | 11.50 ms |
+| private C++ (3,248 files) | 12,066 | 149 | 0.048 ms | 0.042 ms (0.865x) | 0.372 ms (**7.7x worse**) |
+| this repo | 4,182 | 137 | 0.018 ms | 0.017 ms (0.960x) | 0.052 ms (**2.9x worse**) |
+| `django` | 1,578 | 19 | 0.010 ms | 0.010 ms (0.958x) | 0.079 ms (**7.9x worse**) |
+| `rust-analyzer` | 640 | 43 | 0.0045 ms | 0.0044 ms (0.991x) | 0.021 ms (**4.7x worse**) |
+| `go` | 26 | 2 | 0.021 ms | 0.021 ms (1.000x) | 0.021 ms |
+
+An unconditional conversion regresses four of six corpora by 3–8x. With the threshold, no corpus regresses
+and `rails` gains 3.7x. **`rails` is the only corpus where this phase is large at all** — Σ|closure| there is
+331x the next-biggest — which is the loop-hoist round's own lesson repeating: this is a Ruby `require`-graph
+shape, and a C++/Go/Python corpus cannot see it.
+
+### In situ — `buildGraph/2b`, warm, interleaved A,B
+
+| corpus | base | radix | ratio |
+| --- | ---: | ---: | ---: |
+| `rails` (n=7) | min 64.97 med 65.21 ms | **min 34.73 med 35.01 ms** | **0.537** |
+| `go` (n=5) | 0.029 ms | 0.026 ms | (sub-ms, jitter) |
+| `django` (n=5) | 0.048 ms | 0.047 ms | (sub-ms, jitter) |
+| `rust-analyzer` (n=5) | 0.022 ms | 0.023 ms | (sub-ms, jitter) |
+| private C++ (n=5) | 0.289 ms | 0.300 ms | (sub-ms, jitter) |
+| this repo (n=5) | 0.097 ms | 0.101 ms | (sub-ms, jitter) |
+
+The `rails` reps do not overlap: base 65.0 65.0 65.1 65.2 65.3 65.4 65.5, radix 34.7 34.8 34.9 35.0 35.0
+35.2 35.7. `buildGraph` total on `rails`: 223.0 → 186.7 ms median (−16%); `go` 1.000x, private C++ 0.995x.
+
+Whole run, two independent n=21 interleaved A/Bs each:
+
+| run | median | min |
+| --- | ---: | ---: |
+| `rails --callers=main` | **−7.8% / −8.5%** | −8.8% / −9.1% |
+| `rails` default map | **−7.6% / −7.3%** | −8.2% / −7.6% |
+| `go` / `django` / `rust-analyzer` / private C++ / this repo (n=15 each) | −0.6% / −0.5% / −0.8% / +0.1% / +0.5% | all within ±1.7% |
+
+Byte-identical on six corpora × three verbs (default map, `--callers=main`, `--impact=main`): 18
+comparisons, 18 distinct output sizes proving the corpus argument took effect in every one.
+
+### The `std::unique` was dead, and it is dead by construction rather than by luck
+
+`w` is appended to `trans[s]` inside the same branch that stamps `seenEpoch[w] = epoch`, and nothing clears
+that stamp before `++epoch`. A file therefore reaches `trans[s]` **at most once per source** — the set is
+duplicate-free by construction, not by coincidence. Measured: **0 duplicates removed in 24,216 calls across
+six corpora**, costing **0.992 ms on `rails`** (independently reproducing the 0.98 ms recorded above).
+
+It is removed. The sibling `ancestorsReach` in `graph.h` has always relied on this same epoch stamp with no
+dedup, so this makes two walks agree rather than introducing a new assumption. It is NOT replaced by a
+`VERIFY`: in a release build `VERIFY_TEXT` still evaluates its expression before `__builtin_unreachable`, so
+an O(n) uniqueness scan there would reintroduce exactly the cost being removed. The invariant is asserted by
+a gate instead (below), which costs nothing at runtime.
+
+**The sort itself stays, and the reason is non-negotiable #2.** It is not merely making membership a
+`binary_search` — the walk's discovery order is deterministic but is NOT id order, so the sort is what makes
+`trans` a pure function of `adj`, exactly as this function's header comment claims. Radix only changes how
+it is paid for. Attribution of the 30.2 ms: ~30.6 ms is the sort, 0.99 ms is the dedup.
+
+### Three sites REFUSED — and the mechanism is presortedness, not size
+
+`g.implementors[]`, `g.mentions[]` (`graph.h`) and the CHA cone/ancestor closures were the other candidates.
+Measured on captured real data, thresholded exactly as 2b is:
+
+| site | corpus | Σ | max n | duplicates | radix T=128 |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `implementors` | `django` | 646,700 | 2,401 | 0 | **2.87x WORSE** |
+| `implementors` | `rails` | 7 | 3 | 0 | 1.00x |
+| `mentions` | `rails` | 73,948 | 79 | 18,732 | 0.89x |
+| `mentions` | private C++ | 51,188 | 116 | 8,622 | 0.93x |
+| `chacone` | `django` | 2,195 | 335 | 100 | 0.83x (of 0.008 ms) |
+| `chaanc` | `rust-analyzer` | 3,326 | 27 | 0 | 0.98x |
+
+`django`'s `implementors` is the interesting refusal: Σ = 646,700 with a max of 2,401 looks like the ideal
+radix case and loses badly. The reason is that **100.0% of its 47,830 records arrive already sorted, with
+zero adjacent descents** — they are built by `push_back` while iterating references in ascending id order.
+`std::sort` detects that in O(n); radix cannot exploit it and pays both passes regardless. `rails`'
+`mentions` is 100.0% presorted for the same reason. 2b is the odd one out at **1.6% presorted** (0.18
+adjacent descents per element) because a graph walk emits in discovery order.
+
+So the rule that decided all four sites is not "how big is n" but **"was this set built by appending in id
+order, or by a scattered walk?"** — and it is now written into `radixSortIdsAscending`'s comment, because it
+is the thing a future caller will get wrong. The remaining sites' absolute costs (0.008–0.6 ms) would not
+have justified the churn even had they won.
+
+### The gate, and the arm that proved the fixture could not see the defect
+
+`test/includeprecisecheck.sh` gained: a postcondition sweep asserting every `trans[f]` is sorted AND
+duplicate-free; a **diamond** fixture (`diamond/top.h` → `left.h`+`right.h` → both → `shared.h`) asserting
+`shared.h` appears exactly once despite two distinct paths; a **cycle** fixture (`cyc/p.h` ↔ `cyc/q.h`); and
+a **400-node synthetic** arm checked element-for-element against an independent mark-and-sweep oracle.
+
+The synthetic arm is not decoration. Two mutation controls were run:
+
+| mutation | fixture arms | large-N arm |
+| --- | --- | --- |
+| delete the sort | **all PASS** | FAIL (sorted + oracle) |
+| append without the epoch guard | uniqueness + diamond FAIL | FAIL (unique + oracle) |
+
+**With the sort deleted entirely, every fixture-based arm stayed green** — the fixture's closures are all
+under ten elements and its discovery order happens to be ascending, so it is a population that cannot
+contain the defect (CONTRIBUTING.md §2, shape 1). Only the scrambled 400-node graph, whose closures exceed
+the 128 threshold and whose discovery order is nowhere near sorted, can fail. It also carries an explicit
+non-vacuity assertion that at least one synthetic closure exceeds the radix threshold, so the radix branch
+cannot silently stop being exercised.
+
+### Reproduce
+
+```
+cmake -S . -B build_prof -DRIPWIRE_PROFILE=ON && cmake --build build_prof -j
+export TMPDIR=<scratch>/tmp-rails; mkdir -p "$TMPDIR"
+build_prof/ripwire <scratch>/rails --callers=main >/dev/null 2>prime.err   # warm prime, then re-run
+# the stderr "hottest scopes" table is the phase split; buildGraph/2b is the closure.
+# Take the MIN over >=5 interleaved A,B reps — this box ran 1-minute loads of 5-19 across the session.
+```

--- a/bench/PROFILE.md
+++ b/bench/PROFILE.md
@@ -1495,6 +1495,15 @@ order, or by a scattered walk?"** — and it is now written into `radixSortIdsAs
 is the thing a future caller will get wrong. The remaining sites' absolute costs (0.008–0.6 ms) would not
 have justified the churn even had they won.
 
+**Also noted, not attempted: the two `std::vector<std::string>` sorts** at `graph.h:1886-1887` (the
+`chaUp` / `chaDown` dedup). A string radix is a materially bigger change than an id radix — variable-length
+keys, no fixed pass count, and the whole `sortKeySmall` contract assumes a scalar key — so it was scoped
+out rather than rushed. The number that says it can wait: those two lines live inside `buildGraph/2h`, and
+that WHOLE phase (name-graph construction, interning and both sorts together) measures **0.70 ms on `rails`,
+3.69 ms on `django`, 1.93 ms on `go`, 0.90 ms on `rust-analyzer`, 0.50 ms on a private C++ tree** — a 4.5%
+ceiling on `django`'s `buildGraph` and under 1.2% everywhere else, with the sorts themselves only a fraction
+of it. It never appeared in the loop-hoist phase table because it never cleared the reporting threshold.
+
 ### The gate, and the arm that proved the fixture could not see the defect
 
 `test/includeprecisecheck.sh` gained: a postcondition sweep asserting every `trans[f]` is sorted AND

--- a/src/infra/sortutil.h
+++ b/src/infra/sortutil.h
@@ -163,6 +163,49 @@ inline void radixSortByScoreDescId( std::vector<std::uint32_t>& order, const std
     radixSortByScoreDescId( order, scores, scratch );
 }
 
+// Ascending sort for a dense set of 32-bit ids held in a plain vector, radix above a size
+// threshold and std::sort below it. `scratch` is caller-owned so a loop over many sets pays one growth
+// instead of one allocation per set.
+//
+// THE THRESHOLD IS 128 AND NOT THE 2048 THE TWO ENTRY POINTS BELOW USE. That is deliberate, and the two
+// numbers must not be unified — they describe different work. Measured 2026-09-09 on Apple Silicon,
+// `-O2 -mcpu=apple-m1 -ffast-math`, medians of 15 interleaved reps over random keys, ratio = radix/std
+// (<1 means radix is faster):
+//
+//     key range        n=32    n=64    n=128   n=256   n=1024
+//     12-bit           2.31x   0.86x   0.47x   0.21x   0.18x
+//     16-bit           1.79x   0.85x   0.47x   0.26x   0.18x
+//     32-bit           4.16x   1.50x   0.73x   0.45x   0.25x
+//
+// 2048 is honest for what it guards: `radixSortByFromTo` moves 12-byte Edge RECORDS through two full key
+// passes, and `radixSortByScoreDescId` pays a `scores[id]` GATHER plus up to two sortKeySmall calls and
+// three O(n) prechecks before it sorts anything. This entry point does none of that — one 4-byte item,
+// one direct key, and a narrow id range lets the no-op pass skip collapse it to two passes — so its
+// crossover sits two powers of two lower. 128 is the crossover of the WIDEST key range measured, so the
+// door holds whichever way the id range turns out.
+//
+// ONE CALLER-SHAPE CAVEAT, and it decided two of this round's four candidate sites: radix cannot exploit
+// a pre-sorted input and std::sort can. A set built by appending in ascending-id order arrives ~100%
+// sorted, where std::sort is O(n) and radix still pays both passes — such a caller belongs on the
+// std::sort side of this door at ANY n. Only a set built in scattered discovery order (a graph walk)
+// should come here. bench/PROFILE.md carries the per-site measurements.
+inline void radixSortIdsAscending( std::vector<std::uint32_t>& values, std::vector<std::uint32_t>& scratch )
+{
+    constexpr std::size_t kRadixThreshold = 128;
+    const std::size_t count = values.size();
+    if( count < kRadixThreshold )
+    {
+        std::sort( values.begin(), values.end() );
+        return;
+    }
+
+    if( scratch.size() < count )
+    {
+        scratch.resize( count );
+    }
+    radix::sortKeySmall( values.data(), scratch.data(), count, []( std::uint32_t id ) noexcept { return id; } );
+}
+
 template<class Edge>
 inline bool lessByFromTo( const Edge& a, const Edge& b ) noexcept
 {

--- a/src/resolve.h
+++ b/src/resolve.h
@@ -48,6 +48,7 @@
 #include "model.h"
 #include "arch.h"        // §B1.3: relForHash — the root-relative path segment canonicalIdRelTo keys on
 #include "smallvec.h"
+#include "infra/sortutil.h"      // radixSortIdsAscending — the id-set sort buildGraph/2b below runs F times
 #include "infra/profileScope.h"  // PROFILE_SCOPE self-profiling — gated by PROFILE_ENABLED (off unless -DRIPWIRE_PROFILE=ON)
 
 #include <algorithm>
@@ -1889,6 +1890,7 @@ inline std::vector<std::vector<NodeId>> transitiveIncludeSet( const std::vector<
     std::vector<std::vector<NodeId>> trans( F );
     std::vector<std::uint32_t>   seenEpoch( F, 0 );
     std::vector<std::uint32_t>   stack;
+    std::vector<NodeId>          sortScratch;   // radix ping-pong buffer, reused across all F closures
     stack.reserve( F );
     std::uint32_t                epoch = 1;
     for( std::uint32_t s = 0; s < F; ++s )
@@ -1907,9 +1909,21 @@ inline std::vector<std::vector<NodeId>> transitiveIncludeSet( const std::vector<
                 }
             }
         }
-        // …trans[s] already excludes s (never pushed as a reachable target). Sort+dedup for binary search.
-        std::sort( trans[s].begin(), trans[s].end() );
-        trans[s].erase( std::unique( trans[s].begin(), trans[s].end() ), trans[s].end() );
+        // …trans[s] already excludes s (never pushed as a reachable target). Sorted for the binary_search
+        // in rule3IncludeFile, and for the determinism contract in this function's header comment — the
+        // walk's discovery order is deterministic but is NOT id order, so the sort is what makes the
+        // result a pure function of `adj`. It stays; only its implementation changes.
+        //
+        // NO DEDUP PASS. `w` is appended in the same branch that stamps `seenEpoch[w] = epoch`, and
+        // nothing clears that stamp before `++epoch` below, so a file can be appended to trans[s] at most
+        // once per source — the set is duplicate-free BY CONSTRUCTION. The `std::unique` that used to sit
+        // here removed 0 elements in 24,216 calls across six corpora (rails, go, django, rust-analyzer, a
+        // private C++ tree, this repo) at a measured 0.99 ms on rails. Its sibling `ancestorsReach` in
+        // graph.h has always relied on this same stamp without a dedup. The invariant is now asserted by
+        // test/includeprecisecheck.sh — a diamond fixture (two distinct paths to one file) plus a 400-node
+        // scrambled synthetic graph checked against an independent mark-sweep oracle — rather than paid
+        // for on every call.
+        rw::sortutil::radixSortIdsAscending( trans[s], sortScratch );
         ++epoch;
     }
     return trans;

--- a/test/includeprecise_unit.cpp
+++ b/test/includeprecise_unit.cpp
@@ -9,6 +9,7 @@
 #include "../src/ingest.h"
 #include "../src/resolve.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <string>
 #include <string_view>
@@ -99,6 +100,118 @@ int main( int argc, char** argv )
     check( !has( trans[aH], aH ), "transitive closure: a.h does NOT include itself" );
     check( has( trans[bH], cH ) && !has( trans[bH], aH ),
            "transitive closure: b.h reaches c.h but not a.h (direction respected)" );
+
+    // ── (d2) POSTCONDITION over EVERY closure: sorted ascending, and duplicate-free ──────────────
+    // `trans[f]` is consumed by std::binary_search (rule3IncludeFile), so ASCENDING ORDER is the
+    // contract, not a nicety. Duplicate-freedom is the separate invariant the epoch stamp in the walk
+    // already guarantees — asserted here so that guarantee is checked by a gate rather than assumed by
+    // a reader. Both arms run over every file in the fixture, including the diamond and the cycle below.
+    {
+        bool allSorted = true, allUnique = true;
+        std::size_t worstFile = 0;
+        for( std::size_t f = 0; f < trans.size(); ++f )
+        {
+            if( !std::is_sorted( trans[f].begin(), trans[f].end() ) )
+            {
+                allSorted = false; worstFile = f;
+            }
+            if( std::adjacent_find( trans[f].begin(), trans[f].end() ) != trans[f].end() )
+            {
+                allUnique = false; worstFile = f;
+            }
+        }
+        check( allSorted, "closure postcondition: EVERY trans[f] is sorted ascending (binary_search contract)" );
+        check( allUnique, "closure postcondition: EVERY trans[f] is duplicate-free (epoch-stamp invariant)" );
+        (void)worstFile;
+    }
+
+    // ── (d3) DIAMOND: two distinct paths reach the same file — the duplicate-producing shape ──────
+    // diamond/top.h includes left.h and right.h; BOTH include shared.h. A walk without the epoch stamp
+    // would append shared.h twice. This is the population that makes the uniqueness arm above non-vacuous.
+    {
+        const std::uint32_t top    = fileEndingWith( ing, "includeprecisefix/diamond/top.h" );
+        const std::uint32_t left   = fileEndingWith( ing, "includeprecisefix/diamond/left.h" );
+        const std::uint32_t right  = fileEndingWith( ing, "includeprecisefix/diamond/right.h" );
+        const std::uint32_t shared = fileEndingWith( ing, "includeprecisefix/diamond/shared.h" );
+        check( top < trans.size() && left < trans.size() && right < trans.size() && shared < trans.size(),
+               "diamond fixture located (top/left/right/shared)" );
+        if( top < trans.size() && shared < trans.size() )
+        {
+            const std::size_t sharedCount = std::size_t( std::count( trans[top].begin(), trans[top].end(), NodeId( shared ) ) );
+            check( sharedCount == 1, "diamond: top.h reaches shared.h EXACTLY ONCE despite two distinct paths" );
+            check( has( trans[top], left ) && has( trans[top], right ), "diamond: top.h reaches both left.h and right.h" );
+        }
+    }
+
+    // ── (d4) CYCLE: mutually-including headers terminate, and neither lands in its own set ────────
+    {
+        const std::uint32_t pH = fileEndingWith( ing, "includeprecisefix/cyc/p.h" );
+        const std::uint32_t qH = fileEndingWith( ing, "includeprecisefix/cyc/q.h" );
+        check( pH < trans.size() && qH < trans.size(), "cycle fixture located (cyc/p.h, cyc/q.h)" );
+        if( pH < trans.size() && qH < trans.size() )
+        {
+            check( has( trans[pH], qH ) && has( trans[qH], pH ), "cycle: p.h and q.h each reach the other" );
+            check( !has( trans[pH], pH ) && !has( trans[qH], qH ), "cycle: neither file lands in its OWN closure" );
+        }
+    }
+
+    // ── (d5) LARGE-N arm: closures above the radix threshold, against an INDEPENDENT oracle ───────
+    // THE FIXTURE CANNOT REACH THIS CODE PATH. Every closure above is under ten elements, so a
+    // size-routed sort inside transitiveIncludeSet would take its small-input branch on all of them and
+    // the large-input branch would be gated by nothing at all (CONTRIBUTING.md §2, shape 1: a population
+    // that cannot contain the defect). transitiveIncludeSet is a pure function of `adj`, so this arm
+    // hands it a synthetic 400-node graph directly. The adjacency is a deliberately SCRAMBLED expander
+    // (i*7+13, i*29+5, i*101+61 mod N) so discovery order is nowhere near sorted order — a chain would
+    // arrive pre-sorted and prove nothing about the sort at all. The oracle is an independent
+    // mark-and-sweep reachability, written differently from the code under test.
+    {
+        constexpr std::uint32_t N = 400;
+        std::vector<std::vector<std::uint32_t>> synth( N );
+        for( std::uint32_t i = 0; i < N; ++i )
+        {
+            synth[i] = { ( i * 7 + 13 ) % N, ( i * 29 + 5 ) % N, ( i * 101 + 61 ) % N };
+            std::sort( synth[i].begin(), synth[i].end() );
+            synth[i].erase( std::unique( synth[i].begin(), synth[i].end() ), synth[i].end() );
+        }
+        const auto got = transitiveIncludeSet( synth );
+
+        bool bigEnough = false, matches = true, sortedAll = true, uniqueAll = true;
+        std::size_t maxClosure = 0;
+        for( std::uint32_t s0 = 0; s0 < N; ++s0 )
+        {
+            // independent oracle: iterate-to-fixpoint mark sweep, then materialise ascending by scan.
+            std::vector<char> reach( N, 0 );
+            reach[s0] = 2;                              // 2 = seed (excluded from the answer)
+            bool changed = true;
+            while( changed )
+            {
+                changed = false;
+                for( std::uint32_t v = 0; v < N; ++v )
+                {
+                    if( reach[v] == 0 ) { continue; }
+                    for( std::uint32_t w : synth[v] )
+                    {
+                        if( reach[w] == 0 ) { reach[w] = 1; changed = true; }
+                    }
+                }
+            }
+            std::vector<std::uint32_t> want;
+            for( std::uint32_t v = 0; v < N; ++v ) { if( reach[v] == 1 ) { want.push_back( v ); } }
+
+            const std::vector<NodeId>& have = got[s0];
+            maxClosure = std::max( maxClosure, have.size() );
+            if( have.size() >= 128 ) { bigEnough = true; }
+            if( !std::is_sorted( have.begin(), have.end() ) ) { sortedAll = false; }
+            if( std::adjacent_find( have.begin(), have.end() ) != have.end() ) { uniqueAll = false; }
+            if( have.size() != want.size() ) { matches = false; }
+            else { for( std::size_t k = 0; k < want.size(); ++k ) { if( have[k] != want[k] ) { matches = false; break; } } }
+        }
+        std::printf( "  INFO  synthetic closure max=%zu (radix path needs >=128)\n", maxClosure );
+        check( bigEnough,  "large-N arm is NON-VACUOUS: at least one synthetic closure exceeds the radix threshold" );
+        check( sortedAll,  "large-N: every synthetic closure is sorted ascending" );
+        check( uniqueAll,  "large-N: every synthetic closure is duplicate-free" );
+        check( matches,    "large-N: every synthetic closure equals an INDEPENDENT mark-sweep oracle, element for element" );
+    }
 
     // ── determinism: build the set twice, identical ──────────────────────────────────────────────
     const auto trans2 = transitiveIncludeSet( buildPreciseIncludeAdj( ing ) );

--- a/test/includeprecisefix/cyc/p.h
+++ b/test/includeprecisefix/cyc/p.h
@@ -1,0 +1,2 @@
+#include "q.h"
+int p_fn( void );

--- a/test/includeprecisefix/cyc/q.h
+++ b/test/includeprecisefix/cyc/q.h
@@ -1,0 +1,2 @@
+#include "p.h"
+int q_fn( void );

--- a/test/includeprecisefix/diamond/left.h
+++ b/test/includeprecisefix/diamond/left.h
@@ -1,0 +1,2 @@
+#include "shared.h"
+int left_fn( void );

--- a/test/includeprecisefix/diamond/right.h
+++ b/test/includeprecisefix/diamond/right.h
@@ -1,0 +1,2 @@
+#include "shared.h"
+int right_fn( void );

--- a/test/includeprecisefix/diamond/shared.h
+++ b/test/includeprecisefix/diamond/shared.h
@@ -1,0 +1,1 @@
+int shared_fn( void );

--- a/test/includeprecisefix/diamond/top.h
+++ b/test/includeprecisefix/diamond/top.h
@@ -1,0 +1,3 @@
+#include "left.h"
+#include "right.h"
+int top_fn( void );


### PR DESCRIPTION
One sort converted to radix, **three refused with numbers**, and one dead `std::unique` removed. The refusals are the useful half.

## The conversion

`transitiveIncludeSet` — `buildGraph/2b`, the transitive include closure — was the single largest phase on a Ruby corpus, and **38.7 ms of its ~62 ms was one `std::sort`** over 3,916 runs averaging 1,020 elements, sorted only so a membership test could be a `binary_search`.

| on `rails` | before | after | |
| --- | --- | --- | --- |
| `buildGraph/2b` | 65.21 ms | **35.01 ms** | −46%, n=7 interleaved, reps do not overlap |
| `buildGraph` total | 223.0 ms | **186.7 ms** | −16% |
| `--callers=main`, whole run | | | **−7.8% / −8.5%** median, two independent n=21 A/Bs |
| default map, whole run | | | −7.6% / −7.3% median |

Five control corpora, n=15 each: within **±1.7%**, no regression in either direction.

## The threshold is what makes it safe

Unthresholded, the same conversion **regresses** a private C++ tree 7.7×, django 7.9×, rust-analyzer 4.7×. `rails` is a genuine outlier — its Σ|closure| is **331× the next corpus** — because this is a Ruby `require`-graph shape that no C++/Go/Python corpus can produce.

`sortutil.h` already carried a measured `kRadixThreshold = 2048`, and **honouring it literally would have forfeited the entire win**: 2b's closures top out at n=1,420, so every one takes the `std::sort` branch. 2048 is not wrong — it guards *different work*. It bounds 12-byte `Edge` records through two key passes plus a `scores[id]` gather. 2b sorts a `vector<NodeId>`: one 4-byte item, one direct key, and a **12-bit id range, so the no-op pass skip collapses it to 2 passes, not 4**. Re-measured (ratio radix/std, <1 = radix faster):

| key range | n=32 | n=64 | n=128 | n=1024 |
|---|---:|---:|---:|---:|
| 12-bit | 2.31× | 0.86× | 0.47× | 0.18× |
| 32-bit | 4.16× | 1.50× | 0.73× | 0.25× |

Crossover is **64–128**; this takes 128. The two constants describe different work and the header now says at length why they must not be unified.

## Three refusals — and the mechanism is presortedness, not size

django's `implementors` (Σ = 646,700, max n = 2,401) looks like the ideal radix case and is **2.87× worse**. The reason: **100.0% of its records arrive already sorted, 0 adjacent descents**, because they are built by `push_back` in ascending-id order. `std::sort` detects that in O(n); radix always pays both passes. `mentions` on rails is 100.0% presorted for the same reason. 2b is the odd one out at **1.6%** — a graph walk emits in discovery order.

So the rule that now sits in the entry point's comment is *"was this built by appending in id order, or by a scattered walk?"* — **not** a size threshold.

## The dead `std::unique`

**0 duplicates removed in 24,216 calls across six corpora**, at 0.99 ms on rails. Dead *by construction*: `w` is appended in the same branch that stamps `seenEpoch[w]`, so a file reaches `trans[s]` at most once per source, and the sibling `ancestorsReach` already relies on that same stamp with no dedup.

Removed — but deliberately **not** replaced by a `VERIFY`: in release, `VERIFY_TEXT` still evaluates its expression before `__builtin_unreachable`, so an O(n) uniqueness scan there would reintroduce exactly the cost being removed. Gated instead.

**The sort itself stays.** Discovery order is deterministic but is *not* id order, so the sort is what makes `trans` a pure function of `adj` — non-negotiable #2.

## Two process findings worth keeping

1. **A gate arm that could not see the defect.** With the sort deleted entirely, *every fixture-based arm stayed green* — fixture closures are under ten elements and incidentally ascending. Only a 400-node scrambled synthetic arm with an independent mark-sweep oracle fails. Both mutation controls are recorded.
2. **A byte-identity pass that nearly went in fake.** `declare -A` failed on macOS bash 3.2, so all six "corpora" ran with empty paths and produced identical 24,825-byte output. Redone with a distinctness guard: **18 comparisons, 18 distinct sizes, all identical**, plus 18 more across 12 verbs.

Also surfaced and filed separately: a **pre-existing** UBSan abort in a vendored markdown grammar, proved pre-existing because the baseline binary reproduces it identically.

Verified on the exact tip: CI **26/26**; this lane adds no new gate script, so no count bump was owed and none happened — the loop names 572 and all eight published sites agree. `kParserVer` 86 == mirror. Main's post-#94 `collectioncapcheck` additionally run against this tree: ALL PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
