### PR TITLE
skills: restore routing triggers in six descriptions (Codex) — and keep the frontmatter stop rules

### DIFF
--- a/bench/skillrater/results/2026-09-07/CODEX_ROUTING_CHECK.md
+++ b/bench/skillrater/results/2026-09-07/CODEX_ROUTING_CHECK.md
@@ -1,37 +1,53 @@
-# Codex routing check — operator notes (do not give this file to Codex; give it `codex_prompt.md`)
+# Codex routing check — operator notes
 
-One Codex turn (~5K input tokens, ~2K output) measures how the shortened skill set routes for a real GPT
-reader — the one measurement the 2026-09-07 round could not take itself (its raters were Claude models).
+Give the evaluator only `codex_prompt.md`, unchanged. Do not give it these notes, answer keys, or reference answers. Record the source commit, Codex version/model, installed catalog and description hashes, startup warnings, raw response, and token usage for each fresh turn.
 
-## 1. Install the landed skills (no tokens)
+## 1. Install and choose the catalog before running
 
-    git pull && bash skills/install.sh --codex
+Use an up-to-date checkout, then choose the treatment explicitly:
 
-Open a fresh Codex session in any repo. Before spending anything, note `codex --version` and whether the
-"Skill descriptions were shortened to fit the skills context budget" warning still appears. If it does,
-count your non-ripwire skills — they are the remainder of the budget now — or raise
-`[skills] max_context_tokens` in `~/.codex/config.toml`.
+```sh
+# Normal user catalog: excludes the contributor-only compiler-remark skill.
+bash skills/install.sh --codex
 
-## 2. The turn (the only tokens spent)
+# Full catalog for working on Ripwire itself and comparing all 85 positives.
+bash skills/install.sh --codex --contributor
+```
 
-Paste `bench/skillrater/results/2026-09-07/codex_prompt.md` as one message. It carries the instructions and
-the 138 held-out prompts (85 with a labelled skill, 53 where no skill should fire); it carries no labels and
-no skill descriptions — Codex must route from the catalog it loaded itself. Save the TSV it returns as
-`/tmp/answers_codex.tsv`.
+Run **one** of these commands per treatment. The second includes `ripwire-opt-remarks`; the first deliberately prunes it. The frozen C2 key contains two positives for that skill, so a default install cannot reproduce the full-catalog reference treatment. Do not count those two rows as default-catalog routing failures or silently change the historical key.
 
-## 3. Score (no tokens)
+Open a fresh Codex session after installation: an existing session may retain its earlier catalog. Record `codex --version` and `ripwire . --doctor --agent=codex`. Check the startup output for the "Skill descriptions were shortened to fit the skills context budget" warning. If it appears, record the other installed skills and the actual treatment before changing any budget setting. Do not tune configuration between turns without labelling the change.
 
-    python3 bench/skillrater/score.py bench/skillrater/results/2026-09-07/keys/key_C2.tsv /tmp/answers_codex.tsv
+## 2. The blind turn
 
-Prints hit@1 / hit@2 on the 85 positives, false fires on the 53 negatives, and a per-skill won/rows table.
-Reference on the same 138 prompts, same key: Opus 85/85, Sonnet 84/85, Fable 84/85, 0 negative fires each.
-Within a few rows of that = the shortened set routes the same for Codex. Far below, clustered on one skill in
-the per-skill table = that skill's description is the one to fix; the key's id column maps back to the prompt.
+Paste `bench/skillrater/results/2026-09-07/codex_prompt.md` as one message. It contains 138 prompts (85 labelled positives, 53 negatives), no labels and no descriptions; Codex routes from the catalog it loaded itself. Save the raw TSV response before scoring, for example as `/tmp/answers_codex_default.tsv` or `/tmp/answers_codex_contributor.tsv`. Preserve raw events and stderr when using the CLI so tool calls and truncation warnings can be checked.
 
