### PR TITLE
fix(ci): a declared gate budget is a floor, not a ceiling

### DIFF
--- a/test/lib/headbinlib.sh
+++ b/test/lib/headbinlib.sh
@@ -60,6 +60,11 @@ ripwire_head_binary()
     # 240 s here against pargates' 900 s for the six head-binary gates (its `slow` set) leaves 660 s of
     # headroom. If either number moves, move it with the other one: pargates.py's `slow` comment names this
     # file, and this comment names pargates.py, so neither can drift alone unnoticed.
+    #
+    # Since 2026-09-10 pargates spends max(declared, DEFAULT x --budget-scale) on a declared gate, so the
+    # headroom can only GROW from 660 s under CI's scale -- it never shrinks. The invariant to preserve is
+    # still the strict inequality, not the arithmetic difference: this wait must expire with the gate's own
+    # assertions still able to run, so raise this number only alongside the 900 s it is measured against.
     _t=0
     while [ "$_t" -lt 240 ]; do
         [ -x "$_bin" ] && { printf '%s\n' "$_bin"; return 0; }

--- a/test/pargates.py
+++ b/test/pargates.py
@@ -26,7 +26,7 @@ only = None
 jsonout = None
 shard = None          # (k, n): run only the k-th of n deterministic slices of the gate list
 shard_plan = False    # print every slice's membership and predicted weight, run nothing
-budget_scale = 1.0    # multiply the DEFAULT per-gate budget (never the explicit overrides) -- CI passes >1
+budget_scale = 1.0    # scales the DEFAULT budget; a declared override acts as a FLOOR under it -- CI passes >1
 exclude_list = None   # a committed file naming gates this leg does not run (one per line, # comments)
 args = sys.argv[3:]
 for i, a in enumerate(args):
@@ -212,8 +212,19 @@ exclusive = {"editcheckcheck.sh"}
 # 151 s local -> rc=124 at 300.1 s; paginationcheck 53 s local -> rc=124 at 300.0 s). Sixty-four uncapped gates
 # sit inside that multiplier of the cap, so per-gate entries would be the wrong shape -- and raising the constant
 # itself would blunt the tripwire on the machines it was measured on. So CI passes a scale factor that applies
