### PR TITLE
fix(pargates): gates stop writing __pycache__/ into the checkout the crawl counts

### DIFF
--- a/test/pargates.py
+++ b/test/pargates.py
@@ -392,7 +392,13 @@ def failure_report(out, logpath):
 
 
 def run(g):
-    env = dict(os.environ, RIPWIRE_BIN=binp)
+    # PYTHONDONTWRITEBYTECODE: a gate that imports a module straight out of the checkout (agentlooplockcheck:
+    # bench/agentloop/; aiderbytescheck: bench/headtohead/r4-2026-08-06/) would otherwise have Python drop a
+    # __pycache__/ beside it. That directory is gitignored, so the tree tripwire below cannot see it, and its
+    # name is on the crawl's built-in denylist, so every crawl of the live repo still counts it
+    # (corpus_pruned_dirs=). Created between the two re-crawls of pagingsweepcheck's cold grep (G) pair, it
+    # made that pair disagree on main twice (CI runs 34534320580, 34536435376). pargatescheck.sh pins it.
+    env = dict(os.environ, RIPWIRE_BIN=binp, PYTHONDONTWRITEBYTECODE="1")
     scaled_default = int( round( DEFAULT_TIMEOUT_SEC * budget_scale ) )
     if g in GATE_BUDGET_SEC:
         # A declared entry is a FLOOR, not a ceiling: it is the number below which this gate would be a
@@ -481,6 +487,11 @@ def _bin_fingerprint():
 # counts. A hit FAILS the run: a writer is a defect whether or not a determinism arm happened to be
 # reading in that window, and the same suite would only flake somewhere else next time.
 # `--no-optional-locks` keeps the sampler from ever taking the index lock a gate might need.
+#
+# Its blind spot is a write git ignores. That is usually harmless, because the crawl skips gitignored paths
+# too -- EXCEPT a directory whose NAME is on the crawl's own denylist (build, __pycache__, node_modules, ...):
+# a crawl of the live repo still counts it in corpus_pruned_dirs= while `git status` stays empty. Python's
+# bytecode cache was one such writer (see run()'s PYTHONDONTWRITEBYTECODE); a clean report stays "none found".
 DIRT_POLL_SEC = float(os.environ.get("PARGATES_DIRT_POLL_SEC", "0.25"))
 
 
@@ -603,7 +614,8 @@ if dirt_seen:
         print(f"***   {ln}  seen {n}x, T+{t_first}s..T+{t_last}s; running then: {who}")
     print("***   Every stamped verb reads `git status --porcelain` for its at=\"...+dirty\" bit from ANY crawl root")
     print("***   inside this checkout, so a determinism arm that ran in that window can red with the tree innocent.")
-    print("***   Fix the writer first (work on a copy, or a gitignored name); only then triage the arms above.")
+    print("***   Fix the writer first (work on a copy, or a gitignored name that is not a crawl-pruned directory")
+    print("***   name -- never build/, __pycache__/ or node_modules/); only then triage the arms above.")
 if skips:
     print("\nSKIPPED (ran, but proved nothing — not counted as passing):")
     for g, rc, dt, out, _ in skips:

--- a/test/pargatescheck.sh
+++ b/test/pargatescheck.sh
@@ -277,6 +277,80 @@ printf '%s\n' "$outN" | grep -q 'tree tripwire: DISARMED' \
     && ok "functional(tree): UNWATCHED -- the run says the tripwire is disarmed rather than implying a clean tree" \
     || no "functional(tree): UNWATCHED -- no DISARMED disclosure on a corpus git cannot see"
 
