### PR TITLE
docs(readme): Trendshift badge beside the wave, one heading at the top, and the Austen readings wink at themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 # Rip'n Fast. Fewer Tokens. Better Code.
 
-## The ripgrep of AI context. Give your coding agent a map before it reads the repo.
+**The ripgrep of AI context. Give your coding agent a map before it reads the repo.**
 
 Point it at any repository and your agent gets a ranked, deterministic call graph — what to touch,
 what it breaks, which tests to run — instead of grepping around and reading whole files.
 
-<p align="center"><img src="docs/assets/paddle-out.svg" alt="Paddle out with a map." width="470"></p>
+<p align="center"><img src="docs/assets/paddle-out.svg" alt="Paddle out with a map. See the rip before you’re in it." width="470"> <a href="https://trendshift.io/repositories/217924?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-217924"><img align="middle" src="https://trendshift.io/api/badge/trendshift/repositories/217924/daily?language=C%2B%2B" alt="Trendshift: #1 C++ Repository of the Day, 2026-09-07" width="250" height="55"></a></p>
 
 <details>
 <summary><b>Fifty years of software-engineering results, and research from last month.</b> 46 repositories and 69 papers folded — McCabe (1976) through to <b>seven published in the last two months</b> — each row in <a href="docs/LINEAGE.md"><b>docs/LINEAGE.md</b></a> naming the lesson taken and the file it lives in</summary>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Point it at any repository and your agent gets a ranked, deterministic call graph — what to touch,
 what it breaks, which tests to run — instead of grepping around and reading whole files.
 
-<p align="center"><img src="docs/assets/paddle-out.svg" alt="Paddle out with a map. See the rip before you’re in it." width="470"> <a href="https://trendshift.io/repositories/217924?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-217924"><img align="middle" src="https://trendshift.io/api/badge/trendshift/repositories/217924/daily?language=C%2B%2B" alt="Trendshift: #1 C++ Repository of the Day, 2026-09-07" width="250" height="55"></a></p>
+<p align="center"><img src="docs/assets/paddle-out.svg" alt="Paddle out with a map. See the rip before you’re in it." width="470"> <a href="https://trendshift.io/repositories/217924?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-217924"><img align="middle" src="https://trendshift.io/api/badge/trendshift/repositories/217924/daily?language=C%2B%2B" alt="Trendshift: C++ Repository of the Day badge for redhat-et/ripwire" width="250" height="55"></a></p>
 
 <details>
 <summary><b>Fifty years of software-engineering results, and research from last month.</b> 46 repositories and 69 papers folded — McCabe (1976) through to <b>seven published in the last two months</b> — each row in <a href="docs/LINEAGE.md"><b>docs/LINEAGE.md</b></a> naming the lesson taken and the file it lives in</summary>

--- a/README.md
+++ b/README.md
@@ -402,7 +402,8 @@ wherever they live — not by file path alone. On an astral-sh/ruff clone (5,945
 ---
 
 *The table above, read two other ways. Every figure in both is one of its measured numbers; only the
-manners and the cynicism are editorial.*
+manners and the cynicism are editorial. Should the reader find the manners excessive, the author begs
+them to recall that the alternative was a second table.*
 
 <details>
 <summary>📖 &nbsp;<b>The same table, as narrated by Jane Austen</b></summary>


### PR DESCRIPTION
## What

Vertical space at the top of the README is at a premium. Two changes, both on lines a first-time visitor sees without scrolling:

- The Trendshift **#1 C++ Repository of the Day** badge (2026-09-07) sits beside the paddle-out wave on one centered line. Both are inline images in one paragraph, with no floats: on a narrow screen they stack, centered, and the `<details>` block below never wraps around them.
- The tagline under the H1 goes from an `##` heading to bold text. That is one heading block and its underline less, and the H1 no longer shares the top with a second large heading.

The wave's `alt` text now carries both of its lines.

Separately, the always-visible line above the Jane Austen and cynic readings of the comparison table gains one sentence that puts the joke on the README rather than on its readers: *"Should the reader find the manners excessive, the author begs them to recall that the alternative was a second table."* The figures, the folds and both narrations are unchanged.

## Checked

- GitHub's own renderer (`POST /markdown` with context `redhat-et/ripwire`) keeps `align="middle"` and the badge's `width`/`height`, and serves the badge through its image proxy. Inline `style` and `<font size>` are stripped, so an H1 is already the largest text GitHub renders; demoting the second heading is what makes the first one read bigger.
- No link anywhere in the repository targets the removed heading's anchor, and no gate pins those lines.
- The 21 local gates that read `README.md` pass on this commit: readmedriftcheck, readmeexamplecheck, recallevalcheck, recallrankdepthcheck, recalltotalcheck, tokenbudgetcheck, textdocscheck, docdriftcommentcheck, deckclaimcheck, deckcheck, ripwirepubliccheck, rootrelcheck, gatecountcheck, manifestcheck, forrankordercheck, attrvocabcheck, floormarkcheck, propcostcheck, emittertruthcheck, mcpverbscheck and agenttablecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