-# to the DEFAULT only; the explicit entries in GATE_BUDGET_SEC were derived from CI measurements and stay as
-# declared. The TIMEOUT message names the effective budget and the scale, so a red still names its own limit.
+# to the DEFAULT, and a declared entry below acts as a FLOOR under it rather than a ceiling over it. The
+# TIMEOUT message names the effective budget and the scale, so a red still names its own limit.
+#
+# The floor (2026-09-10) repairs an inversion the first shape had. Skipping the scale for declared entries
+# meant that under CI's --budget-scale 4 the gates this table calls out as HEAVY were the only gates in the
+# job running on LESS time than an ordinary one: crossdirincludecheck, which builds a whole second ripwire
+# from git HEAD, got 900 s while xmlwellformed -- which pipes one map through xmllint -- got 300 x 4 = 1200.
+# Measured on a CI run of main (34479806177, macos-14 Release shard 2/2): crossdirincludecheck rc=124 at
+# 900.1 s in a shard whose wall was 3588.6 s, with xmlwellformed at 585.8 s and rootrelcheck at 345.9 s in
+# the same job -- every gate on that runner ran 6-10x its idle-local wall, and only the UNDECLARED ones had
+# a budget that had moved with it. max(declared, default x scale) keeps each declared number meaningful on
+# the machine it was measured on (at scale 1.0 the declared value still wins, unchanged) and stops the table
+# from buying a gate less time than saying nothing would have. It never loosens a tripwire below today.
 DEFAULT_TIMEOUT_SEC = 300
 GATE_BUDGET_SEC = {
     "crossdirincludecheck.sh":    900,
@@ -377,10 +388,15 @@ def failure_report(out, logpath):
 
 def run(g):
     env = dict(os.environ, RIPWIRE_BIN=binp)
+    scaled_default = int( round( DEFAULT_TIMEOUT_SEC * budget_scale ) )
     if g in GATE_BUDGET_SEC:
-        limit, scaled = GATE_BUDGET_SEC[g], ""
+        # A declared entry is a FLOOR, not a ceiling: it is the number below which this gate would be a
+        # hang even on an idle machine. It must never buy the gate LESS time than an undeclared one gets.
+        declared = GATE_BUDGET_SEC[g]
+        limit = max( declared, scaled_default )
+        scaled = "" if limit == declared else f", declared {declared}s raised to the scaled default {DEFAULT_TIMEOUT_SEC}s x --budget-scale {budget_scale:g}"
     else:
-        limit = int(round(DEFAULT_TIMEOUT_SEC * budget_scale))
+        limit = scaled_default
         scaled = "" if budget_scale == 1.0 else f", default {DEFAULT_TIMEOUT_SEC}s x --budget-scale {budget_scale:g}"
     t0 = time.time()
     with running_lock:

--- a/test/pargatescheck.sh
+++ b/test/pargatescheck.sh
@@ -277,4 +277,144 @@ printf '%s\n' "$outN" | grep -q 'tree tripwire: DISARMED' \
     && ok "functional(tree): UNWATCHED -- the run says the tripwire is disarmed rather than implying a clean tree" \
     || no "functional(tree): UNWATCHED -- no DISARMED disclosure on a corpus git cannot see"
 
+# ── THE DECLARED BUDGET IS A FLOOR, NOT A CEILING (2026-09-10, CI run 34479806177) ───────────────────────
+# GATE_BUDGET_SEC entries were originally exempt from --budget-scale, on the reasoning that each was derived
+# from a CI measurement and should stand as declared. Under CI's --budget-scale 4 that inverted the table's
+# meaning: the gates it names as HEAVY became the only gates in the job running on LESS time than an unnamed
+# one. crossdirincludecheck -- which builds a whole second ripwire from git HEAD -- was killed at 900.1 s in
+# a macos-14 shard where xmlwellformed (one map piped through xmllint) was allowed 1200 s and took 585.8 s.
+#
+# Every arm above checks a declared NUMBER. None compared a declared number against what saying nothing
+# would have bought, so nothing in the suite could see the inversion. This section gates the POPULATION
+# instead: at the scale ci.yml actually passes, no declared budget may sit below the effective default. Both
+# inputs come from their real sources -- the table AND run()'s own prologue lifted out of pargates.py by ast
+# (never reimplemented, the same rule the FUNCTIONAL section follows), the scale out of the workflow -- so
+# moving --budget-scale re-evaluates the invariant instead of quietly re-opening the hole.
+CI_YML="$ROOT/.github/workflows/ci.yml"
+FLOORSCAN="$TMP/floorscan.py"
+rm -f "$TMP/floorfail"
+cat > "$FLOORSCAN" <<'PYEOF'
+# floorscan.py PARGATES SCALE -- re-runs pargates.py's OWN budget selection for every declared gate at a
+# given --budget-scale. The selection is lifted out of run() by ast, never reimplemented here: a copy of
+# the logic would keep passing after the original changed, which is the failure mode this gate exists for.
+import ast, io, os, sys
+
+pargates, scale = sys.argv[1], float(sys.argv[2])
+tree = ast.parse(io.open(pargates, encoding="utf-8").read())
+
+consts = {}
+for n in tree.body:
+    if isinstance(n, ast.Assign) and isinstance(n.targets[0], ast.Name) \
+       and n.targets[0].id in ("DEFAULT_TIMEOUT_SEC", "GATE_BUDGET_SEC"):
+        consts[n.targets[0].id] = ast.literal_eval(n.value)
+if set(consts) != {"DEFAULT_TIMEOUT_SEC", "GATE_BUDGET_SEC"}:
+    print("ERROR could not read DEFAULT_TIMEOUT_SEC / GATE_BUDGET_SEC as literals"); sys.exit(2)
+
+runfn = next((n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "run"), None)
+if runfn is None:
+    print("ERROR no def run(g) in pargates.py"); sys.exit(2)
+cut = next((i for i, st in enumerate(runfn.body)
+            if isinstance(st, ast.Assign) and getattr(st.targets[0], "id", "") == "t0"), None)
+if cut is None:
+    print("ERROR could not find the t0 = time.time() boundary in run()"); sys.exit(2)
+block = ast.unparse(ast.Module(body=runfn.body[:cut], type_ignores=[]))
+if "limit" not in block:
+    print("ERROR the pre-t0 prologue of run() no longer computes 'limit'"); sys.exit(2)
+
+def limit_for(g):
+    ns = dict(consts, budget_scale=scale, g=g, os=os, binp="")
+    exec(block, {"max": max, "int": int, "round": round, "dict": dict}, ns)
+    return ns["limit"]
+
+undeclared = limit_for("a-gate-that-is-not-in-the-table.sh")
+print("SCALED_DEFAULT %d" % undeclared)
+print("DECLARED_COUNT %d" % len(consts["GATE_BUDGET_SEC"]))
+eff = {}
+for g, declared in sorted(consts["GATE_BUDGET_SEC"].items()):
+    e = limit_for(g); eff[g] = e
+    if e < undeclared:
+        print("VIOLATION %s declared=%d effective=%d undeclared_gets=%d" % (g, declared, e, undeclared))
+    if e < declared:
+        print("LOWERED %s declared=%d effective=%d" % (g, declared, e))
+print("MIN_EFFECTIVE %d" % min(eff.values()))
+PYEOF
+
+# the scale is whatever the workflow really passes -- not a number retyped into this gate. Kept as a
+# newline-separated string, not an array: macOS ships bash 3.2, which has no mapfile, and an empty array
+# expanded under `set -u` there is an error rather than nothing.
+CI_SCALES="$( grep -oE -- '--budget-scale[[:space:]]+[0-9]+(\.[0-9]+)?' "$CI_YML" \
+              | awk '{print $2}' | LC_ALL=C sort -u )"
+FIRST_SCALE="$( printf '%s\n' "$CI_SCALES" | head -1 )"
+if [ -z "$CI_SCALES" ]; then
+    no "floor: .github/workflows/ci.yml passes no --budget-scale -- this gate cannot know what CI gives an undeclared gate"
+    FIRST_SCALE=1.0
+else
+    ok "floor: ci.yml passes --budget-scale $( printf '%s' "$CI_SCALES" | tr '\n' ',' ) (read from the workflow, not retyped here)"
+fi
+
+# every scale CI actually uses, plus 1.0 -- the bare regression.sh regime, where a declared entry must
+# still come out exactly as declared.
+printf '%s\n1.0\n' "$CI_SCALES" | grep -v '^$' | LC_ALL=C sort -u | while IFS= read -r S; do
+    scanOut="$( python3 "$FLOORSCAN" "$PARGATES" "$S" 2>&1 )" || {
+        printf '  FAIL  floor: could not evaluate run() budget prologue at --budget-scale %s: %s\n' "$S" "$scanOut"
+        printf 'x' >> "$TMP/floorfail"; continue; }
+    nDeclared="$( printf '%s\n' "$scanOut" | awk '/^DECLARED_COUNT /{print $2}' )"
+    scaledDef="$( printf '%s\n' "$scanOut" | awk '/^SCALED_DEFAULT /{print $2}' )"
+    violations="$( printf '%s\n' "$scanOut" | grep -c '^VIOLATION ' || true )"
+    lowered="$(   printf '%s\n' "$scanOut" | grep -c '^LOWERED '   || true )"
+
+    if [ "$violations" -eq 0 ]; then
+        printf '  PASS  floor: at --budget-scale %s all %s declared budgets are >= the %ss an UNDECLARED gate gets\n' "$S" "$nDeclared" "$scaledDef"
+    else
+        printf '  FAIL  floor: at --budget-scale %s, %s of %s declared gates get LESS than the %ss an undeclared gate gets -- the table is buying them less time than saying nothing would\n' "$S" "$violations" "$nDeclared" "$scaledDef"
+        printf '%s\n' "$scanOut" | grep '^VIOLATION ' | sed 's/^/    /'
+        printf 'x' >> "$TMP/floorfail"
+    fi
+
+    if [ "$lowered" -eq 0 ]; then
+        printf '  PASS  floor: at --budget-scale %s no declared budget is reduced below its declared value (a floor never lowers)\n' "$S"
+    else
+        printf '  FAIL  floor: at --budget-scale %s, %s declared budgets came out BELOW their declared value\n' "$S" "$lowered"
+        printf '%s\n' "$scanOut" | grep '^LOWERED ' | sed 's/^/    /'
+        printf 'x' >> "$TMP/floorfail"
+    fi
+done
+# that loop is a pipeline, so it ran in a subshell: its verdict travels through the filesystem, not $fail.
+if [ -s "$TMP/floorfail" ]; then fail=1; fi
+
+# headbinlib's waiter must still expire with the gate's own assertions able to run. That coupling is stated
+# in both files; measuring it against the MINIMUM effective declared budget means raising --budget-scale can
+# only widen it, and lowering a declared entry cannot silently close it.
+HEADBINLIB="$ROOT/test/lib/headbinlib.sh"
+waitBudget="$( grep -oE 'while \[ "\$_t" -lt [0-9]+ \]' "$HEADBINLIB" | grep -oE '[0-9]+' | head -1 )"
+minEff="$( python3 "$FLOORSCAN" "$PARGATES" "$FIRST_SCALE" 2>/dev/null | awk '/^MIN_EFFECTIVE /{print $2}' )"
+if [ -n "$waitBudget" ] && [ -n "$minEff" ]; then
+    [ "$waitBudget" -lt "$minEff" ] \
+        && ok "floor: headbinlib.sh waits ${waitBudget}s, strictly under the ${minEff}s smallest effective declared budget (a waiter cannot burn a whole gate budget and be killed as its wait expires)" \
+        || no "floor: headbinlib.sh waits ${waitBudget}s against a smallest effective declared budget of ${minEff}s -- the two budgets must not be equal or inverted"
+else
+    no "floor: could not read headbinlib.sh's wait budget (${waitBudget:-unset}) or the minimum effective budget (${minEff:-unset})"
+fi
+
+# MUTATION: the section must be able to go red. The mutation is to the CODE, not the table -- reverting
+# run() to the pre-floor form is exactly the regression this section exists to catch, and lowering a TABLE
+# entry would no longer prove anything, because the floor repairs one automatically. That is the point.
+MUTANT="$TMP/pargates_prefloor.py"
+python3 - "$PARGATES" "$MUTANT" <<'PYEOF'
+import io, sys
+src, dst = sys.argv[1], sys.argv[2]
+t = io.open(src, encoding="utf-8").read()
+old = "limit = max( declared, scaled_default )"
+assert old in t, "the floor expression is not in run() verbatim -- the arms above should already have failed"
+io.open(dst, "w", encoding="utf-8").write(t.replace(old, "limit = declared", 1))
+PYEOF
+mutOut="$( python3 "$FLOORSCAN" "$MUTANT" "$FIRST_SCALE" 2>&1 )"
+mutHits="$( printf '%s\n' "$mutOut" | grep -c '^VIOLATION ' || true )"
+if [ "$mutHits" -gt 0 ]; then
+    ok "floor(mutation): reverting run() to the pre-floor 'limit = declared' is caught ($mutHits violations at --budget-scale $FIRST_SCALE) -- this section is not vacuous"
+else
+    no "floor(mutation): a pre-floor run() produced NO violation at --budget-scale $FIRST_SCALE -- this whole section is vacuous"
+    printf '%s\n' "$mutOut" | sed 's/^/    /' | head -8
+fi
+
 [ "$fail" -eq 0 ] && echo "pargatescheck: ALL PASS" || { echo "pargatescheck: SOME CHECKS FAILED"; exit 1; }


### PR DESCRIPTION
## The 900 s macOS timeout is not a hang — it is the smaller of two budgets

`--budget-scale` applies to `DEFAULT_TIMEOUT_SEC` only. That was deliberate: the `GATE_BUDGET_SEC`
entries were each derived from a CI measurement and were meant to stand as declared. Under CI's
`--budget-scale 4` it inverts the table's meaning — the gates it names as **heavy** become the only
gates in the job running on **less** time than an unnamed one.

| gate | in the table? | effective budget in CI |
| --- | --- | --- |
| `xmlwellformed.sh` — pipes one map through `xmllint` | no | 300 × 4 = **1200 s** |
| `crossdirincludecheck.sh` — builds a whole second ripwire from `git HEAD` | yes | **900 s** |

### Measured, on a CI run of `main`

Run `34479806177`, `macos-14` Release shard 2/2:

```
gates=297 pass=292 skip=4 fail=1 wall=3588.6s
=== crossdirincludecheck.sh (rc=124, 900.1s) ===
    L11: TIMEOUT after 900s (declared budget=900s)

slowest:
   900.1s  crossdirincludecheck.sh     <- killed at its cap
   585.8s  xmlwellformed.sh            <- 1200 s available
   345.9s  rootrelcheck.sh             <- 1200 s available
```

`xmlwellformed` at 586 s is the tell. Every gate on that runner ran 6–10× its idle-local wall, and only
the **undeclared** ones had a budget that had moved with it. `crossdirincludecheck`'s own arms all
passed — it was killed for being on a starved machine holding the smaller of the two budgets.

### The change

```python
limit = max( declared, DEFAULT_TIMEOUT_SEC * budget_scale )
```

At scale 1.0 — `regression.sh`, and a bare `pargates.py` run — every declared value still wins, so local
behaviour is byte-identical. No tripwire is loosened below what it is today on the machine it was
measured on. What changes is that the table can no longer buy a gate *less* time than saying nothing
would have.

**15 of the 18 declared entries were on the wrong side of that line**, not one. Only the three at 1200 s
were already safe.

### Gated as a population, not per entry

The arms already in `pargatescheck.sh` each check a declared **number** — and no number was wrong, which
is exactly why the suite could not see this. `git merge` sees text; this invariant is about the
population. The new arms:

- take the table **and** `run()`'s own budget prologue out of `pargates.py` **by `ast`** — never a
  reimplementation, so a copied formula cannot keep passing after the original moves;
- take the scale out of `ci.yml`, so raising `--budget-scale` re-evaluates the invariant instead of
  quietly re-opening the hole;
- assert at every scale CI really passes (plus 1.0) that no declared budget sits below the effective
  default, and that the floor never *lowers* a declared value;
- check `headbinlib.sh`'s 240 s waiter against the **minimum effective** declared budget rather than a
  hand-copied `900`, so the coupling those two files describe to each other can only widen;
- **mutation arm**: revert `run()` to `limit = declared` and the section must go red. The mutation is to
  the *code*, not the table — lowering a table entry proves nothing now, because the floor repairs one
  automatically. That is the point.

```
PASS  floor: ci.yml passes --budget-scale 4 (read from the workflow, not retyped here)
PASS  floor: at --budget-scale 1.0 all 18 declared budgets are >= the 300s an UNDECLARED gate gets
PASS  floor: at --budget-scale 4   all 18 declared budgets are >= the 1200s an UNDECLARED gate gets
PASS  floor: at both scales no declared budget is reduced below its declared value (a floor never lowers)
PASS  floor: headbinlib.sh waits 240s, strictly under the 1200s smallest effective declared budget
PASS  floor(mutation): reverting run() to the pre-floor 'limit = declared' is caught (15 violations)
```

`pargatescheck.sh` 40/40 PASS locally; `manifestcheck.sh` and `gatecountcheck.sh` green.

No gate added, **no gate count change**, no published number moves — so this cannot collide with any lane
in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