+# ── A WRITE THE TRIPWIRE CANNOT SEE: PYTHON'S BYTECODE CACHE (2026-09-10, CI runs 34534320580, 34536435376) ──
+# The tripwire reads `git status`, so it sees what git sees and nothing else. A gate that imports a module
+# straight out of the checkout makes Python write __pycache__/ beside it -- agentlooplockcheck into
+# bench/agentloop/ and bench/locbench/, aiderbytescheck into bench/headtohead/r4-2026-08-06/. That name is
+# gitignored, so the run reports tree_writes=0; it is also on the crawl's built-in denylist, so every crawl of
+# the live repo counts it (grep's corpus_pruned_dirs= goes 3 -> 4 on a fresh checkout). #118 moved both
+# importers into pagingsweepcheck's shard 1/4, and its cold grep (G) pair -- two full re-crawls seconds apart --
+# went red twice on main with "paged page NOT deterministic" on a tree clean by every measure the harness had.
+# run() now gives every gate PYTHONDONTWRITEBYTECODE=1. Two functional arms on one corpus shape:
+#   BYTECODE  the REAL script: a git corpus (__pycache__/ gitignored, as in this repo) whose one gate imports a
+#             committed module -> the gate passes, tree_writes=0, rc 0, and no __pycache__ exists afterwards.
+#   MUTANT    a copy with ONLY that variable removed from run()'s env -> the same gate leaves __pycache__ behind
+#             and the run STILL reports tree_writes=0. That proves the probe really caches bytecode (so BYTECODE
+#             is not vacuous on a Python that never does), and it pins the blind spot the variable closes.
+grep -qE '^    env = dict\(os\.environ, RIPWIRE_BIN=binp, PYTHONDONTWRITEBYTECODE="1"\)$' "$PARGATES" \
+    && ok "static: run() gives every gate PYTHONDONTWRITEBYTECODE=1" \
+    || no "static: run() no longer sets PYTHONDONTWRITEBYTECODE=1 -- a gate importing from the checkout leaves a __pycache__/ the crawl counts and git cannot see"
+
+mkPycCorpus(){   # mkPycCorpus <dir>
+    local d="$1"
+    mkdir -p "$d/test/pyprobe"
+    printf '__pycache__/\n' > "$d/.gitignore"
+    printf 'VALUE = 1\n' > "$d/test/pyprobe/pycprobemod.py"
+    cat > "$d/test/pycprobecheck.sh" <<'EOF'
+#!/usr/bin/env bash
+ROOT="$( cd "$( dirname "$0" )/.." && pwd )"
+if python3 - "$ROOT" <<'PY'
+import sys
+sys.path.insert( 0, sys.argv[1] + "/test/pyprobe" )
+import pycprobemod
+sys.exit( 0 if pycprobemod.VALUE == 1 else 1 )
+PY
+then printf '  PASS  %s\n' "imported a committed module out of the checkout"; echo "ALL PASS"; exit 0
+else printf '  FAIL  %s\n' "could not import test/pyprobe/pycprobemod.py"; echo "FAILURES ABOVE"; exit 1
+fi
+EOF
+    chmod +x "$d/test/pycprobecheck.sh"
+    ( cd "$d" && git init -q . && git config user.email t@t && git config user.name t \
+      && git add -A && git commit -qm base ) >/dev/null 2>&1 \
+      || { no "functional(bytecode): could not init the synthetic git corpus at $d"; return 1; }
+}
+pycDirs(){ find "$1" -name __pycache__ -type d 2>/dev/null | wc -l | tr -d ' '; }
+
+PYC="$TMP/pyc";       mkPycCorpus "$PYC"
+PYCMUT="$TMP/pycmut"; mkPycCorpus "$PYCMUT"
+NOPYC="$TMP/pargates_nopyc.py"
+python3 - "$PARGATES" "$NOPYC" 2>/dev/null <<'PYEOF'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+text = open(src).read()
+needle = 'env = dict(os.environ, RIPWIRE_BIN=binp, PYTHONDONTWRITEBYTECODE="1")'
+assert needle in text, "run()'s env line not found verbatim -- the static arm above should already have failed"
+open(dst, "w").write(text.replace(needle, 'env = dict(os.environ, RIPWIRE_BIN=binp)', 1))
+PYEOF
+
+# `env -u`: an outer PYTHONDONTWRITEBYTECODE (a developer's shell, a CI image) would make both arms pass for the
+# wrong reason -- the variable under test must come from pargates.py or from nowhere.
+outP="$( env -u PYTHONDONTWRITEBYTECODE python3 "$PARGATES" "$PYC" "$FAKEBIN" --only pycprobecheck 2>&1 )"; rcP=$?
+printf '%s\n' "$outP" | grep -qE '^gates=1 pass=1 .* tree_writes=0$' && [ "$rcP" -eq 0 ] && [ "$( pycDirs "$PYC" )" = 0 ] \
+    && ok "functional(bytecode): BYTECODE -- a gate importing from the checkout passes and leaves no __pycache__ (tree_writes=0, rc 0)" \
+    || { no "functional(bytecode): BYTECODE -- expected pass, tree_writes=0, rc 0, 0 __pycache__ dirs; got rc=$rcP, $( pycDirs "$PYC" ) dir(s): $( printf '%s\n' "$outP" | grep -E '^gates=' )"; printf '%s\n' "$outP" | sed 's/^/    /' | head -20; }
+
+if [ ! -s "$NOPYC" ]; then
+    no "functional(bytecode): MUTANT -- could not build the mutant: run()'s env line is not verbatim (the static arm above says why)"
+else
+    outM="$( env -u PYTHONDONTWRITEBYTECODE python3 "$NOPYC" "$PYCMUT" "$FAKEBIN" --only pycprobecheck 2>&1 )"; rcM=$?
+    [ "$( pycDirs "$PYCMUT" )" != 0 ] \
+        && ok "functional(bytecode): MUTANT -- without the variable the same gate leaves __pycache__ behind (the probe is live)" \
+        || no "functional(bytecode): MUTANT -- without the variable the probe still wrote no __pycache__: this Python never caches bytecode, so BYTECODE proves nothing"
+    printf '%s\n' "$outM" | grep -qE '^gates=1 pass=1 .* tree_writes=0$' \
+        && ok "functional(bytecode): MUTANT -- and the run still reports tree_writes=0: git cannot see this write, only the variable prevents it" \
+        || no "functional(bytecode): MUTANT -- expected tree_writes=0 for a gitignored write the tripwire cannot see; got rc=$rcM: $( printf '%s\n' "$outM" | grep -E '^gates=' )"
+fi
+
 # ── THE DECLARED BUDGET IS A FLOOR, NOT A CEILING (2026-09-10, CI run 34479806177) ───────────────────────
 # GATE_BUDGET_SEC entries were originally exempt from --budget-scale, on the reasoning that each was derived
 # from a CI measurement and should stand as declared. Under CI's --budget-scale 4 that inverted the table's

