### PR TITLE
docs(readme): a second tagline line, and lead with what a stranger can check in ten seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,6 @@ around and reading whole files.
 
 <p align="center"><img src="docs/assets/paddle-out.svg" alt="Paddle out with a map." width="470"></p>
 
-### The goal: one question, one complete answer.
-
-**Terminality is the objective.** Ask the codebase a question and the answer should carry everything
-you need — no follow-on grep, no three more whole-file reads to fill in what it left out. A call
-followed by three greps is the same search paid for twice: it does not save you tokens and it does
-not make the coding faster.
-
-**Two things make that reachable in practice, and neither is the destination.** Answers are honest
-about their own limits — a count that cannot be a total is labelled a floor, a zero means "none
-found" and never "none exists", every truncation is disclosed — so an answer never looks more
-complete than it is, and the map never degrades the code by guessing. And an answer can be given a
-token budget, so what one costs is something you ask for rather than discover; where a complete
-answer will not fit, it says it went over rather than silently dropping the row you needed.
-
-Those two are the stair-steps: honest about what is missing, priced in what it spends. The step they
-climb toward is a question fully answered in one call, which is not always trivial to reach — and
-where it is not, the output says so rather than pretending otherwise.
-
 <details>
 <summary><b>Fifty years of software-engineering results, and research from last month.</b> 46 repositories and 69 papers folded — McCabe (1976) through to <b>seven papers published in the last two months</b> — each row in <a href="docs/LINEAGE.md"><b>docs/LINEAGE.md</b></a> naming the lesson taken and the file it lives in, all of it put into a single blazing-fast compiled executable</summary>
 
@@ -99,6 +81,28 @@ ripwire . --for="<the change you are about to make, in words>"
 **Reach for the CLI first — it is the cheaper interface.** The MCP server is the optional second
 way in, and its convenience has a cost the shell pipe does not carry: its verb schemas sit in your
 agent's context every session, whether or not it calls them.
+
+### The goal: one question, one complete answer.
+
+**Terminality is the objective.** Ask the codebase a question and the answer should carry everything
+you need — no follow-on grep, no three more whole-file reads to fill in what it left out. A call
+followed by three greps is the same search paid for twice: it does not save you tokens and it does
+not make the coding faster.
+
+<details>
+<summary>The two stair-steps that make it reachable — <b>honest about what is missing</b>, <b>priced in what it spends</b></summary>
+
+**Two things make that reachable in practice, and neither is the destination.** Answers are honest
+about their own limits — a count that cannot be a total is labelled a floor, a zero means "none
+found" and never "none exists", every truncation is disclosed — so an answer never looks more
+complete than it is, and the map never degrades the code by guessing. And an answer can be given a
+token budget, so what one costs is something you ask for rather than discover; where a complete
+answer will not fit, it says it went over rather than silently dropping the row you needed.
+
+Those two are the stair-steps: honest about what is missing, priced in what it spends. The step they
+climb toward is a question fully answered in one call, which is not always trivial to reach — and
+where it is not, the output says so rather than pretending otherwise.
+</details>
 
 ### Same answer, a fraction of the tokens — read this table first if your agent is on a budget
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@
 
 # Rip'n Fast. Fewer Tokens. Better Code.
 
-## Give your coding agent a map before it reads the repo.
+## The ripgrep of AI context. Give your coding agent a map before it reads the repo.
 
-**ripwire is the ripgrep of AI context.** Point it at any repository and your agent gets a ranked,
-deterministic call graph — what to touch, what it breaks, which tests to run — instead of grepping
-around and reading whole files.
+Point it at any repository and your agent gets a ranked, deterministic call graph — what to touch,
+what it breaks, which tests to run — instead of grepping around and reading whole files.
 
 <p align="center"><img src="docs/assets/paddle-out.svg" alt="Paddle out with a map." width="470"></p>
 
 <details>
-<summary><b>Fifty years of software-engineering results, and research from last month.</b> 46 repositories and 69 papers folded — McCabe (1976) through to <b>seven papers published in the last two months</b> — each row in <a href="docs/LINEAGE.md"><b>docs/LINEAGE.md</b></a> naming the lesson taken and the file it lives in, all of it put into a single blazing-fast compiled executable</summary>
+<summary><b>Fifty years of software-engineering results, and research from last month.</b> 46 repositories and 69 papers folded — McCabe (1976) through to <b>seven published in the last two months</b> — each row in <a href="docs/LINEAGE.md"><b>docs/LINEAGE.md</b></a> naming the lesson taken and the file it lives in</summary>
 
 Beside those sits a labelled survey of **237 tools** that contributed nothing and says so. The two
 sets are disjoint by construction, so they add rather than nest — a tool that gave a lesson is never