-## 4. Optional second turn — the comparison the issue reporter actually asked about
+Require all 138 unique IDs, exactly three tab-separated columns, and installed skill names or `none`. Missing, duplicate, unknown or malformed rows invalidate the run; the scorer is not a substitute for this format check. The prompt forbids tools and reading skills; record any violation rather than presenting the run as blind.
 
-Same prompt, pre-round descriptions: `git worktree add /tmp/rw-old c7914e8d`, install from
-`/tmp/rw-old/skills/install.sh --codex` (it prunes and relinks), run the turn again, score against
-`keys/key_A.tsv` (the 18-skill labels), then re-install from main. That shows whether Codex, unlike the
-Claude raters, loses anything to the truncation of the old text. Record both runs in `docs/EVALS.md` under
-the round's RESULT.
+One turn is roughly 5K tokens of prompt text and 2K output; loaded skills, system instructions and other runtime context add to the actual input. Record measured usage rather than budgeting only the prompt text (the 2026-09-09 live-catalog run used 23,824 input tokens).
+
+## 3. Score against the matching treatment
+
+```sh
+# Default catalog: 83 applicable positives and all 53 negatives.
+python3 bench/skillrater/score.py \
+  bench/skillrater/results/2026-09-07/keys/key_C2.tsv \
+  /tmp/answers_codex_default.tsv --exclude-labels=ripwire-opt-remarks
+
+# Contributor catalog: all 85 positives and all 53 negatives.
+python3 bench/skillrater/score.py \
+  bench/skillrater/results/2026-09-07/keys/key_C2.tsv \
+  /tmp/answers_codex_contributor.tsv
+```
+
+Keep the full unfiltered default-catalog score as a diagnostic if useful, but label its two unavailable-skill rows. Never compare the 83-positive filtered score directly with an 85-positive historical score.
+
+The frozen full-catalog reference on these 138 prompts is Opus 85/85, Sonnet 84/85, Fable 84/85, all with 0/53 negative fires. The scorer reports hit@1, hit@2 and per-skill results. A default-catalog comparison requires rescoring the historical answer files with the same exclusion. Record model, catalog and context differences alongside comparisons.
+
+After using failures to change descriptions, this packet is a regression set for that work. Use independently prepared prompts for forward validation, freeze labels before evaluation, and do not call score-driven retries held-out evidence.
+
+## 4. Optional old-description comparison
+
+For the pre-round descriptions, create a separate worktree at `c7914e8d`. Install from that worktree, start a fresh session, run the same unchanged prompt and score with `keys/key_A.tsv` (the 18-skill labels). Record exactly which skills were active rather than assuming the old installer supports the current contributor option.
+
+After the comparison, reinstall from the current checkout with the intended default or contributor command from step 1. Confirm doctor/catalog parity again. Record both treatments and their limitations in `docs/EVALS.md`; preserve the historical packet and answer files.

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -2594,6 +2594,13 @@ numbers for this exact text: C2 = 85 / 84 / 84 (Opus / Sonnet / Fable), 0 negati
 claims is "no routing loss under three LLM readers and one artifact boundary removed", not the decisive win
 the band asked for — the record above stands as written.
 