--- a/test/regression.sh
+++ b/test/regression.sh
@@ -11,6 +11,9 @@
 # cache-transparency compare ripwire against itself so they hold on any corpus.
 
 set -u
+# A gate that imports a module out of the checkout would otherwise leave __pycache__/ in it: gitignored, but
+# still counted by every crawl of the live repo (corpus_pruned_dirs=). test/pargates.py sets the same per gate.
+export PYTHONDONTWRITEBYTECODE=1
 ROOT="$( cd "$( dirname "$0" )/.." && pwd )"
 BIN="${RIPWIRE_BIN:-$ROOT/build/ripwire}"
 [ "${BIN#/}" = "$BIN" ] && BIN="$ROOT/$BIN"          # allow a repo-relative RIPWIRE_BIN


### PR DESCRIPTION
## What was red

`pagingsweepcheck.sh` → `grep: paged page NOT deterministic`, twice in a row on main (dacf47fe, c1d90d3e), ubuntu plain clang shard 1/4, with `tree_writes=0`.

## Cause

The (G) arm runs two cold `--grep=NodeId` crawls of the live repo a few seconds apart. Between them, a neighbour gate imported a Python module straight out of the checkout, and Python wrote a `__pycache__/` beside it:

| gate | writes |
| --- | --- |
| agentlooplockcheck | `bench/agentloop/__pycache__/`, `bench/locbench/__pycache__/` |
| aiderbytescheck | `bench/headtohead/r4-2026-08-06/__pycache__/` |

`__pycache__/` is gitignored, so `git status --porcelain --untracked-files=all` stays empty and the tree tripwire reports `tree_writes=0`. But the name is also on the crawl's built-in denylist, so `--grep` counts it: `corpus_pruned_dirs=` goes from 3 to 4 on a fresh checkout, and the two page outputs differ. #118's new gate reshuffled the LPT shard plan and moved both importers into pagingsweepcheck's shard 1/4. Before #118 they ran in shards 2 and 3.

## Fix

- `test/pargates.py` `run()`: every gate runs with `PYTHONDONTWRITEBYTECODE=1`. The tripwire comment and advice now say that a gitignored name the crawl prunes (`build/`, `__pycache__/`, `node_modules/`) is not a safe scratch name.
- `test/regression.sh`: the same export.
- `test/pargatescheck.sh`: three new arms.
  - A static arm.
  - **BYTECODE**: runs the real script. A gate that imports a committed module leaves no `__pycache__` behind, with `tree_writes=0` and rc 0.
  - **MUTANT**: a copy with only that variable removed. The gate leaves `__pycache__` behind, and the run still reports `tree_writes=0`.

## Evidence

- On a fresh origin/main checkout, the real gates leave three `__pycache__/` dirs with `tree_writes=0`. With this `pargates.py` they leave none.
- `pargatescheck.sh`: 43 PASS, 0 FAIL.
- Reverting the env line turns the static, BYTECODE and MUTANT-build arms red.
- No gate count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
