### PR TITLE
ci: drop every non-ubuntu apt source, not the one vendor that broke last time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,18 @@ jobs:
 
       - name: Install clang-format / clang-tidy (PINNED major — see the job comment)
         run: |
-          ls /etc/apt/sources.list.d/ && sudo rm -f /etc/apt/sources.list.d/google-chrome*   # the runner image ships a Chrome apt source (deb822 .sources on 24.04, not .list); its "Hash Sum mismatch" killed every Linux job on 2026-09-09
+          # Third-party apt sources ship in the runner image and are outside our control. TWICE now
+          # one has been mid-publish when a job ran and taken every Linux job on every branch down
+          # with it: `apt-get update` exits 100 and the leg dies in setup, before a single gate runs,
+          # with a failure that looks nothing like a package problem. google-chrome on 2026-09-09
+          # ("Hash Sum mismatch"; deb822 .sources on 24.04, not .list) and packages.microsoft.com on
+          # 2026-09-10 ("403 Forbidden ... is no longer signed"). Naming vendors one at a time only
+          # ever fixes the last outage, so: we install ubuntu-archive packages ONLY, and every
+          # non-ubuntu source goes. -print names what went, so a future reader can tell whether a
+          # missing package traces back to here.
+          ls /etc/apt/sources.list.d/ || true
+          sudo find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) \
+               ! -name 'ubuntu*' -print -delete || true
           wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
           chmod +x /tmp/llvm.sh
           sudo /tmp/llvm.sh "$CLANG_VERSION" all
@@ -191,7 +202,18 @@ jobs:
       - name: Install tooling (Linux)
         if: runner.os == 'Linux'
         run: |
-          ls /etc/apt/sources.list.d/ && sudo rm -f /etc/apt/sources.list.d/google-chrome*   # the runner image ships a Chrome apt source (deb822 .sources on 24.04, not .list); its "Hash Sum mismatch" killed every Linux job on 2026-09-09
+          # Third-party apt sources ship in the runner image and are outside our control. TWICE now
+          # one has been mid-publish when a job ran and taken every Linux job on every branch down
+          # with it: `apt-get update` exits 100 and the leg dies in setup, before a single gate runs,
+          # with a failure that looks nothing like a package problem. google-chrome on 2026-09-09
+          # ("Hash Sum mismatch"; deb822 .sources on 24.04, not .list) and packages.microsoft.com on
+          # 2026-09-10 ("403 Forbidden ... is no longer signed"). Naming vendors one at a time only
+          # ever fixes the last outage, so: we install ubuntu-archive packages ONLY, and every
+          # non-ubuntu source goes. -print names what went, so a future reader can tell whether a
+          # missing package traces back to here.
+          ls /etc/apt/sources.list.d/ || true
+          sudo find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) \
+               ! -name 'ubuntu*' -print -delete || true
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libxml2-utils ripgrep bc clang
 
@@ -270,7 +292,18 @@ jobs:
           fetch-depth: 0
       - name: Install tooling
         run: |
-          ls /etc/apt/sources.list.d/ && sudo rm -f /etc/apt/sources.list.d/google-chrome*   # the runner image ships a Chrome apt source (deb822 .sources on 24.04, not .list); its "Hash Sum mismatch" killed every Linux job on 2026-09-09
+          # Third-party apt sources ship in the runner image and are outside our control. TWICE now
+          # one has been mid-publish when a job ran and taken every Linux job on every branch down
+          # with it: `apt-get update` exits 100 and the leg dies in setup, before a single gate runs,
+          # with a failure that looks nothing like a package problem. google-chrome on 2026-09-09
+          # ("Hash Sum mismatch"; deb822 .sources on 24.04, not .list) and packages.microsoft.com on
+          # 2026-09-10 ("403 Forbidden ... is no longer signed"). Naming vendors one at a time only
+          # ever fixes the last outage, so: we install ubuntu-archive packages ONLY, and every
+          # non-ubuntu source goes. -print names what went, so a future reader can tell whether a
+          # missing package traces back to here.
+          ls /etc/apt/sources.list.d/ || true
+          sudo find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) \
+               ! -name 'ubuntu*' -print -delete || true
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libxml2-utils ripgrep bc
       - name: Configure with the image's stock gcc 13 (plain flavour)
@@ -422,7 +455,18 @@ jobs:
       - name: Install tooling (Linux)
         if: runner.os == 'Linux'
         run: |
-          ls /etc/apt/sources.list.d/ && sudo rm -f /etc/apt/sources.list.d/google-chrome*   # the runner image ships a Chrome apt source (deb822 .sources on 24.04, not .list); its "Hash Sum mismatch" killed every Linux job on 2026-09-09
+          # Third-party apt sources ship in the runner image and are outside our control. TWICE now
+          # one has been mid-publish when a job ran and taken every Linux job on every branch down
+          # with it: `apt-get update` exits 100 and the leg dies in setup, before a single gate runs,
+          # with a failure that looks nothing like a package problem. google-chrome on 2026-09-09
+          # ("Hash Sum mismatch"; deb822 .sources on 24.04, not .list) and packages.microsoft.com on
+          # 2026-09-10 ("403 Forbidden ... is no longer signed"). Naming vendors one at a time only
+          # ever fixes the last outage, so: we install ubuntu-archive packages ONLY, and every
+          # non-ubuntu source goes. -print names what went, so a future reader can tell whether a
+          # missing package traces back to here.
+          ls /etc/apt/sources.list.d/ || true
+          sudo find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) \
+               ! -name 'ubuntu*' -print -delete || true
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libxml2-utils ripgrep bc clang
 


### PR DESCRIPTION
`main`'s own CI run on `15e0f2ac` died in setup on `release (ubuntu-24.04, plain, clang, shard 4/4)`:

```
E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/InRelease
   403  Forbidden [IP: 13.107.213.71 443]
E: The repository '...' is no longer signed.
Process completed with exit code 100
```

No gate ran. The branch that produced that commit had been 26/26 green minutes earlier, so the red carried **no information about the code** — which is the real cost of this class, not the lost minutes.

This is the **second** time a vendor apt source shipped in the runner image has taken down Linux legs across every branch. The first was `google-chrome` on 2026-09-09 ("Hash Sum mismatch", and a deb822 `.sources` file on 24.04 rather than the `.list` everyone greps for), fixed then by removing that one vendor at four sites.

Removing vendors one at a time only ever fixes the last outage. So the four Chrome-specific removals become one rule:

```bash
sudo find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) \
     ! -name 'ubuntu*' -print -delete || true
```

We install `libxml2-utils ripgrep bc clang` — all ubuntu-archive, none from a third-party repo — so every non-ubuntu source goes before `apt-get update`.

**`ubuntu*` must be preserved.** On 24.04 the archive itself lives in that directory as `ubuntu.sources`; wiping the directory wholesale would break the install rather than protect it. That is the one thing to get right here, and it is why this is a `find ! -name` and not an `rm -rf`.

`ls` is kept (non-fatal) and `find` runs with `-print`, so every run logs exactly which files were removed. If this ever *does* break an install, the evidence sits directly above the failure instead of being invisible — the same reasoning that made the original Chrome line keep its `ls`.

No gate is added, no gate script changes, and `test/regression.sh` is untouched, so the published gate count is unaffected and this lane carries no count-collision risk.

Verified: 26/26 on this branch — which is the check that matters, since it proves the guard does not break the package install on any leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