+**Amendment 2026-09-10 — the per-description 320 is retired (owner).** It was a design ceiling, not a client
+limit: Codex has no per-description cut — it trims every description round-robin only when the whole catalog
+overflows its total budget — and it rejects a description over 1,024 characters; Claude Code caps an entry at
+1,536. Holding 320 pushed routing boundaries and the `agentloopcodexcheck` stop-rule markers out of the text
+(PR #112). `test/skilldescbudgetcheck.sh` now fails only a description over 1,024 and keeps the 5,400 set
+total, which is what guards the round-robin tail cut. The rules above stay as registered.
+
 ### Subtoken acronym shredding — PRE-REGISTERED 2026-08-19 (before the fix is measured)
 
 **The defect.** The shared subtoken tokenizer shreds an all-caps run into single characters, which

--- a/skills/ripwire-before-you-build/SKILL.md
+++ b/skills/ripwire-before-you-build/SKILL.md
@@ -3,8 +3,8 @@ name: ripwire-before-you-build
 description: >
   Starting a FEATURE (multi-symbol work): the plan, the API boundary, the scope — how big does
   this change get — from the codebase's real structure. Implementing an EXISTING interface?
-  --lego=Iface lists its contract and implementors. ONE symbol → reuse-first. A small feature with
-  an obvious home needs none of this.
+  --lego=Iface lists its contract and current implementors. ONE standalone symbol → reuse-first.
+  A small feature with an obvious home needs none of this.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-before-you-build/SKILL.md
+++ b/skills/ripwire-before-you-build/SKILL.md
@@ -3,7 +3,8 @@ name: ripwire-before-you-build
 description: >
   Starting a FEATURE (multi-symbol work): the plan, the API boundary, the scope — how big does
   this change get — from the codebase's real structure. Implementing an EXISTING interface?
-  --lego=Iface lists its contract and current implementors. ONE standalone symbol → reuse-first.
+  --lego=Iface lists its contract and implementors. ONE symbol → reuse-first. A small feature with
+  an obvious home needs none of this.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-before-you-build/SKILL.md
+++ b/skills/ripwire-before-you-build/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: ripwire-before-you-build
 description: >
-  Starting a FEATURE (multi-symbol work): the plan, the API boundary, the scope — how big does this
-  change get — from the codebase's real structure; --lego=Iface lists an interface's contract and its
-  implementors. ONE symbol → reuse-first. A small feature with an obvious home needs none of this.
+  Starting a FEATURE (multi-symbol work): the plan, the API boundary, the scope — how big does
+  this change get — from the codebase's real structure. Implementing an EXISTING interface?
+  --lego=Iface lists its contract and current implementors. ONE standalone symbol → reuse-first.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-fresh-eyes/SKILL.md
+++ b/skills/ripwire-fresh-eyes/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ripwire-fresh-eyes
 description: >
-  Maintenance risk in code you did NOT write — inheriting a module, a suspected god object, 'what's
-  gnarly / where's the rot / safe to touch?': hotspots, dead code, clones, a function's real shape,
-  bus factor, co-change. Naming the fix or judging YOUR new code → quality-bar. A single-lens question
-  is a single call.
+  Maintenance risk in code you did NOT write — planning a refactor, a suspected god object,
+  'what's gnarly / where's the rot / safe to touch?': hotspots, dead code, clones, a function's
+  shape, bus factor, co-change. Also inactive code and switches/defaults (--flags). Judging YOUR
+  new code → quality-bar.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-fresh-eyes/SKILL.md
+++ b/skills/ripwire-fresh-eyes/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ripwire-fresh-eyes
 description: >
-  Maintenance risk in code you did NOT write — planning a refactor, a suspected god object,
-  'what's gnarly / where's the rot / safe to touch?': hotspots, dead code, clones, a function's
-  shape, bus factor, co-change. Also inactive code and switches/defaults (--flags). Judging YOUR
-  new code → quality-bar.
+  Maintenance risk in code you did NOT write — planning a refactor, a god object, 'what's gnarly /
+  where's the rot / safe to touch?': hotspots, dead or inactive code, switches/defaults (--flags),
+  clones, a function's shape, bus factor, co-change. YOUR new code → quality-bar. A single-lens
+  question is a single call.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-fresh-eyes/SKILL.md
+++ b/skills/ripwire-fresh-eyes/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ripwire-fresh-eyes
 description: >
-  Maintenance risk in code you did NOT write — planning a refactor, a god object, 'what's gnarly /
-  where's the rot / safe to touch?': hotspots, dead or inactive code, switches/defaults (--flags),
-  clones, a function's shape, bus factor, co-change. YOUR new code → quality-bar. A single-lens
-  question is a single call.
+  Maintenance risk in code you did NOT write — inheriting a module, planning a refactor, a suspected
+  god object, 'what's gnarly / where's the rot / safe to touch?': hotspots, dead or inactive code,
+  switches/defaults (--flags), clones, a function's real shape, bus factor, co-change. Naming the fix
+  or judging YOUR new code → quality-bar. A single-lens question is a single call.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-orient/SKILL.md
+++ b/skills/ripwire-orient/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: ripwire-orient
 description: >
-  Landing COLD in an unfamiliar repo/subsystem or about to open several files: map main subsystems
-  and entry points, 'how does X work / where is Y'. Also recover context, saved docs (--recall),
-  subagent splits (--partition), code gotchas (--note-add). NAMED symbol → navigate. Stop at the
-  first rung that answers.
+  Landing COLD in an unfamiliar repo or subsystem, or about to open several files for one question:
+  map first, read only what it ranks highest — main subsystems, entry points, 'how does X work /
+  where is Y'. Also recover context after compaction, retrieve saved docs (--recall), divide code for
+  subagents (--partition), save gotchas (--note-add). NAMED symbol → navigate. Stop at the first rung
+  that answers.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-orient/SKILL.md
+++ b/skills/ripwire-orient/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ripwire-orient
 description: >
-  Landing COLD in an unfamiliar repo or subsystem, or about to open several files for one question:
-  map first, read only the files it ranks highest. Main subsystems and entry points, 'how does X work
-  / where is Y'; compacted mid-task, rebuild what you knew. A NAMED symbol → navigate. Stop at the
-  first rung that answers.
+  Landing COLD in an unfamiliar repo/subsystem or about to open several files: map main subsystems
+  and entry points, 'how does X work / where is Y'. Also recover context, retrieve saved docs
+  (--recall), divide code for subagents (--partition), save code gotchas (--note-add). NAMED
+  symbol → navigate.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-orient/SKILL.md
+++ b/skills/ripwire-orient/SKILL.md
@@ -2,9 +2,9 @@
 name: ripwire-orient
 description: >
   Landing COLD in an unfamiliar repo/subsystem or about to open several files: map main subsystems
-  and entry points, 'how does X work / where is Y'. Also recover context, retrieve saved docs
-  (--recall), divide code for subagents (--partition), save code gotchas (--note-add). NAMED
-  symbol → navigate.
+  and entry points, 'how does X work / where is Y'. Also recover context, saved docs (--recall),
+  subagent splits (--partition), code gotchas (--note-add). NAMED symbol → navigate. Stop at the
+  first rung that answers.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-quality-bar/SKILL.md
+++ b/skills/ripwire-quality-bar/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ripwire-quality-bar
 description: >
-  Code QUALITY of what YOU just wrote, before you commit or say 'done': --quality-delta reports only
-  what got WORSE across 10 kinds and exits non-zero on new debt; then which restructuring a measured
-  shape (humps/deep, a tangle) calls for. Merge safety → change-check. Even a single-line leaf fix
-  runs the one-shot delta.
+  Code QUALITY of what YOU just wrote, or verifying a cleanup: --quality-delta reports only what
+  got WORSE across 10 kinds and exits non-zero on new debt; which restructuring a measured shape
+  (humps/deep, a tangle) calls for. Merge safety → change-check. Even a single-line leaf fix runs
+  the one-shot delta.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-quality-bar/SKILL.md
+++ b/skills/ripwire-quality-bar/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ripwire-quality-bar
 description: >
-  Code QUALITY of what YOU just wrote, or verifying a cleanup: --quality-delta reports only what
-  got WORSE across 10 kinds and exits non-zero on new debt; which restructuring a measured shape
-  (humps/deep, a tangle) calls for. Merge safety → change-check. Even a single-line leaf fix runs
-  the one-shot delta.
+  Code QUALITY of what YOU just wrote, before you commit or say 'done', or verifying a cleanup:
+  --quality-delta reports only what got WORSE across 10 kinds and exits non-zero on new debt; which
+  restructuring a measured shape (humps/deep, a tangle) calls for. Merge safety → change-check. Even
+  a single-line leaf fix runs the one-shot delta.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-reuse-first/SKILL.md
+++ b/skills/ripwire-reuse-first/SKILL.md
@@ -3,7 +3,7 @@ name: ripwire-reuse-first
 description: >
   About to write ONE symbol (even a 'quick' one-liner) or add a dependency: reuse before you reinvent.
   Finds the building block that already exists, the house pattern to imitate, the duplicate you'd
-  recreate, a vendored dependency. A whole feature → before-you-build. One --exemplar or --grep call
+  recreate, a vendored dependency. An interface or whole feature → before-you-build. One --exemplar or --grep call
   at most.
 allowed-tools: Bash, Read
 ---

--- a/skills/ripwire-write-tests/SKILL.md
+++ b/skills/ripwire-write-tests/SKILL.md
@@ -2,9 +2,9 @@
 name: ripwire-write-tests
 description: >
   Write tests for EXISTING code that has none — 'this is untested, add coverage', 'add a safety
-  net first'; also verify a new test reaches its code. Finds what no test reaches: --seams ranks
-  untested edges, --callers gives the outside contract. Diff test selection → change-check. For one
-  target one pass suffices.
+  net first'; also verify a new test reaches its intended code. Finds what no test reaches: --seams
+  ranks untested cross-module edges, --callers gives the outside contract. Diff test selection →
+  change-check. For one target one --seams or --callers pass suffices.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-write-tests/SKILL.md
+++ b/skills/ripwire-write-tests/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ripwire-write-tests
 description: >
-  Write tests for EXISTING code that has none — 'this is untested, add coverage', 'add a safety net
-  first'. Finds what no test reaches: --seams ranks untested cross-module edges, --callers gives the
-  outside contract. Judging your own diff → change-check. For one target one --seams or --callers pass
-  suffices.
+  Write tests for EXISTING code that has none — 'this is untested, add coverage', 'add a safety
+  net first'; also verify a new test reaches its intended code. Finds what no test reaches:
+  --seams ranks untested cross-module edges, --callers gives the outside contract. Diff test
+  selection → change-check.
 allowed-tools: Bash, Read
 ---
 

--- a/skills/ripwire-write-tests/SKILL.md
+++ b/skills/ripwire-write-tests/SKILL.md
@@ -2,9 +2,9 @@
 name: ripwire-write-tests
 description: >
   Write tests for EXISTING code that has none — 'this is untested, add coverage', 'add a safety
-  net first'; also verify a new test reaches its intended code. Finds what no test reaches:
-  --seams ranks untested cross-module edges, --callers gives the outside contract. Diff test
-  selection → change-check.
+  net first'; also verify a new test reaches its code. Finds what no test reaches: --seams ranks
+  untested edges, --callers gives the outside contract. Diff test selection → change-check. For one
+  target one pass suffices.
 allowed-tools: Bash, Read
 ---
 

--- a/test/skilldescbudgetcheck.sh
+++ b/test/skilldescbudgetcheck.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# skilldescbudgetcheck.sh — every skill description fits the client budget it is actually rendered under.
+# skilldescbudgetcheck.sh — every skill description fits the clients that actually render it.
 #
 # Issue #49 (2026-09-07): Codex renders the skill catalog under a TOTAL budget (2% of the context window,
 # or 8,000 chars) and, on overflow, hands description characters out round-robin — every over-long
-# description ends at the same count (350 in the reporter's install) and the tail, where the routing
-# boundaries lived, is what vanishes. Claude Code lists under 1% of the context window and caps an entry
-# at 1,536. The registered design ceiling (docs/EVALS.md "Skill descriptions under a client budget") is
-# 320 normalized characters per description — 30 under the observed cut, so the head IS the description —
-# and 5,400 (amended from 4,800 before measurement, see the registration) for the whole set, so the eighteen together stay a minority of any of those budgets.
+# description ends at the same count and the tail, where the routing boundaries live, is what vanishes.
+# Codex also REJECTS a description over 1,024 characters; Claude Code caps an entry at 1,536. So two things
+# are gated, both real: no description over 1,024 (Codex would drop the skill), and a set total of 5,400
+# (amended from 4,800 before measurement, see docs/EVALS.md "Skill descriptions under a client budget") so
+# the skills together stay a minority of those budgets. There is deliberately no tighter per-description
+# number: the registered 320 was a design ceiling, not a client limit, and holding it pushed routing
+# boundaries and stop rules out of the text — retired 2026-09-10 (the amendment in that EVALS section).
 # Length = the YAML content (whitespace-normalized, block-scalar marker excluded), exactly what a client
 # reads; bench/skilldesc_budget.py is the measurement and this gate's body.
 set -u
@@ -17,12 +19,12 @@ fail=0
 ok()  { echo "  ok   $*"; }
 no()  { echo "  FAIL $*"; fail=1; }
 
-out="$( python3 "$ROOT/bench/skilldesc_budget.py" "$ROOT/skills" --limit=320 2>&1 )"; rc=$?
+out="$( python3 "$ROOT/bench/skilldesc_budget.py" "$ROOT/skills" --limit=1024 2>&1 )"; rc=$?
 summary="$( printf '%s\n' "$out" | tail -1 )"
 printf '%s\n' "$out" | sed 's/^/    /'
 [ "$rc" -eq 0 ] \
-    && ok "every skill description is at or under 320 normalized characters" \
-    || no "a skill description exceeds 320 normalized characters — the head cut would drop its routing boundary ($summary)"
+    && ok "every skill description is at or under Codex's 1,024-character hard limit" \
+    || no "a skill description exceeds 1,024 characters — Codex rejects the skill outright ($summary)"
 
 total="$( printf '%s' "$summary" | sed -n 's/.* total=\([0-9]*\).*/\1/p' )"
 count="$( printf '%s' "$summary" | sed -n 's/.*skills=\([0-9]*\).*/\1/p' )"
@@ -36,10 +38,17 @@ tmp="$( mktemp -d )"; trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/a/ripwire-x" "$tmp/a/ripwire-y"
 printf -- '---\nname: ripwire-x\ndescription: >\n  one two   three\n  four\n---\nbody\n' > "$tmp/a/ripwire-x/SKILL.md"
 printf -- '---\nname: ripwire-y\ndescription: one two three four\n---\nbody\n' > "$tmp/a/ripwire-y/SKILL.md"
-lens="$( python3 "$ROOT/bench/skilldesc_budget.py" "$tmp/a" --limit=320 | awk 'NF==3{print $1}' | sort -u | tr '\n' ' ' )"
+lens="$( python3 "$ROOT/bench/skilldesc_budget.py" "$tmp/a" --limit=1024 | awk 'NF==3{print $1}' | sort -u | tr '\n' ' ' )"
 [ "$lens" = "18 " ] \
     && ok "block-scalar and inline descriptions measure identically (18 chars, marker excluded)" \
     || no "measurement disagrees between block-scalar and inline forms: '$lens'"
+
+# the per-description arm must be able to go red: a synthetic 1,100-character description has to fail it
+mkdir -p "$tmp/b/ripwire-z"
+printf -- '---\nname: ripwire-z\ndescription: %s\n---\nbody\n' "$( printf 'x%.0s' $( seq 1 1100 ) )" > "$tmp/b/ripwire-z/SKILL.md"
+python3 "$ROOT/bench/skilldesc_budget.py" "$tmp/b" --limit=1024 >/dev/null 2>&1 \
+    && no "a 1,100-character description passed the 1,024 limit — the per-description arm cannot go red" \
+    || ok "a 1,100-character description fails the 1,024 limit (the arm can go red)"
 
 # the binary's own skill discovery must see the same set the measurement measured: --eval-skills reports
 # K = candidate skills (ripwire-router excluded); a stub or stale binary, or a SKILL.md the binary cannot


### PR DESCRIPTION
## What this is

A Codex session wrote this branch, rebased it onto main `d90acb2c`, and ran out of tokens before pushing or opening a PR. It is pushed from a Claude session at the owner's request, with two follow-up commits.

**`29ae28d9` (Codex): restore routing capabilities and match evaluation catalogs**
- Six skill descriptions get back discovery triggers the budget round had dropped: `--lego` for implementing an existing interface (before-you-build), `--flags` for inactive code and switches (fresh-eyes), `--recall` / `--partition` / `--note-add` (orient), verifying that a new test reaches its code (write-tests), verifying a cleanup (quality-bar), and interface → before-you-build (reuse-first).
- `bench/skillrater/results/2026-09-07/CODEX_ROUTING_CHECK.md` (operator notes) now separates the default catalog (16 skills, 83 applicable positives) from the contributor catalog (17 skills, all 85), so the two are never scored as one. It also asks for the catalog, model, startup warnings and measured token usage to be recorded, and says the 138-prompt packet stops being held-out evidence once descriptions are tuned against its misses.

**`d1e5176f`: the four stop rules go back into frontmatter**

To fit a 320-character per-description ceiling, `29ae28d9` had deleted four one-sentence stop rules that `agentloopcodexcheck` requires (`first rung`, `needs none of this`, `single call`, `one target`), so it was red on that gate as submitted.

**`908110ab`: no arbitrary per-description ceiling**

The 320 was a design number, not a client limit. Codex has no per-description cut: it trims every description round-robin only when the whole catalog overflows its total budget, and it rejects a description over 1,024 characters. Claude Code caps an entry at 1,536. Holding 320 is what pushed the stop rules and several routing boundaries out of the text.

- `test/skilldescbudgetcheck.sh` now fails only a description over **1,024** (a real client limit) and keeps the **5,400 set total**, which guards against the round-robin tail cut. A new arm proves the per-description check still goes red, using a synthetic 1,100-character description.
- `docs/EVALS.md` gets a dated amendment under "Skill descriptions under a client budget"; the registered rules stay as written.
- The descriptions get back what they need to be correct, and nothing more:
  - **orient:** read only what it ranks highest; one question; recover context after compaction; the verbs back on `--recall` / `--partition` / `--note-add`
  - **before-you-build:** *ONE standalone symbol* (a symbol inside a feature is not reuse-first)
  - **fresh-eyes:** inheriting a module; *Naming the fix* → quality-bar
  - **write-tests:** intended code; cross-module edges; *one --seams or --callers pass*
  - **quality-bar:** *before you commit or say 'done'*

| skill | `29ae28d9` | now |
| --- | --- | --- |
| orient | 298 | 406 |
| fresh-eyes | 302 | 376 |
| write-tests | 300 | 355 |
| quality-bar | 305 | 338 |
| before-you-build | 277 | 334 |

Set total: 5,397 of 5,400. Not restored: quality-bar's list of the ten kinds and reuse-first's ROLE clause, which are body detail rather than routing.

## Verification

On `908110ab`, from a worktree with a fresh plain build, all of these pass: the 20 gates that read `SKILL.md` (agentloopcodexcheck, skilldescbudgetcheck, skilltruthcheck, skillevalcheck, skillinstallcheck, skillscanreadcheck, reusefirstworkflowcheck, shapingflagcheck, codexdoctorcheck, codexplugincheck, hermesinstallcheck, releaseinstallcheck, mcpverbscheck, subtokencheck, testedreachcheck, deckcheck, htmlhostcheck, claudeconfigdircheck, taskroutecheck, readmedriftcheck), plus mcpattrparitycheck, mcptranchecheck and limitstablecheck, which read `docs/EVALS.md`. `binoverridecheck` builds a second binary inside the gate and is left to CI, which runs the full suite here.

Checked before pushing: no plan or prompt files, no private-corpus names, no home paths, no `.json`, and no change to the gate count, parser version or ack ledger.

## Not measured

- Codex planned an after-fix routing evaluation (fresh Codex turns on the installed catalog, plus a sealed forward packet). It never ran; its results directory holds only the plan. The only live Codex routing number is the **pre-fix** 2026-09-09 run (77/85 hit@1, 77/83 excluding the contributor-only skill, 0/53 false fires). It is not committed here and says nothing about these descriptions.
- The deterministic routing floors in skillevalcheck and taskroutecheck pass. That is the whole routing evidence for this change.
- The operator notes cite a 23,824-input-token run from 2026-09-09 whose raw results are not in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
