### PR TITLE
tidy(swappable): the defaults reveal — 18 more real swappable-parameter rows, none silenced

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,3 +41,20 @@ WarningsAsErrors: ''
 
 # No automatic fixes. `-fix` on a data-oriented tree rewrites layout decisions that were made on purpose.
 FormatStyle: none
+
+# bugprone-easily-swappable-parameters is set to REVEAL, because the rows are real. Measured 2026-09-10 on e63e2d43
+# with the style job's toolchain and version.h stamped: every one of the 209 rows the upstream defaults report was
+# read and labeled. 208 are role pairs where a swap compiles and silently changes the answer — (root, path),
+# (fileId, line), (topN, budgetBytes), out-parameter pairs — and 1 is noise. So every option that shrinks the table
+# silences real rows. Counted per option: ModelImplicitConversions=false 31, MinimumLength=3 192, ignoring the
+# string_view suffix 54, the name lists a;b;x;y / from;to;lo;hi;start;stop;open;close / second;lo;hi 4 / 9 / 1, and a
+# name-affix threshold of 3 8. None of those is set. The two options below only ADD rows, and every added row is real:
+#   NamePrefixSuffixSilenceDissimilarityThreshold 0 (upstream 1): +3. Names one character apart were silenced as
+#     "similar", which hid archViolates(la, lb), findStringValue(vs, ve) and parseCappedCsvPair(capA, capB).
+#   QualifiersMix true (upstream false): +15. A const T& input beside a T& output, e.g. readFile(path, out): a swap
+#     compiles whenever the caller's input is a mutable lvalue, the common case here. These rows are also debt against
+#     CONTRIBUTING.md §3 "Interfaces" (structured-binding returns over out-params).
+# SuppressParametersUsedTogether stays true: false adds 440 rows, most of them (a, b) / (i, n) noise.
+CheckOptions:
+  bugprone-easily-swappable-parameters.NamePrefixSuffixSilenceDissimilarityThreshold: 0
+  bugprone-easily-swappable-parameters.QualifiersMix: true


### PR DESCRIPTION
**The defaults are set to reveal, because the rows are real.** You may have expected a smaller table: there is no
zero-casualty way to get one. Of the 209 rows `bugprone-easily-swappable-parameters` reports at the upstream defaults,
208 are genuine — a swap compiles and silently changes the answer — so every option that shrinks the table silences real
hazards. The two options set here only add rows, and every added row is real. The job stays advisory
(`continue-on-error`, empty `WarningsAsErrors`), so the extra rows cost nothing in CI.

Based on main after #120 (ea742649), which stamps version.h before the style job — without it the job measures a broken
parse. Lands after the string/perf integration PR, whose `-march=x86-64-v3` changes the flags the tidy job parses with;
the table below is measured on e63e2d43, and the re-measure on that branch is under Verification.

