### PR TITLE
fix(config): respect CLAUDE_CONFIG_DIR instead of hardcoding ~/.claude

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,9 +43,9 @@ cmake --install build-install --prefix "$prefix" --component ripwire
 # meaning: Codex skills plus its advisory hooks.
 skillsInstaller="$prefix/share/ripwire/skills/install.sh"
 if [ -z "${RIPWIRE_NO_ACTIVATE:-}" ] && [ -f "$skillsInstaller" ]; then
-    if [ -d "$HOME/.claude" ]; then
+    if [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" ]; then
         if bash "$skillsInstaller" >/dev/null 2>&1; then
-            echo "install.sh: activated the ripwire skills for Claude Code ($HOME/.claude/skills)"
+            echo "install.sh: activated the ripwire skills for Claude Code (${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills)"
         else
             echo "install.sh: could not activate the Claude Code skills; run: bash \"$skillsInstaller\"" >&2
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -237,9 +237,9 @@ if [ -d "$extractedDir/skills" ]; then
     # provision agent homes later. test/releaseinstallcheck.sh arms (E1)-(E6) pin all of it.
     activated=0
     if [ -z "${RIPWIRE_NO_ACTIVATE:-}" ]; then
-        if [ -d "$HOME/.claude" ]; then
+        if [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" ]; then
             if bash "$skillsShareDir/install.sh" >/dev/null 2>&1; then
-                echo "install.sh: activated the ripwire skills for Claude Code ($HOME/.claude/skills)"
+                echo "install.sh: activated the ripwire skills for Claude Code (${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills)"
                 activated=$(( activated + 1 ))
             else
                 echo "install.sh: could not activate the Claude Code skills; run: bash \"$skillsShareDir/install.sh\"" >&2

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -135,7 +135,7 @@ install_claude_route()
 # once per session per pattern. Idempotent — re-running does not duplicate the settings.json entry.
 install_claude_hook()
 {
-    settings="$HOME/.claude/settings.json"
+    settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
     hookScript="$( dirname "$src" )/hooks/ripwire-nudge.sh"
     chmod +x "$hookScript" 2>/dev/null || true
 
@@ -301,7 +301,7 @@ case "$mode" in
                   echo "  Installing there anyway; openclaw will not discover these skills until that is unset." >&2
               fi ;;
     codex-legacy) dst="${CODEX_HOME:-$HOME/.codex}/skills" ;;
-    claude) dst="$HOME/.claude/skills" ;;
+    claude) dst="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills" ;;
     hermes) dst="${HERMES_HOME:-$HOME/.hermes}/skills" ;;
     path) dst="$explicitPath" ;;
 esac

--- a/src/cli.h
+++ b/src/cli.h
@@ -2296,7 +2296,7 @@ inline constexpr char kHelpTail[] =
         "                               carries the human tally line\n"
         "    --scan-skill=FILE          scan a single skill file before installing (any file, not just .md)\n"
         "    --scan-skills[=DIR]        scan a skills directory before installing — every text file, .md and .sh alike\n"
-        "                               scan DIR (or .agents/skills/ + ~/.claude/skills/ + ${CODEX_HOME:-~/.codex}/skills/).\n"
+        "                               scan DIR (or .agents/skills/ + ${CLAUDE_CONFIG_DIR:-~/.claude}/skills/ + ${CODEX_HOME:-~/.codex}/skills/).\n"
         "                               EVERY text file, .md and .sh alike — a skill dir's executables are the\n"
         "                               files most worth scanning. skipped= counts what it could not scan\n"
         "                               (binary content, or unreadable); denylisted subtrees (.git, node_modules,\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3122,8 +3122,13 @@ static int dispatchMain( const rw::Config& cfg, char** argv )
         else
         {
             addDir( ".agents/skills" );
-            const char* homeEnv = std::getenv( "HOME" );
-            if( homeEnv && *homeEnv )
+            const char* homeEnv        = std::getenv( "HOME" );
+            const char* claudeConfigEnv = std::getenv( "CLAUDE_CONFIG_DIR" );
+            if( claudeConfigEnv && *claudeConfigEnv )
+            {
+                addDir( std::string( claudeConfigEnv ) + "/skills" );
+            }
+            else if( homeEnv && *homeEnv )
             {
                 addDir( std::string( homeEnv ) + "/.claude/skills" );
             }

--- a/src/wrap.h
+++ b/src/wrap.h
@@ -101,7 +101,7 @@ struct AgentTarget
 
 inline constexpr AgentTarget kAgentTargets[] = {
     { "claude",   "Claude Code",  "CLAUDE.md",                   "",
-      "~/.claude",           "~/.claude/skills",                 "",            true,  WrapPrimary::Cli,     McpForm::CliAdd,     "claude mcp add ripwire -- ",          " --mcp\n",            "" },
+      "~/.claude",           "${CLAUDE_CONFIG_DIR:-~/.claude}/skills", "",       true,  WrapPrimary::Cli,     McpForm::CliAdd,     "claude mcp add ripwire -- ",          " --mcp\n",            "" },
     { "codex",    "OpenAI Codex", "AGENTS.md",                   "",
       "~/.codex",            "${AGENTS_HOME:-~/.agents}/skills", " --codex",    true,  WrapPrimary::Cli,     McpForm::Toml,       "",                                    "",                    "" },
     { "cursor",   "Cursor",       ".cursor/rules (a .mdc file)", "",
@@ -411,6 +411,18 @@ inline std::function<bool()> agentDetector( const AgentTarget& row, const std::s
     if( row.homeDir.empty() )
     {
         return []() { return true; };   // aider ships no config dir — it is always available
+    }
+
+    if( row.name == "claude" )
+    {
+        // CLAUDE_CONFIG_DIR relocates the entire config directory away from ~/.claude.
+        return [ home ]() -> bool
+        {
+            std::error_code ec;
+            const char*       ccd     = std::getenv( "CLAUDE_CONFIG_DIR" );
+            const std::string configDir = ( ccd && *ccd ) ? std::string( ccd ) : home + "/.claude";
+            return fs::is_directory( configDir, ec ) && !ec;
+        };
     }
 
     if( row.name == "opencode" )


### PR DESCRIPTION
## Problem

Every path that resolved Claude Code's config directory was hardcoded to `$HOME/.claude`, ignoring the `CLAUDE_CONFIG_DIR` environment variable that Claude Code itself honours when relocating its config.

## Fix

Six sites updated across the shell scripts and C++ source:

| File | What changed |
|------|-------------|
| `install.sh` | Detection check and receipt message |
| `scripts/install.sh` | Same two sites in the release installer |
| `skills/install.sh` | `settings.json` path (--hook) and the `claude)` destination branch |
| `src/main.cpp` | `--scan-skills` default skill-home enumeration |
| `src/wrap.h` | `agentDetector()` — new `claude` branch (mirrors the `opencode` branch) checks `CLAUDE_CONFIG_DIR` before falling back to `$HOME/.claude`; `skillsRoot` display string updated to show the env-var form |
| `src/cli.h` | `--scan-skills` help text updated to show `${CLAUDE_CONFIG_DIR:-~/.claude}` |

Follows the same pattern already used for `CODEX_HOME` and `AGENTS_HOME` in the same files.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSxdjhzx7tgQpBpjsiCWy