@@ -47,7 +46,8 @@ claim cannot quietly drift. The row-by-row ledger is
 JavaScript · Java · Ruby · PHP · Lua · Elixir · Bash · C# · JSON · TOML · YAML · Markdown — see
 [language support and limits](#languages).
 
-### No API key. No embeddings. No index server. No daemon.
+<p align="center"><img src="docs/assets/no-deps.svg"
+  alt="No API key. No embeddings. No index server. No daemon." width="470"></p>
 
 <details>
 <summary><b>One process, no server</b> — indexes this repository in <b>0.25 s</b> using <b>6.6 MB</b>, against <b>46.8 s</b> and <b>391 MB</b> for the graph-database MCP server it was measured against; warm queries answer in <b>197 ms</b> to its <b>1,082 ms</b></summary>

--- a/docs/assets/no-deps.svg
+++ b/docs/assets/no-deps.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="470" height="30" viewBox="0 0 470 30" role="img"
+     aria-label="No API key. No embeddings. No index server. No daemon.">
+  <title>No API key. No embeddings. No index server. No daemon.</title>
+  <g transform="translate(25.5 0)">
+    <rect x="0" y="1" width="85.1" height="24" rx="12" fill="none" stroke="#56D6E8" stroke-width="1.3" opacity="0.6"/>
+    <text x="42.5" y="17.6" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif"
+          font-size="12" font-weight="600" fill="#56D6E8">No API key</text>
+  </g>
+  <g transform="translate(119.6 0)">
+    <rect x="0" y="1" width="109.5" height="24" rx="12" fill="none" stroke="#56D6E8" stroke-width="1.3" opacity="0.6"/>
+    <text x="54.7" y="17.6" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif"
+          font-size="12" font-weight="600" fill="#56D6E8">No embeddings</text>
+  </g>
+  <g transform="translate(238.1 0)">
+    <rect x="0" y="1" width="111.9" height="24" rx="12" fill="none" stroke="#56D6E8" stroke-width="1.3" opacity="0.6"/>
+    <text x="55.9" y="17.6" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif"
+          font-size="12" font-weight="600" fill="#56D6E8">No index server</text>
+  </g>
+  <g transform="translate(359.0 0)">
+    <rect x="0" y="1" width="85.5" height="24" rx="12" fill="none" stroke="#56D6E8" stroke-width="1.3" opacity="0.6"/>
+    <text x="42.8" y="17.6" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif"
+          font-size="12" font-weight="600" fill="#56D6E8">No daemon</text>
+  </g>
+</svg>

--- a/docs/assets/paddle-out.svg
+++ b/docs/assets/paddle-out.svg
@@ -1,15 +1,33 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="470" height="52" viewBox="0 0 470 52" role="img" aria-label="Paddle out with a map.">
-  <title>Paddle out with a map.</title>
-  <g transform="translate(18 26) rotate(-24)">
-    <ellipse cx="0" cy="0" rx="19" ry="6.4" fill="#56D6E8"/>
-    <path d="M -19 0 L 19 0" stroke="#0D1117" stroke-width="1.1" opacity="0.55"/>
-    <path d="M 12 3.2 L 15 8.4" stroke="#F2B84B" stroke-width="2.2" stroke-linecap="round"/>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="470" height="96" viewBox="0 0 470 96" role="img" aria-label="Paddle out with a map. See the rip before you’re in it.">
+  <title>Paddle out with a map. See the rip before you’re in it.</title>
+
+  <defs>
+    <!-- A barrelling wave. The long gentle face on the left and the tight throwing lip on the right
+         are what make it read as a wave rather than an arch: a circular arc always reads as a
+         rainbow at this size. The two trailing strokes are the face behind the lip. -->
+    <g id="barrel">
+      <path d="M -23 14 C -20 2 -12 -10 0 -14 C 12 -18 22 -12 22 -2 C 22 6 15 11 9 8 C 5 6 5 2 8 2"
+            stroke="#F2B84B" stroke-width="4" fill="none" stroke-linecap="round"/>
+      <path d="M -12 14 C -10 5 -4 -3 4 -7"
+            stroke="#F2B84B" stroke-width="2.1" fill="none" opacity="0.55" stroke-linecap="round"/>
+      <path d="M -3 14 C -1 8 3 3 9 1"
+            stroke="#F2B84B" stroke-width="1.7" fill="none" opacity="0.4" stroke-linecap="round"/>
+    </g>
+
+    <g id="board">
+      <ellipse cx="0" cy="0" rx="19" ry="6.4" fill="#56D6E8"/>
+      <path d="M -19 0 L 19 0" stroke="#0D1117" stroke-width="1.1" opacity="0.55"/>
+      <path d="M 12 3.2 L 15 8.4" stroke="#F2B84B" stroke-width="2.2" stroke-linecap="round"/>
+    </g>
+  </defs>
+
+  <use href="#board" transform="translate(18 26) rotate(-24)"/>
   <text x="235" y="34" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif"
         font-size="30" font-style="italic" font-weight="600" fill="#56D6E8">Paddle out with a map.</text>
-  <g transform="translate(452 26) scale(-1 1) rotate(-24)">
-    <ellipse cx="0" cy="0" rx="19" ry="6.4" fill="#56D6E8"/>
-    <path d="M -19 0 L 19 0" stroke="#0D1117" stroke-width="1.1" opacity="0.55"/>
-    <path d="M 12 3.2 L 15 8.4" stroke="#F2B84B" stroke-width="2.2" stroke-linecap="round"/>
-  </g>
+  <use href="#board" transform="translate(452 26) scale(-1 1) rotate(-24)"/>
+
+  <use href="#barrel" transform="translate(29 68)"/>
+  <text x="235" y="75" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif"
+        font-size="21" font-style="italic" font-weight="600" fill="#F2B84B">See the rip before you’re in it.</text>
+  <use href="#barrel" transform="translate(441 68) scale(-1 1)"/>
 </svg>


### PR DESCRIPTION
Two changes above the fold, plus a second line on the banner. No claim is dropped and no published number moves.

## The banner gains a second line

**"See the rip before you're in it."** in `#F2B84B` — the hero's amber, the `wire` half of the wordmark — with a breaking wave at each end answering the surfboards on the line above. 21px against the first line's 30px, so it reads as the follow-through rather than a competing headline.

The wave took five attempts and the failures were all the same mistake, which is worth one line so nobody repeats it: **a circular arc reads as a rainbow, a filled mound reads as a dune, and nested symmetric arcs read as an archway.** What makes a wave read at 44px is asymmetry — a long gentle face on one side, a tight throwing lip on the other — so the shape here is a swept curve with a short tuck rather than any kind of arc.

## The order above the fold

Now leads with what someone deciding whether to try this can **check in ten seconds**:

1. Fifty years of software-engineering results, and research from last month
2. Languages
3. No API key. No embeddings. No index server. No daemon.

**"The goal: one question, one complete answer"** moves down to sit immediately above **"Same answer, a fraction of the tokens"**, where the terminality argument is next to the table that pays it off. Its first paragraph — the actual claim — stays visible; the two paragraphs on the stair-steps fold behind a click. Terminality is the principle *behind* the numbers, and it lands better once you have seen one.

## Three tightenings

- **The top said the same thing twice.** The h2 and the sentence under it were one idea in two registers, and the reader paid for both before reaching anything checkable. Merged into one heading that keeps both halves.
- **The four negations are a badge row, not a section heading** — `docs/assets/no-deps.svg`, four outlined chips in the wordmark's cyan. It is a **local asset, deliberately, rather than shields.io**: this project's whole claim is that it needs no network, and a README that fetches four images from a badge CDN to say "no daemon" argues against itself. Alt text and the SVG `<title>` carry the same four facts, so nothing is lost to a screen reader or a text-only view.
- **The lineage summary was ~340 characters** — a wall of prose as the first thing after the banner, before the reader has clicked anything. Cut to ~250. The gated substring `46 repositories and 69 papers` and the `docs/LINEAGE.md` link are untouched.

## The Languages list stays in full, deliberately

It was tempting to collapse 23 names to a count plus a link, and that would have been wrong. A stranger scanning for **their** language is exactly who that line exists for, and "23 languages…" does not answer that question — the twenty-three names do. Same reason the card logos are at the checkout.

---

Verified on the exact tip: CI **26/26**; `readmedrift`, `readmeexample`, `deplangs` and `ripwirepublic` green. The set diff against main's gate loop is **empty** — this lane adds no gate, so it inherits main's count of 577 and carries no count-collision risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