## Method
- Corpus: e63e2d43 (#120 merged with main 05f4b892), the style job's five TUs, clang-tidy 22.1.8. Linux x86-64 container
  (GNU 13.3 compile database, libstdc++ 14) for the reference run; native macOS clang-tidy 22.1.8 for the search. At
  the defaults the two produce the identical 209-row key set.
- Every one of the 209 rows was read and labeled with evidence (function body, call sites): SYM (swap-invariant),
  CALLBACK (no positional human call site), RANGE, OUTPAIR, ROLE-STRING / ROLE-INT / ROLE-OTHER.
- Rubric, reviewed in the "cap follow-up round: six lanes" thread: NOISE = SYM + CALLBACK + RANGE only when the names are
  conventional range vocabulary AND a swap normalizes or degrades to empty. KEEP = everything else. Objective: **zero
  KEEP casualties** (a KEEP function silenced entirely; a run that re-splits into a shorter one still warns).
- Result: **208 KEEP, 1 NOISE** (`inconsistentReturnLine(bodyStart, bodyEnd)`). Rows that looked like noise and are not:
  `equalsIgnoringAsciiSpace(a, b)` skips whitespace in `a` only; `countAbsent(a, b)` is one-way; `unionInto` writes
  `into` only; `sliceBodyLinesOrError` normalizes a swapped window to a valid-but-wrong line; the one lambda is called
  positionally by our own template `forEachLexSubtokenHashed`.

## Every option measured, one at a time
| option | rows | NOISE removed | KEEP casualties |
| --- | --- | --- | --- |
| (upstream defaults) | 209 | — | — |
| ModelImplicitConversions: false | 177 | 0 | 31 |
| MinimumLength: 3 | 14 | 1 | 192 |
| IgnoredParameterTypeSuffixes += string_view;string | 154 | 0 | 54 |
| IgnoredParameterNames += a;b;x;y | 205 | 0 | 4 |
| IgnoredParameterNames += from;to;lo;hi;start;stop;open;close | 200 | 0 | 9 |
| IgnoredParameterNames += second;lo;hi (± start;stop) | 208 | 0 | 1 (`hostsForSpan(fileId, lo)`) |
| NamePrefixSuffixSilenceDissimilarityThreshold: 3 | 204 | 0 | 8 (srcFile/dstFile, rows/cols, defPath/usePath …) |
| NamePrefixSuffixSilenceDissimilarityThreshold: 2 | 211 | 0 | 0 (+2) |
| **NamePrefixSuffixSilenceDissimilarityThreshold: 0** | **212** | 0 | **0 (+3)** |
| **QualifiersMix: true** | **223** | 0 | **0 (+15)** |
| SuppressParametersUsedTogether: false | 628 | — | — (+440, mostly `(a, b)` / `(i, n)` noise; stays true) |
| **both bold options (this PR)** | **226** | 0 | **0 (+18)** |

No renames and no NOLINTs: no verified CALLBACK row remains, and no name option is one role-carrying rename away from clean.

## What the two options surface
- Threshold 0 (+3): `archViolates(la, lb)` (dependency direction), `findStringValue(vs, ve)` (an out-pair),
  `parseCappedCsvPair(capA, capB)`.
- QualifiersMix (+15): a `const T&` input beside a `T&` output — `readFile` / `readWhole` / `readWholeFile` /
  `readFilePrefix` / `readQSnapBlob(path, out)`, `readTraceText(src, text)`, `qualityDeltaJson` /
  `qualityBaselineJson(root, errOut)`, `ensureStage(root, error)`, `applyOutInto(const float* a, float* h)`,
  `harvestCodeLine(wanted, into)`, `appendRowText(out, src)`, `appendForListStems(tokens, stems)`,
  `parseSkillMd(text, descOut)`, `sliceSincePrepare`. A swap compiles whenever the caller's input is a mutable lvalue —
  the common case here, where paths and buffers are `std::string` locals. These rows are also debt against CONTRIBUTING.md
  §3 "Interfaces" (structured-binding returns over out-params): a follow-up that returns the value retires them properly.
  Suppressing them would not.

## Verification
- `clang-tidy --verify-config`: the new options parse and apply (`--dump-config` shows `0` / `true`). Its one warning
  predates this PR: the curated `misc-dangling-*` glob matches no check in clang-tidy 22.
- Swappable-only run driven by the committed `.clang-tidy`: 226 rows, key-for-key identical to the measured F2 config.
- Linux x86-64 (the style job's toolchain): threshold 0 alone → 212 rows and both options → 226 rows, each key-for-key
  identical to the native search runs, 0 KEEP casualties against the Linux default run.
- Full-check run of the whole curated selection, before and after (native): only bugprone-easily-swappable-parameters
  rows differ (+18 added, 1 re-split); every other check reports the identical set.
- **Re-measured on the string/perf integration head** (PR #127, 17058123 on main edbb978d; the compile database carries
  `-march=x86-64-v3`; Linux x86-64, version.h stamped): upstream defaults 219 rows, this config 237. The 14 rows new at
  the defaults were read and labeled like the rest (lane K's strkern.h kernels among them): **217 KEEP, 2 NOISE**
  (`inconsistentReturnLine`, and `Byteset256::addRange(lo, hi)`, whose swap empties the loop). This config adds 19
  rows — the 18 above plus `mentionUnkeptFiles(kept, out)` — every one KEEP (237 = 235 KEEP + the same 2 NOISE), and
  silences none: **0 casualties**. #127 does not touch `.clang-tidy`, and #124 merges cleanly on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
