### PR TITLE
perf(ingest,pattern): the last indexed child walks — twenty-two cursors, three reasons, every arm red first

### DIFF
--- a/src/infra/tschildren.h
+++ b/src/infra/tschildren.h
@@ -23,6 +23,17 @@
 // a FIXED-INDEX probe (`ts_node_child( n, 0 )`), or a scan of a node whose children a comment cannot reach.
 // If you cannot name that reason in one line, use the cursor.
 //
+// Lane W4 (2026-09-10) then audited the ~25 loops the class-3 table had left across ingest_relations.h,
+// ingest_names.h, ingest_elixir.h, ingest_sidecap.h and pattern.h: twenty-two of them measured 13x..126x
+// their control under the flood and are cursors now (test/childwalkscalecheck.sh, arms B13..B36 — every
+// one proven red on the pre-change binary first); the three that stay indexed each carry the one-line
+// reason at the loop — the markdown grammar has no extras at all (mdWalk), and a string's children come
+// from the external scanner, which owns every byte between the delimiters (stringLiteralText, the Elixir
+// test-title scan). Two lessons from that round: a FLAT measurement proves the fixture missed the list,
+// never that the loop is safe (leading comments belong to the PARENT, not the child that has not started;
+// an uncaptured form never enters the walk); and a control can be quadratic in its own right when the walk
+// under test runs on every ancestor of a def.
+//
 // WHY IT IS ITS OWN HEADER AND NOT A SECTION OF ingest.cpp. It was one, inside ingest_metrics.h's unnamed
 // namespace, and that made it unreachable from the two headers that ALSO walk whole subtrees and are
 // compiled outside that translation unit — src/preprocdead.h (shared with src/slice.h). The result was
@@ -47,6 +58,8 @@
 // also why a scaling gate must flood with comments: a declaration flood of identical width goes green
 // over a live defect.
 
+#include <cstring>
+#include <initializer_list>
 #include <vector>
 
 #include <tree_sitter/api.h>
@@ -133,6 +146,35 @@ inline bool anyChildBelow( TSNode n, int maxDepth, bool namedOnly, const Pred& p
         }
         found = true;
         return false;
+    } );
+    return found;
+}
+
+// FIRST child of n whose node type is one of `kinds` (named children only when `namedOnly`), or a null node
+// when none is — the cursor form of the `for( i ) { if( strcmp( ts_node_type( ts_node_child( n, i ) ), K ) == 0 )
+// return child; }` probe that lane W4 found spelled at six sites (a C# using directive's specifier, an Elixir
+// call's `arguments` and `do_block`, an ObjC method's body, a linkage_specification's string, the C++
+// using-declaration keyword). One spelling, so a converted probe cannot drift back into an indexed one.
+inline TSNode firstChildOfKind( TSNode n, bool namedOnly, std::initializer_list<const char*> kinds )   // A4-F25: NOT noexcept — the cursor allocates
+{
+    TSNode      found = {};
+    ChildCursor cursor( n );
+    forEachChild( n, cursor.cur, [ & ]( TSNode child )
+    {
+        if( namedOnly && !ts_node_is_named( child ) )
+        {
+            return true;
+        }
+        const char* type = ts_node_type( child );
+        for( const char* kind : kinds )
+        {
+            if( std::strcmp( type, kind ) == 0 )
+            {
+                found = child;
+                return false;
+            }
+        }
+        return true;
     } );
     return found;
 }

--- a/src/ingest_docs.h
+++ b/src/ingest_docs.h
@@ -111,6 +111,11 @@ inline void mdWalk( TSNode node, std::string_view src, bool inQuote, std::uint32
         out.opaque.emplace_back( a, b );
         return;   // nothing inside is structure, mention or link
     }
+    // Every indexed named-child loop in this walker stays indexed ON PURPOSE (src/infra/tschildren.h's
+    // one-line test): the markdown grammar declares NO extras — its vendored parser.c carries zero
+    // SHIFT_EXTRA actions — so nothing is ever spliced into a child array here, and every list below is a
+    // balanced grammar repeat that ts_node__child skips in O(1). Measured: a 16 000-paragraph document is
+    // flat on the indexed form (lane W3's sweep, test/childwalkscalecheck.sh).
     if( std::strcmp( type, "link_reference_definition" ) == 0 )
     {
         out.opaque.emplace_back( a, b );   // not mention-scanned …

--- a/src/ingest_elixir.h
+++ b/src/ingest_elixir.h
@@ -47,15 +47,10 @@ TSNode elixirArguments( TSNode node ) noexcept
     {
         return {};
     }
-    for( std::uint32_t childId = 0; childId < ts_node_named_child_count( node ); ++childId )
-    {
-        const TSNode child = ts_node_named_child( node, childId );
-        if( std::strcmp( ts_node_type( child ), "arguments" ) == 0 )
-        {
-            return child;
-        }
-    }
-    return {};
+    // O(children): tree-sitter-elixir accepts comments between a call's head and its do-block and splices
+    // them into the call node itself — 16 000 of them measured 82x under elixirBody's twin of this scan
+    // (test/childwalkscalecheck.sh, arm B30, attributed by `sample`; the rule is on src/infra/tschildren.h)
+    return firstChildOfKind( node, /*namedOnly=*/true, { "arguments" } );
 }
 
 /// Return the first direct call argument, or a null node for an absent or empty argument list.
@@ -75,43 +70,45 @@ TSNode elixirKeywordValue( TSNode node, std::string_view key, std::string_view s
     {
         return {};
     }
-    for( std::uint32_t argId = 0; argId < ts_node_named_child_count( args ); ++argId )
+    // O(children) at both levels: `def f(x), # … do: x` puts the comments in the arguments (81x at 16 000,
+    // test/childwalkscalecheck.sh arm B29). Two cursors: the pair walk runs while the argument walk is open.
+    TSNode      value   = {};
+    bool        matched = false;
+    ChildCursor argCursor( args );
+    ChildCursor pairCursor( args );
+    forEachNamedChild( args, argCursor.cur, [ & ]( TSNode arg )
     {
-        const TSNode arg = ts_node_named_child( args, argId );
         if( std::strcmp( ts_node_type( arg ), "keywords" ) != 0 )
         {
-            continue;
+            return true;
         }
-        for( std::uint32_t pairId = 0; pairId < ts_node_named_child_count( arg ); ++pairId )
+        forEachNamedChild( arg, pairCursor.cur, [ & ]( TSNode pair )
         {
-            const TSNode pair = ts_node_named_child( arg, pairId );
             auto found = nodeTextOf( fieldChild( pair, NodeField::Key ), src );
             while( !found.empty() && std::isspace( static_cast<unsigned char>( found.back() ) ) )
             {
                 found.remove_suffix( 1 );
             }
-            if( found == key )
+            if( found != key )
             {
-                return fieldChild( pair, NodeField::Value );
+                return true;
             }
-        }
-    }
-    return {};
+            value   = fieldChild( pair, NodeField::Value );
+            matched = true;
+            return false;
+        } );
+        return !matched;
+    } );
+    return value;
 }
 
 /// Find a definition's direct do-block or do-keyword value without adopting an ancestor's body.
 /// node must be non-null; src must contain its source span. Return a null node when no body exists.
 TSNode elixirBody( TSNode node, std::string_view src ) noexcept
 {
-    for( std::uint32_t childId = 0; childId < ts_node_named_child_count( node ); ++childId )
-    {
-        const TSNode child = ts_node_named_child( node, childId );
-        if( std::strcmp( ts_node_type( child ), "do_block" ) == 0 )
-        {
-            return child;
-        }
-    }
-    return elixirKeywordValue( node, "do:", src );
+    // O(children) — arm B30 in test/childwalkscalecheck.sh; the note is on elixirArguments
+    const TSNode block = firstChildOfKind( node, /*namedOnly=*/true, { "do_block" } );
+    return ts_node_is_null( block ) ? elixirKeywordValue( node, "do:", src ) : block;
 }
 
 /// Count syntactic parameters in an ordinary or guarded definition head, saturating at UINT16_MAX.
@@ -152,6 +149,8 @@ bool elixirKeepCapture( TSNode role, TSNode name, bool isDef, SymKind kind, std:
             {
                 return false; // only complete, ordinary string titles have a static display name here
             }
+            // indexed on purpose: a string's children come from the external scanner, which owns every byte
+            // between the quotes, so no comment token can be lexed into this list (src/infra/tschildren.h)
             for( std::uint32_t childId = 0; childId < ts_node_named_child_count( name ); ++childId )
             {
                 if( std::strcmp( ts_node_type( ts_node_named_child( name, childId ) ), "interpolation" ) == 0 )

--- a/src/ingest_names.h
+++ b/src/ingest_names.h
@@ -52,19 +52,13 @@ inline bool isCppCastKeyword( std::string_view name ) noexcept
 
 // First DIRECT child of `n` whose node type is `type`, or a null node when none exists — the one
 // child-scan shape shared by the using-declaration keyword guard below and the phantom-`::` probe
-// (hasPhantomScopeSeparator), so the two cannot drift into near-clones of each other.
+// (hasPhantomScopeSeparator), so the two cannot drift into near-clones of each other. O(children): lane W3
+// kept this indexed because "the width comes from the grammar", and `using /*…*/ namespace ns::inner;`
+// refuted that at 12.9x its control (test/childwalkscalecheck.sh, arm B22) — the comments are the
+// using_declaration's own children, like every extra (src/infra/tschildren.h).
 inline TSNode firstChildOfType( TSNode n, const char* type ) noexcept
 {
-    const std::uint32_t childCount = ts_node_child_count( n );
-    for( std::uint32_t i = 0; i < childCount; ++i )
-    {
-        const TSNode child = ts_node_child( n, i );
-        if( std::strcmp( ts_node_type( child ), type ) == 0 )
-        {
-            return child;
-        }
-    }
-    return TSNode {};
+    return firstChildOfKind( n, /*namedOnly=*/false, { type } );
 }
 
 // using-declaration re-exports (r9 loss bucket 1): TRUE when a C++ `using_declaration` node is a grammar
@@ -617,14 +611,19 @@ inline bool rustItemCarriesTestAttr( TSNode item, std::string_view src ) noexcep
         const char* t = ts_node_type( prev );
         if( kindIs( t, "attribute_item" ) )
         {
-            const std::uint32_t childCount = ts_node_child_count( prev );
-            for( std::uint32_t ci = 0; ci < childCount; ++ci )
+            // O(children): `#[ /*…*/ test ]` puts the comments in the attribute_item — 56x at 16 000
+            // (test/childwalkscalecheck.sh, arm B23). The sibling climb this sits in is a different scan:
+            // ts_node_prev_sibling restarts from the parent's first child too (the parent-chain family).
+            bool        marked = false;
+            ChildCursor cursor( prev );
+            forEachChild( prev, cursor.cur, [ & ]( TSNode ch )
             {
-                const TSNode ch = ts_node_child( prev, ci );
-                if( kindIs( ts_node_type( ch ), "attribute" ) && rustAttrIsTestMarker( nodeTextOf( ch, src ) ) )
-                {
-                    return true;
-                }
+                marked = kindIs( ts_node_type( ch ), "attribute" ) && rustAttrIsTestMarker( nodeTextOf( ch, src ) );
+                return !marked;
+            } );
+            if( marked )
+            {
+                return true;
             }
             continue;
         }
@@ -667,26 +666,28 @@ inline bool csharpAttrIsTestMarker( std::string_view name ) noexcept
 // they decorate (the mirror image of Rust's sibling placement — again verified by --match probe).
 inline bool csharpNodeCarriesTestAttr( TSNode n, std::string_view src ) noexcept
 {
-    const std::uint32_t childCount = ts_node_child_count( n );
-    for( std::uint32_t ci = 0; ci < childCount; ++ci )
+    // O(children) at both levels — and this runs on every ANCESTOR of a def (anySelfOrAncestor), so the
+    // declaration_list and the compilation_unit scan their whole child lists too: `public /*…*/ void M()`
+    // measured 37x its control at 16 000 comments (test/childwalkscalecheck.sh, arm B24). Two cursors:
+    // the attribute_list walk runs while the declaration walk is mid-iteration.
+    bool        marked = false;
+    ChildCursor lists( n );
+    ChildCursor attrs( n );
+    forEachChild( n, lists.cur, [ & ]( TSNode list )
     {
-        const TSNode list = ts_node_child( n, ci );
         if( !kindIs( ts_node_type( list ), "attribute_list" ) )
         {
-            continue;
+            return true;
         }
-        const std::uint32_t attrCount = ts_node_child_count( list );
-        for( std::uint32_t ai = 0; ai < attrCount; ++ai )
+        forEachChild( list, attrs.cur, [ & ]( TSNode attr )
         {
-            const TSNode attr = ts_node_child( list, ai );
-            if(    kindIs( ts_node_type( attr ), "attribute" )
-                && csharpAttrIsTestMarker( nodeTextOf( fieldChild( attr, NodeField::Name ), src ) ) )
-            {
-                return true;
-            }
-        }
-    }
-    return false;
+            marked =    kindIs( ts_node_type( attr ), "attribute" )
+                     && csharpAttrIsTestMarker( nodeTextOf( fieldChild( attr, NodeField::Name ), src ) );
+            return !marked;
+        } );
+        return !marked;
+    } );
+    return marked;
 }
 
 // Python's rule, written as its own pass because the two halves are ORDERED: a `def test_*` counts
@@ -829,17 +830,12 @@ inline TestMacroBlockParts testMacroBlockPartsOf( TSNode exprStmtNode, std::stri
         return {};
     }
 
-    // the MISSING ";" — the one structural mark separating a macro-with-block from a real statement
-    bool hasMissingSemicolon = false;
-    const std::uint32_t childCount = ts_node_child_count( exprStmtNode );
-    for( std::uint32_t childIx = 0; childIx < childCount; ++childIx )
-    {
-        if( ts_node_is_missing( ts_node_child( exprStmtNode, childIx ) ) )
-        {
-            hasMissingSemicolon = true;
-            break;
-        }
-    }
+    // the MISSING ";" — the one structural mark separating a macro-with-block from a real statement.
+    // O(children): the recovered expression_statement owns every comment between `)` and the block —
+    // 16 000 of them measured 29x the identical flood after the block (childwalkscalecheck B26)
+    bool        hasMissingSemicolon = false;
+    ChildCursor cursor( exprStmtNode );
+    forEachChild( exprStmtNode, cursor.cur, [ & ]( TSNode c ) { hasMissingSemicolon = ts_node_is_missing( c ); return !hasMissingSemicolon; } );
     if( !hasMissingSemicolon )
     {
         return {};
@@ -872,18 +868,23 @@ inline TestMacroBlockParts testMacroBlockPartsOf( TSNode exprStmtNode, std::stri
         return {};
     }
 
-    // the FIRST string literal among the arguments is the title
-    const TSNode args = fieldChild( call, NodeField::Arguments );
-    const std::uint32_t argCount = ts_node_is_null( args ) ? 0u : ts_node_named_child_count( args );
-    for( std::uint32_t argIx = 0; argIx < argCount; ++argIx )
+    // the FIRST string literal among the arguments is the title — O(children): `TEST_CASE( /*…*/ "t" )`
+    // measured 28x at 16 000 (childwalkscalecheck B25); the cursor above is free again, its walk is done
+    const TSNode args  = fieldChild( call, NodeField::Arguments );
+    TSNode       title = {};
+    if( !ts_node_is_null( args ) )
     {
-        const TSNode arg = ts_node_named_child( args, argIx );
-        if( kindIs( ts_node_type( arg ), "string_literal" ) && ts_node_end_byte( arg ) > ts_node_start_byte( arg ) + 2 )   // "" is not a name
+        forEachNamedChild( args, cursor.cur, [ & ]( TSNode arg )
         {
-            return { true, body, arg };
-        }
+            if( kindIs( ts_node_type( arg ), "string_literal" ) && ts_node_end_byte( arg ) > ts_node_start_byte( arg ) + 2 )   // "" is not a name
+            {
+                title = arg;
+                return false;
+            }
+            return true;
+        } );
     }
-    return {};
+    return ts_node_is_null( title ) ? TestMacroBlockParts {} : TestMacroBlockParts { true, body, title };
 }
 
 // the title text: the string_literal's content with the delimiting quotes stripped. Escape sequences
@@ -974,35 +975,35 @@ inline bool nameBoundByInitDeclarator( TSNode nameNode, TSNode declNode ) noexce
 // and returns the first child whose source text is one of `tokens` ("" = none).
 inline std::string_view childTokenAmong( TSNode node, std::string_view src, const char* namedChildType, bool acceptAnonymousToken, std::initializer_list<std::string_view> tokens ) noexcept
 {
-    const std::uint32_t childCount = ts_node_child_count( node );
-    for( std::uint32_t childIx = 0; childIx < childCount; ++childIx )
+    // O(children): a declaration with no `static` scans its whole child list, comments included — `int /*…*/ m;`
+    // measured 16x its control at 16 000 (test/childwalkscalecheck.sh, arm B27)
+    std::string_view hit;
+    ChildCursor      cursor( node );
+    forEachChild( node, cursor.cur, [ & ]( TSNode child )
     {
-        const TSNode child   = ts_node_child( node, childIx );
-        const bool   isNamed = ts_node_is_named( child );
-        if( isNamed && std::strcmp( ts_node_type( child ), namedChildType ) != 0 )
+        const bool isNamed = ts_node_is_named( child );
+        if( ( isNamed && std::strcmp( ts_node_type( child ), namedChildType ) != 0 ) || ( !isNamed && !acceptAnonymousToken ) )
         {
-            continue;
-        }
-        if( !isNamed && !acceptAnonymousToken )
-        {
-            continue;
+            return true;
         }
         const std::uint32_t beginByte = ts_node_start_byte( child );
         const std::uint32_t endByte   = ts_node_end_byte( child );
         if( endByte > src.size() || beginByte >= endByte )
         {
-            continue;
+            return true;
         }
         const std::string_view text = src.substr( beginByte, endByte - beginByte );
         for( const std::string_view token : tokens )
         {
             if( text == token )
             {
-                return text;
+                hit = text;
+                return false;
             }
         }
-    }
-    return {};
+        return true;
+    } );
+    return hit;
 }
 
 // CUDA memory-space qualifier of a module-scope declaration ("" = none). The uninitialized-declaration
@@ -1342,31 +1343,31 @@ inline bool isPyEnumMemberTarget( TSNode nameNode, std::string_view src ) noexce
     {
         return false;
     }
-    const std::uint32_t baseCount = ts_node_named_child_count( bases );
-    for( std::uint32_t baseIndex = 0; baseIndex < baseCount; ++baseIndex )
+    // O(children): the superclasses argument_list owns every comment between its names — `class C( # …
+    // Enum ):` measured 54x its control at 16 000 (test/childwalkscalecheck.sh, arm B28)
+    bool        isEnum = false;
+    ChildCursor cursor( bases );
+    forEachNamedChild( bases, cursor.cur, [ & ]( TSNode base )
     {
-        TSNode base = ts_node_named_child( bases, baseIndex );
         if( kindIs( ts_node_type( base ), "attribute" ) )                      // models.TextChoices → TextChoices
         {
             base = fieldChild( base, NodeField::Attribute );
             if( ts_node_is_null( base ) )
             {
-                continue;
+                return true;
             }
         }
         if( !kindIs( ts_node_type( base ), "identifier" ) )
         {
-            continue;
-        }
-        const std::string_view baseName = nodeTextOf( base, src );
-        if( baseName == "Enum" || baseName == "IntEnum" || baseName == "StrEnum"
-         || baseName == "Flag" || baseName == "IntFlag" || baseName == "ReprEnum"
-         || baseName == "Choices" || baseName == "TextChoices" || baseName == "IntegerChoices" )
-        {
             return true;
         }
-    }
-    return false;
+        const std::string_view baseName = nodeTextOf( base, src );
+        isEnum =    baseName == "Enum" || baseName == "IntEnum" || baseName == "StrEnum"
+                 || baseName == "Flag" || baseName == "IntFlag" || baseName == "ReprEnum"
+                 || baseName == "Choices" || baseName == "TextChoices" || baseName == "IntegerChoices";
+        return !isEnum;
+    } );
+    return isEnum;
 }
 }   // namespace — ingest_names.h section of ingest.cpp
 

--- a/src/ingest_relations.h
+++ b/src/ingest_relations.h
@@ -198,10 +198,12 @@ void captureMacroBodyCalls( TSNode defineNode, std::uint32_t fileId, Lang lang, 
     std::vector<std::string> params;
     if( const TSNode paramsNode = fieldChild( defineNode, NodeField::Parameters ); !ts_node_is_null( paramsNode ) )
     {
-        const uint32_t pc = ts_node_child_count( paramsNode );
-        for( uint32_t i = 0; i < pc; ++i )
+        // O(children): a preproc_params list holds every block comment written between its names — extras
+        // land in the child array (src/infra/tschildren.h); 16 000 of them measured 60x the identical flood
+        // outside the #define (test/childwalkscalecheck.sh, arm B13).
+        ChildCursor cursor( paramsNode );
+        forEachChild( paramsNode, cursor.cur, [ & ]( TSNode ch )
         {
-            const TSNode ch = ts_node_child( paramsNode, i );
             if( kindIs( ts_node_type( ch ), "identifier" ) )
             {
                 const uint32_t pa = ts_node_start_byte( ch );
@@ -211,7 +213,8 @@ void captureMacroBodyCalls( TSNode defineNode, std::uint32_t fileId, Lang lang, 
                     params.emplace_back( src.substr( pa, pb - pa ) );
                 }
             }
-        }
+            return true;
+        } );
     }
     const auto isParam = [ & ]( std::string_view w ) noexcept
     {
@@ -492,17 +495,19 @@ void captureFields( TSNode classNode, std::uint32_t fileId, Lang lang, std::stri
             {
                 // Not a plain type_identifier type — could be template, qualified, etc.
                 // Walk the type node's children looking for the innermost type_identifier.
+                // O(children): a qualified_identifier `ns /*…*/ ::T` owns every comment between its tokens —
+                // 16 000 of them measured 16x the identical flood after the field (childwalkscalecheck B14).
+                // `cursor` is free here: the enclosing loops walk materialised vectors, not the cursor.
                 bool found = false;
-                const uint32_t tc2 = ts_node_child_count( typeNode );
-                for( uint32_t k = 0; k < tc2 && !found; ++k )
+                forEachChild( typeNode, cursor.cur, [ & ]( TSNode tc3 )
                 {
-                    const TSNode tc3 = ts_node_child( typeNode, k );
                     if( kindIs( ts_node_type( tc3 ), "type_identifier" ) )
                     {
                         const uint32_t ta = ts_node_start_byte( tc3 ), tb = ts_node_end_byte( tc3 );
                         if( ta < tb && tb <= src.size() ) { typeName = std::string( src.substr( ta, tb - ta ) ); found = true; }
                     }
-                }
+                    return !found;
+                } );
                 if( !found )
                 {
                     continue;
@@ -546,17 +551,17 @@ void captureFields( TSNode classNode, std::uint32_t fileId, Lang lang, std::stri
             else if( kindIs( dt, "reference_declarator" ) || kindIs( dt, "pointer_declarator" ) )
             {
                 declIsRefOrPtr = true;
-                // Walk the declarator's children to find the field_identifier
-                const uint32_t dc = ts_node_child_count( decl );
-                for( uint32_t k = 0; k < dc; ++k )
+                // Walk the declarator's children to find the field_identifier — O(children): `T & /*…*/ m` puts
+                // the comments in the reference_declarator (14x at 16 000, childwalkscalecheck B15)
+                forEachChild( decl, cursor.cur, [ & ]( TSNode dchild )
                 {
-                    const TSNode dchild = ts_node_child( decl, k );
                     if( kindIs( ts_node_type( dchild ), "field_identifier" ) )
                     {
                         const uint32_t da = ts_node_start_byte( dchild ), db = ts_node_end_byte( dchild );
-                        if( da < db && db <= src.size() ) { fieldName = std::string( src.substr( da, db - da ) ); break; }
+                        if( da < db && db <= src.size() ) { fieldName = std::string( src.substr( da, db - da ) ); return false; }
                     }
-                }
+                    return true;
+                } );
             }
             else
             {
@@ -651,21 +656,10 @@ inline std::string csharpUsingTarget( TSNode usingNode, std::string_view src )
         return importSpecifierText( aliasType, src );
     }
 
-    const uint32_t cc = ts_node_child_count( usingNode );
-    for( uint32_t k = 0; k < cc; ++k )
-    {
-        const TSNode c = ts_node_child( usingNode, k );
-        if( !ts_node_is_named( c ) )
-        {
-            continue;
-        }
-        const char* ct = ts_node_type( c );
-        if( kindIs( ct, "qualified_name" ) || kindIs( ct, "identifier" ) || kindIs( ct, "generic_name" ) || kindIs( ct, "alias_qualified_name" ) )
-        {
-            return importSpecifierText( c, src );
-        }
-    }
-    return {};
+    // O(children): `using /*…*/ System.Text;` puts the comments in the using_directive itself — 16 000 of
+    // them measured 36x the identical flood inside a method body (test/childwalkscalecheck.sh, arm B16)
+    const TSNode c = firstChildOfKind( usingNode, /*namedOnly=*/true, { "qualified_name", "identifier", "generic_name", "alias_qualified_name" } );
+    return ts_node_is_null( c ) ? std::string {} : importSpecifierText( c, src );
 }
 
 // csharpUsingTarget's PHP sibling: the written specifier of a `use` statement. Node shapes read off
@@ -688,39 +682,39 @@ inline std::string csharpUsingTarget( TSNode usingNode, std::string_view src )
 // is top-level and unaffected). Both are misses, never wrong answers.
 inline std::string phpUseTarget( TSNode useNode, std::string_view src )
 {
-    const uint32_t cc = ts_node_child_count( useNode );
-    for( uint32_t k = 0; k < cc; ++k )
+    // O(children) at both levels: `use /*…*/ Foo\Bar;` floods the namespace_use_declaration (54x at 16 000,
+    // test/childwalkscalecheck.sh arm B17), and the same comments inside a `{A, B}` group would flood the
+    // clause. Two cursors, because the clause walk runs while the declaration walk is mid-iteration.
+    std::string target;
+    ChildCursor clauses( useNode );
+    ChildCursor names( useNode );
+    forEachNamedChild( useNode, clauses.cur, [ & ]( TSNode c )
     {
-        const TSNode c = ts_node_child( useNode, k );
-        if( !ts_node_is_named( c ) )
-        {
-            continue;
-        }
         const char* ct = ts_node_type( c );
         if( kindIs( ct, "namespace_name" ) )      // the `use Foo\{A, B}` group prefix
         {
-            return importSpecifierText( c, src );
+            target = importSpecifierText( c, src );
+            return false;
         }
         if( !kindIs( ct, "namespace_use_clause" ) )
         {
-            continue;
+            return true;
         }
-        const uint32_t gc = ts_node_child_count( c );
-        for( uint32_t j = 0; j < gc; ++j )
+        bool hit = false;
+        forEachNamedChild( c, names.cur, [ & ]( TSNode g )
         {
-            const TSNode g = ts_node_child( c, j );
-            if( !ts_node_is_named( g ) )
-            {
-                continue;
-            }
             const char* gt = ts_node_type( g );
             if( kindIs( gt, "qualified_name" ) || kindIs( gt, "name" ) )
             {
-                return importSpecifierText( g, src );
+                target = importSpecifierText( g, src );
+                hit    = true;
+                return false;
             }
-        }
-    }
-    return {};
+            return true;
+        } );
+        return !hit;
+    } );
+    return target;
 }
 
 // TS/JS `require("./x")` and dynamic `import("./x")` → the written specifier, or empty when this call
@@ -750,16 +744,10 @@ inline std::string jsModuleLoadTarget( TSNode n, std::string_view src )
         return {};
     }
 
-    TSNode   only  = { };
-    uint32_t named = 0;
-    for( uint32_t k = 0, cc = ts_node_child_count( ar ); k < cc; ++k )
-    {
-        if( const TSNode c = ts_node_child( ar, k );  ts_node_is_named( c ) )
-        {
-            only = c;
-            ++named;
-        }
-    }
+    TSNode      only  = { };
+    uint32_t    named = 0;
+    ChildCursor cursor( ar );   // O(children): `require( /*…*/ 'x' )` — 54x at 16 000 (childwalkscalecheck B18)
+    forEachNamedChild( ar, cursor.cur, [ & ]( TSNode c ) { only = c; ++named; return true; } );
     if( named != 1 || !kindIs( ts_node_type( only ), "string" ) )
     {
         return {};
@@ -902,6 +890,8 @@ inline std::string stringLiteralText( TSNode str, std::string_view src )
     {
         return {};   // `require(mod)`, `require("a" .. b)`, `require "#{x}"` — no single literal to read
     }
+    // Indexed on purpose: a string's children come from the external scanner, which owns every byte between
+    // the delimiters, so no comment token is ever lexed into this list (src/infra/tschildren.h's one-line test).
     for( std::uint32_t i = 0; i < ts_node_named_child_count( str ); ++i )
     {
         const TSNode kid = ts_node_named_child( str, i );
@@ -1001,21 +991,26 @@ inline bool rubyNamespaceOnly( TSNode defNode ) noexcept
     {
         return false;   // an empty open defines its constant
     }
-    bool nestedOpen = false;
-    const std::uint32_t n = ts_node_named_child_count( body );
-    for( std::uint32_t i = 0; i < n; ++i )
+    // O(children): the scan already skips `comment` by kind, which is the author knowing they land in this
+    // list — 16 000 of them measured 58x the identical flood after the class (childwalkscalecheck B19)
+    bool        nestedOpen = false;
+    bool        ownBody    = false;
+    ChildCursor cursor( body );
+    forEachNamedChild( body, cursor.cur, [ & ]( TSNode c )
     {
-        const char* ct = ts_node_type( ts_node_named_child( body, i ) );
+        const char* ct = ts_node_type( c );
         if( kindIs( ct, "class" ) || kindIs( ct, "module" ) )
         {
             nestedOpen = true;
         }
         else if( !kindIs( ct, "comment" ) )
         {
-            return false;   // a method, a call, a constant, `class << self` — a body of its own
+            ownBody = true;   // a method, a call, a constant, `class << self` — a body of its own
+            return false;
         }
-    }
-    return nestedOpen;
+        return true;
+    } );
+    return !ownBody && nestedOpen;
 }
 
 // The text of a constant-shaped node — `constant` (`Base`) or `scope_resolution` (`A::B`, `::Top`) — or
@@ -1118,14 +1113,15 @@ inline std::vector<std::string> rubyMixinTargets( TSNode n, std::string_view src
     {
         return out;
     }
-    const std::uint32_t count = ts_node_named_child_count( args );
-    for( std::uint32_t i = 0; i < count; ++i )
+    ChildCursor cursor( args );   // O(children): `include A, # … B` — 58x at 16 000 (childwalkscalecheck B20)
+    forEachNamedChild( args, cursor.cur, [ & ]( TSNode a )
     {
-        if( std::string c = rubyConstantText( ts_node_named_child( args, i ), src ); !c.empty() )
+        if( std::string c = rubyConstantText( a, src ); !c.empty() )
         {
             out.push_back( std::move( c ) );
         }
-    }
+        return true;
+    } );
     return out;
 }
 
@@ -1260,20 +1256,19 @@ inline std::vector<std::string> elixirAliasGroup( TSNode n, std::string_view src
         return out;
     }
     const std::string_view prefix = nodeTextOf( left, src );
-    for( std::uint32_t i = 0; i < ts_node_named_child_count( right ); ++i )
+    ChildCursor            cursor( right );   // O(children): `{A, # … B}` — 86x at 16 000 (childwalkscalecheck B21)
+    forEachNamedChild( right, cursor.cur, [ & ]( TSNode member )
     {
-        const TSNode member = ts_node_named_child( right, i );
-        if( !kindIs( ts_node_type( member ), "alias" ) )
+        if( kindIs( ts_node_type( member ), "alias" ) )
         {
-            continue;
+            const std::string_view name = nodeTextOf( member, src );
+            if( !prefix.empty() && !name.empty() )
+            {
+                out.emplace_back( std::string( prefix ) + "." + std::string( name ) );
+            }
         }
-        const std::string_view name = nodeTextOf( member, src );
-        if( prefix.empty() || name.empty() )
-        {
-            continue;
-        }
-        out.emplace_back( std::string( prefix ) + "." + std::string( name ) );
-    }
+        return true;
+    } );
     return out;
 }
 

--- a/src/ingest_sidecap.h
+++ b/src/ingest_sidecap.h
@@ -96,6 +96,43 @@ FfiCtx makeFfiCtx( std::uint32_t fileId, Lang lang, std::string_view src, std::v
     return cx;
 }
 
+// `m.def( "alias", &Scope::target )` — the alias string and the `&`-stripped target text of a pybind def
+// call's argument_list, each empty when absent. O(children): the list owns every comment written between
+// its arguments — 13x at 16 000 (test/childwalkscalecheck.sh, arm B31). Its own function so ffiVisitNode's
+// nesting stays where it was: the cursor walk sits one level deeper than the loop it replaced.
+inline std::pair<std::string, std::string> pybindDefParts( TSNode args, std::string_view src )
+{
+    std::string alias, tgt;
+    if( ts_node_is_null( args ) )
+    {
+        return { alias, tgt };
+    }
+    ChildCursor cursor( args );
+    forEachNamedChild( args, cursor.cur, [ & ]( TSNode c )   // named only: skips '(' ',' ')'
+    {
+        const std::string_view ct = ts_node_type( c );
+        if( alias.empty() && ct == "string_literal" )
+        {
+            alias = ffiUnquote( nodeTextOf( c, src ) );
+        }
+        else if( tgt.empty() )
+        {
+            std::string_view txt = nodeTextOf( c, src );               // `&target` / `&Scope::method`
+            if( !txt.empty() && txt.front() == '&' )
+            {
+                txt.remove_prefix( 1 );
+                while( !txt.empty() && ( txt.front() == ' ' || txt.front() == '\t' ) )
+                {
+                    txt.remove_prefix( 1 );
+                }
+                tgt = std::string( txt );
+            }
+        }
+        return true;
+    } );
+    return { alias, tgt };
+}
+
 void ffiVisitNode( FfiCtx& cx, TSNode n, const char* t )
 {
     FUSEPROBE_BUMP( kFfi );
@@ -117,35 +154,7 @@ void ffiVisitNode( FfiCtx& cx, TSNode n, const char* t )
                 const std::string_view meth = nodeSrc( fieldChild( fn, NodeField::Field ) );
                 if( meth == "def" || meth == "def_static" )
                 {
-                    const TSNode args = fieldChild( n, NodeField::Arguments );
-                    std::string alias, tgt;
-                    const std::uint32_t cc = ts_node_is_null( args ) ? 0 : ts_node_child_count( args );
-                    for( std::uint32_t i = 0; i < cc; ++i )
-                    {
-                        const TSNode c = ts_node_child( args, i );
-                        if( !ts_node_is_named( c ) )
-                        {
-                            continue; // skip '(' ',' ')'
-                        }
-                        const std::string_view ct = ts_node_type( c );
-                        if( alias.empty() && ct == "string_literal" )
-                        {
-                            alias = ffiUnquote( nodeSrc( c ) );
-                        }
-                        else if( tgt.empty() )
-                        {
-                            std::string_view txt = nodeSrc( c );               // `&target` / `&Scope::method`
-                            if( !txt.empty() && txt.front() == '&' )
-                            {
-                                txt.remove_prefix( 1 );
-                                while( !txt.empty() && ( txt.front() == ' ' || txt.front() == '\t' ) )
-                                {
-                                    txt.remove_prefix( 1 );
-                                }
-                                tgt = std::string( txt );
-                            }
-                        }
-                    }
+                    auto [ alias, tgt ] = pybindDefParts( fieldChild( n, NodeField::Arguments ), src );
                     if( !alias.empty() && !tgt.empty() )
                     {
                         auto [ scope, name ] = ffiSplitScopeName( tgt );
@@ -161,13 +170,10 @@ void ffiVisitNode( FfiCtx& cx, TSNode n, const char* t )
         else if( cish && kindIs( t, "linkage_specification" ) )
         {
             // confirm the linkage string is "C" (not "C++") before harvesting.
-            bool isC = false;
-            const std::uint32_t lc = ts_node_child_count( n );
-            for( std::uint32_t i = 0; i < lc; ++i )
-            {
-                const TSNode c = ts_node_child( n, i );
-                if( kindIs( ts_node_type( c ), "string_literal" ) ) { isC = ( ffiUnquote( nodeSrc( c ) ) == "C" ); break; }
-            }
+            // O(children): `extern /*…*/ "C"` puts the comments in the linkage_specification itself, before
+            // the string — 13x at 16 000 (childwalkscalecheck B32; ffi/ floods the BODY, arm B4)
+            const TSNode linkage = firstChildOfKind( n, /*namedOnly=*/false, { "string_literal" } );
+            const bool   isC     = !ts_node_is_null( linkage ) && ffiUnquote( nodeSrc( linkage ) ) == "C";
             if( isC )
             {
                 // inner DFS: collect the identifier of every function_declarator in the linkage body.
@@ -332,37 +338,34 @@ inline HttpMethod pyMethodsKeyword( TSNode argsNode, std::string_view src, bool&
     {
         return HttpMethod::Unknown;
     }
-    const std::uint32_t nc = ts_node_named_child_count( argsNode );
-    for( std::uint32_t i = 0; i < nc; ++i )
+    // O(children): `@app.route( "/x", # … methods=[…] )` — 58x at 16 000 (childwalkscalecheck B33)
+    HttpMethod  method = HttpMethod::Unknown;
+    ChildCursor cursor( argsNode );
+    forEachNamedChild( argsNode, cursor.cur, [ & ]( TSNode c )
     {
-        const TSNode c = ts_node_named_child( argsNode, i );
         if( !kindIs( ts_node_type( c ), "keyword_argument" ) )
         {
-            continue;
+            return true;
         }
         const TSNode nameN = fieldChild( c, NodeField::Name );
         if( ts_node_is_null( nameN ) )
         {
-            continue;
+            return true;
         }
         const std::uint32_t na = ts_node_start_byte( nameN ), nb = ts_node_end_byte( nameN );
         if( na > nb || nb > src.size() || src.substr( na, nb - na ) != "methods" )
         {
-            continue;
+            return true;
         }
         hasKeyword = true;
         const TSNode valueN = fieldChild( c, NodeField::Value );
-        if( ts_node_is_null( valueN ) || !kindIs( ts_node_type( valueN ), "list" ) )
+        if( !ts_node_is_null( valueN ) && kindIs( ts_node_type( valueN ), "list" ) && ts_node_named_child_count( valueN ) == 1 )
         {
-            return HttpMethod::Unknown;
+            method = stringNodeToMethod( ts_node_named_child( valueN, 0 ), src );   // else 0 or >1 verbs → ambiguous, path-only match
         }
-        if( ts_node_named_child_count( valueN ) != 1 )
-        {
-            return HttpMethod::Unknown; // 0 or >1 verbs → ambiguous, path-only match
-        }
-        return stringNodeToMethod( ts_node_named_child( valueN, 0 ), src );
-    }
-    return HttpMethod::Unknown;
+        return false;
+    } );
+    return method;
 }
 
 // JS options-object `{ method: 'POST', ... }`: the `method` property's string-literal value, else Unknown
@@ -374,24 +377,25 @@ inline HttpMethod jsMethodProperty( TSNode objNode, std::string_view src )
     {
         return HttpMethod::Unknown;
     }
-    const std::uint32_t nc = ts_node_named_child_count( objNode );
-    for( std::uint32_t i = 0; i < nc; ++i )
+    // O(children): `fetch( '/x', { /*…*/ method: 'POST' } )` — 55x at 16 000 (childwalkscalecheck B34)
+    HttpMethod  method = HttpMethod::Unknown;
+    ChildCursor cursor( objNode );
+    forEachNamedChild( objNode, cursor.cur, [ & ]( TSNode c )
     {
-        const TSNode c = ts_node_named_child( objNode, i );
         if( !kindIs( ts_node_type( c ), "pair" ) )
         {
-            continue;
+            return true;
         }
         const TSNode keyN = fieldChild( c, NodeField::Key );
         if( ts_node_is_null( keyN ) )
         {
-            continue;
+            return true;
         }
         const char* kt = ts_node_type( keyN );
         const std::uint32_t ka = ts_node_start_byte( keyN ), kb = ts_node_end_byte( keyN );
         if( ka > kb || kb > src.size() )
         {
-            continue;
+            return true;
         }
         std::string key;
         if( kindIs( kt, "property_identifier" ) )
@@ -402,17 +406,14 @@ inline HttpMethod jsMethodProperty( TSNode objNode, std::string_view src )
         {
             key = ffiUnquote( src.substr( ka, kb - ka ) );
         }
-        else
-        {
-            continue;
-        }
         if( key != "method" )
         {
-            continue;
+            return true;
         }
-        return stringNodeToMethod( fieldChild( c, NodeField::Value ), src );
-    }
-    return HttpMethod::Unknown;
+        method = stringNodeToMethod( fieldChild( c, NodeField::Value ), src );
+        return false;
+    } );
+    return method;
 }
 
 // One visitor on the shared pre-order stream (streamSideCaptures below). The pass arms only on Python/JS/TS;
@@ -1665,15 +1666,9 @@ void captureTagsFacts( TSQueryCursor* cursor, const LangEntry& le, std::uint32_t
             // and never reach here). See test/langcheck.sh c.m and the byte-identical src/ regression gate.
             if( ts_node_is_null( body ) && le.lang == Lang::ObjC )
             {
-                const std::uint32_t childCount = ts_node_child_count( defNode );
-                for( std::uint32_t ci = 0; ci < childCount; ++ci )
-                {
-                    const TSNode ch = ts_node_child( defNode, ci );
-                    const char*  ct = ts_node_type( ch );
-                    if( kindIs( ct, "compound_statement" )     || kindIs( ct, "function_body" )
-                        || kindIs( ct, "block" )               || kindIs( ct, "implementation_definition" ) )
-                    { body = ch; break; }
-                }
+                // O(children): `- (void) m /*…*/ { }` puts the comments in the method_definition, before its
+                // body — 24x at 16 000 (test/childwalkscalecheck.sh, arm B35)
+                body = firstChildOfKind( defNode, /*namedOnly=*/false, { "compound_statement", "function_body", "block", "implementation_definition" } );
             }
 
             // Dart's body is a SIBLING of the signature, so neither defBodyNodeOf nor the climb above can

--- a/src/pattern.h
+++ b/src/pattern.h
@@ -836,14 +836,26 @@ inline bool nodesMatchExactly( TSNode a, TSNode b, std::string_view src, unsigne
     {
         return false;
     }
-    for( std::uint32_t i = 0; i < an; ++i )
+    // O(children) on both sides: a bound metavariable and its candidate both come from the FILE, so each
+    // list is as wide as the comments in it (a comment is a NAMED extra) — `$X == $X` over two 16 000-comment
+    // argument lists measured 126x the plain map (test/childwalkscalecheck.sh, arm B36). a's list is
+    // materialised so b's can be walked in lockstep; each frame owns its cursors because the body recurses.
+    std::vector<TSNode> aKids;
+    aKids.reserve( an );
     {
-        if( !nodesMatchExactly( ts_node_named_child( a, i ), ts_node_named_child( b, i ), src, depth + 1 ) )
-        {
-            return false;
-        }
+        ChildCursor aCursor( a );
+        forEachNamedChild( a, aCursor.cur, [ & ]( TSNode c ) { aKids.push_back( c ); return true; } );
     }
-    return true;
+    bool          same  = true;
+    std::uint32_t index = 0;
+    ChildCursor   bCursor( b );
+    forEachNamedChild( b, bCursor.cur, [ & ]( TSNode bc )
+    {
+        same = index < aKids.size() && nodesMatchExactly( aKids[ index ], bc, src, depth + 1 );
+        ++index;
+        return same;
+    } );
+    return same;
 }
 
 // V-2 (adversarial verification 2026-08-20). The ellipsis probe ABANDONS a candidate node when the run of

--- a/test/childwalkscalecheck.sh
+++ b/test/childwalkscalecheck.sh
@@ -301,8 +301,11 @@ for n in ( 1000, 16000 ):
     # captureTagsFacts, the ObjC body fallback — a method_definition's own children before its `{`
     w( "objcbody/n%d/big.m" % n, [ "@interface Foo", "@end", "@implementation Foo", "- (void) m" ] + [ C ] * n + [ "{ }", "@end" ] )
     w( "objcbody_off/n%d/big.m" % n, [ "@interface Foo", "@end", "@implementation Foo", "- (void) m { }" ] + [ C ] * n + [ "@end" ] )
-    # nodesMatchExactly — two flooded argument_lists joined by a repeated metavariable (`$X == $X`)
+    # nodesMatchExactly — two flooded argument_lists joined by a repeated metavariable (`$X == $X`); its
+    # control runs the SAME --pattern over the same two floods placed in the body OUTSIDE both argument
+    # lists, so both sides execute nodesMatchExactly and only the flooded list differs (CodeRabbit, #130)
     w( "patmeta/n%d/big.c" % n, [ "int a( int x );", "int f( void )", "{", "    return a(" ] + [ C ] * n + [ "    1 ) == a(" ] + [ C ] * n + [ "    1 );", "}" ] )
+    w( "patmeta_off/n%d/big.c" % n, [ "int a( int x );", "int f( void )", "{", "    return a( 1 ) == a( 1 );" ] + [ C ] * n + [ C ] * n + [ "}" ] )
 PY
 
 # user-CPU seconds (user+sys) of one cold run of "$@" against corpus $1
@@ -520,9 +523,9 @@ pair "(B32) ffiVisitNode/linkage"       externc      externc_off     "a linkage_
 pair "(B33) pyMethodsKeyword"           pyroute      pyroute_off     "a route decorator's argument_list 16000 children wide vs the identical flood after the def"
 pair "(B34) jsMethodProperty"           jsfetch      jsfetch_off     "fetch()'s options object 16000 children wide vs the identical flood after the call"
 pair "(B35) captureTagsFacts/objc-body" objcbody     objcbody_off    "an ObjC method_definition 16000 children wide vs the identical flood after the method"
-b_pm_map="$(  usercpu "$TMP/patmeta/n16000" "$BIN" --top-k=100000 )"
-b_pm_walk="$( usercpu "$TMP/patmeta/n16000" "$BIN" --pattern='$X == $X' )"
-arm "(B36) nodesMatchExactly" "$b_pm_map" "$b_pm_walk" 8 0.30 "--pattern='\$X == \$X' over two 16000-comment argument lists vs the plain map"
+b_pm_off="$(  usercpu "$TMP/patmeta_off/n16000" "$BIN" --pattern='$X == $X' )"
+b_pm_walk="$( usercpu "$TMP/patmeta/n16000"     "$BIN" --pattern='$X == $X' )"
+arm "(B36) nodesMatchExactly" "$b_pm_off" "$b_pm_walk" 8 0.30 "--pattern='\$X == \$X' over two 16000-comment argument lists vs the same pattern with the floods outside both lists"
 
 # ── (C) byte-identical against a reference binary ────────────────────────────────────────────────────
 echo
@@ -552,10 +555,11 @@ else
                  phpuse phpuse_off jsrequire jsrequire_off rubyns rubyns_off rubymixin rubymixin_off exalias exalias_off \
                  cppusing cppusing_off rustattr rustattr_off csattr csattr_off testmacro testmacrosemi testmacro_off \
                  fieldstatic fieldstatic_off pyenum pyenum_off exkw exkw_off excall excall_off pybind pybind_off \
-                 externc externc_off pyroute pyroute_off jsfetch jsfetch_off objcbody objcbody_off patmeta; do
+                 externc externc_off pyroute pyroute_off jsfetch jsfetch_off objcbody objcbody_off patmeta patmeta_off; do
             cmp_pair "$TMP/$d/$n" --top-k=100000
         done
-        cmp_pair "$TMP/patmeta/$n" --pattern='$X == $X'
+        cmp_pair "$TMP/patmeta/$n"     --pattern='$X == $X'
+        cmp_pair "$TMP/patmeta_off/$n" --pattern='$X == $X'
         cmp_pair "$TMP/slicew/$n"  --slice=target
         cmp_pair "$TMP/slicepp/$n" --slice=target
         cmp_pair "$TMP/span/$n"    --grep=needle_marker

--- a/test/childwalkscalecheck.sh
+++ b/test/childwalkscalecheck.sh
@@ -3,7 +3,10 @@
 # and the answers each of them must still produce. Lane W2 wrote arms (B1..B6) for the ten class-1
 # `ts_node_child( n, i )` walks; lane W3 added (B7..B9) for the last two — bindsVisitNode's index-keyed
 # field lookup and --slice`s rung-3 flow walk (`ts_node_named_child`, the same defect with
-# include_anonymous=false) — which together closed the class.
+# include_anonymous=false) — and (B10..B12) for the three "class 3" sites that refuted the class-3 table.
+# Lane W4 (2026-09-10) added (B13..B36): one isolation arm for every indexed loop the W3 handover left
+# unaudited across src/ingest_relations.h, ingest_names.h, ingest_elixir.h, ingest_sidecap.h and
+# pattern.h — twenty-two walks, EVERY one of them red on the pre-change binary (12x..86x its control).
 #
 #   bash test/childwalkscalecheck.sh                       # build/ripwire
 #   bash test/childwalkscalecheck.sh .ripwire_pre          # the RED run (pre-change binary, indexed walks)
@@ -88,9 +91,9 @@
 #     qualifierOf 2 629, enclosingScopeOf 1 040, cc_isCountableLocalDecl 676, cc_walk 531.
 #     bindsVisitNode's TypeScript `type_annotation` scan was converted in the same pass: it breaks at the
 #     first `type_identifier`, but nothing bounds how many comments precede one.
-#   * src/ingest_names.h:61 (firstChildOfType) keeps the indexed form: both callers pass a
-#     `using_declaration` / `qualified_identifier`, whose width comes from the grammar, and a per-call
-#     cursor allocation would cost more than the scan it replaces. Class 3 in practice, not class 2.
+#   * src/ingest_names.h (firstChildOfType) WAS kept indexed by W3 — "both callers pass a using_declaration
+#     / qualified_identifier, whose width comes from the grammar" — which is the exact reason the next bullet
+#     refutes. `using` + 16 000 comments + `namespace ns::inner;` measured 12.9x its control (B22). Converted.
 #   * THE CLASS-3 TABLE WAS WRONG, AND ARMS (B10..B12) ARE WHAT SHOWS IT. The P1-0 follow-up called ~37
 #     sites "class 3 — width from the GRAMMAR, correct as written": base clauses, argument and parameter
 #     lists, attribute lists, a declaration's declarators. A comment can sit between ANY two children of
@@ -98,16 +101,29 @@
 #     by the FILE wherever a comment may legally appear in it. Measured on the W2 binary, 16 000 comments
 #     inside ONE list vs the identical flood just outside it: `declaration` 77x (B7), `argument_list` 56x
 #     (B11), lambda capture list 26x (B12), `base_class_clause` 13x (B10). All four are converted.
-#     WHAT REMAINS, and the sweep that bounds it. Fifteen language shapes were flooded the same way and
-#     timed on the FIXED binary — a C++ `using` declaration, a template argument list, a brace initializer,
-#     a struct field list, an enum body, a parameter list, a Python argument list and base list, a JS object
-#     literal, a TS type annotation, a Ruby class body, a Go call, a Java implements list, a Rust call, and
-#     a 16 000-paragraph markdown document (mdWalk, whose root IS the file). Every one came out at 0.01-0.10 s,
-#     i.e. flat, because the balanced `_repeat` subtree absorbs the flood at those sites or the indexed loop
-#     is not on the map path. That is EVIDENCE OF ABSENCE FOR THOSE FIFTEEN SHAPES ONLY — it is not a proof
-#     that the ~25 remaining indexed loops are safe (src/ingest_relations.h, ingest_names.h, ingest_docs.h,
-#     ingest_elixir.h, ingest_sidecap.h, pattern.h). Each still needs the one-line reason the note on
-#     src/infra/tschildren.h now demands, or a cursor. Handed over whole rather than half-converted.
+#     W3's sweep then flooded fifteen language SHAPES on the fixed binary and found them flat — evidence of
+#     absence for those shapes only, not clearance for the loops. Lane W4 went loop by loop instead, and the
+#     difference is what (B13..B36) record: a Python base list is flat when the flood sits in the class body
+#     (W3's shape) and 54x when it sits INSIDE the superclasses parens (B28); a Ruby class body is flat when
+#     the comments LEAD the body (tree-sitter hands leading extras to the parent `class`, not to the
+#     body_statement that has not started) and 58x once one nested class precedes them (B19); a C++ `using`
+#     is flat in its unqualified spelling because that form is never captured, and 12.9x in the qualified
+#     one (B22). A flat measurement proves the FIXTURE missed the list, never that the loop is safe. Every
+#     arm below therefore records the shape that reached its walk, and the CPU `sample` that attributed the
+#     two fixtures whose owner was not obvious (excall -> elixirBody; testmacrosemi -> the MISSING-`;` probe).
+#     THE THREE LOOPS THAT STAY INDEXED, each with the one-line reason the note on src/infra/tschildren.h
+#     demands, written at the loop: mdWalk (src/ingest_docs.h — the markdown grammar declares NO extras, its
+#     parser.c has zero SHIFT_EXTRA actions, so every child list there is a balanced grammar repeat);
+#     stringLiteralText (src/ingest_relations.h) and the Elixir test-title interpolation scan
+#     (src/ingest_elixir.h) — a string's children are produced by the external scanner, which owns every
+#     byte between the delimiters, so no comment token is ever lexed into that list.
+#     TWO CONTROLS THAT WERE THEMSELVES QUADRATIC, and what they mean. The C# controls first put the flood
+#     in the class body and read 1.09 s / 2.31 s — csharpNodeCarriesTestAttr is applied to every ANCESTOR
+#     of a def (anySelfOrAncestor), so the declaration_list and the compilation_unit scanned the flood too.
+#     The controls now flood a method BODY, which is no def's ancestor. And the Rust control floods AFTER
+#     the item, because rustItemCarriesTestAttr's own prev-sibling climb (`ts_node_prev_sibling`, which
+#     restarts from the parent's first child on every call) is a second restarting scan this gate does not
+#     own — it is the parent-chain family, not a child walk, and is left for that lane.
 #
 # Exit 0 = ALL PASS, non-zero = SOME FAILED.
 
@@ -135,6 +151,8 @@ python3 - "$TMP" <<'PY'
 import os, sys
 base = sys.argv[ 1 ]
 C = "// pad " + "x" * 40
+H = "# pad " + "x" * 40      # the `#` comment: Python, Ruby, Elixir
+B = "/* pad */"              # a block comment: the one shape a preprocessor line can hold 16 000 of
 
 def w( rel, lines ):
     p = os.path.join( base, rel )
@@ -210,6 +228,81 @@ for n in ( 1000, 16000 ):
        [ "int helper( int x );", "int target( int x )", "{", "    int acc = x;" ] + [ C ] * n
        + [ "    if( x > 0 )", "    {", "        acc = x + 1;", "    }" ] + [ C ] * n
        + [ "    return helper( acc );", "}" ] )
+    # ── lane W4: one pair per walk the W3 handover left indexed. Each floods ONE node's own child list and
+    # its control puts the identical flood where no walk under test owns it as a direct child.
+    # captureMacroBodyCalls — a preproc_params list (block comments: a #define is one logical line)
+    w( "macroparams/n%d/big.c" % n, [ "int h( int a, int b );", "#define F( a, " + B * n + " b ) h( a, b )", "int g( int x ) { return F( x, 1 ); }" ] )
+    w( "macroparams_off/n%d/big.c" % n, [ "int h( int a, int b );", B * n, "#define F( a, b ) h( a, b )", "int g( int x ) { return F( x, 1 ); }" ] )
+    # captureFields, the type walk — a qualified_identifier `ns /*…*/ ::T` as a field's type
+    w( "fieldtype/n%d/big.cpp" % n, [ "namespace ns { struct T { int q; }; }", "struct S", "{", "    ns" ] + [ C ] * n + [ "    ::T m;", "};" ] )
+    w( "fieldtype_off/n%d/big.cpp" % n, [ "namespace ns { struct T { int q; }; }", "struct S", "{", "    ns::T m;" ] + [ C ] * n + [ "};" ] )
+    # captureFields, the declarator walk — a reference_declarator `T & /*…*/ m`
+    w( "fielddecl/n%d/big.cpp" % n, [ "struct T { int q; };", "struct S", "{", "    T &" ] + [ C ] * n + [ "    m;", "};" ] )
+    w( "fielddecl_off/n%d/big.cpp" % n, [ "struct T { int q; };", "struct S", "{", "    T & m;" ] + [ C ] * n + [ "};" ] )
+    # csharpUsingTarget — a using_directive; its control floods a method BODY (see the header: a class body
+    # or the file root is an ancestor of every def, and the ancestor scan would read the flood too)
+    w( "csusing/n%d/big.cs" % n, [ "using" ] + [ C ] * n + [ "    System.Text;", "namespace A { class K { void M() {} } }" ] )
+    w( "csusing_off/n%d/big.cs" % n, [ "using System.Text;", "namespace A { class K { void M() {" ] + [ C ] * n + [ "} } }" ] )
+    # phpUseTarget — a namespace_use_declaration
+    w( "phpuse/n%d/big.php" % n, [ "<?php", "namespace A;", "use" ] + [ C ] * n + [ "    Foo\\Bar;", "function f() {}" ] )
+    w( "phpuse_off/n%d/big.php" % n, [ "<?php", "namespace A;", "use Foo\\Bar;" ] + [ C ] * n + [ "function f() {}" ] )
+    # jsModuleLoadTarget — require()'s arguments
+    w( "jsrequire/n%d/big.js" % n, [ "const m = require(" ] + [ C ] * n + [ "    'mod' );", "function f() { return m; }" ] )
+    w( "jsrequire_off/n%d/big.js" % n, [ "const m = require( 'mod' );" ] + [ C ] * n + [ "function f() { return m; }" ] )
+    # rubyNamespaceOnly — a class body_statement; ONE nested class precedes the flood so the comments are
+    # the body's children (leading extras go to the parent `class` node, whose body has not started)
+    w( "rubyns/n%d/big.rb" % n, [ "class Foo", "  class Baz", "  end" ] + [ H ] * n + [ "  class Bar", "  end", "end" ] )
+    w( "rubyns_off/n%d/big.rb" % n, [ "class Foo", "  class Baz", "  end", "  class Bar", "  end", "end" ] + [ H ] * n )
+    # rubyMixinTargets — an `include` argument_list
+    w( "rubymixin/n%d/big.rb" % n, [ "module A; end", "module B; end", "class Foo", "  include A," ] + [ "  " + H ] * n + [ "    B", "end" ] )
+    w( "rubymixin_off/n%d/big.rb" % n, [ "module A; end", "module B; end", "class Foo", "  include A, B" ] + [ "  " + H ] * n + [ "end" ] )
+    # elixirAliasGroup — an `alias Foo.{…}` tuple
+    w( "exalias/n%d/big.ex" % n, [ "defmodule M do", "  alias Foo.{A," ] + [ "  " + H ] * n + [ "    B}", "  def f, do: 1", "end" ] )
+    w( "exalias_off/n%d/big.ex" % n, [ "defmodule M do", "  alias Foo.{A, B}" ] + [ "  " + H ] * n + [ "  def f, do: 1", "end" ] )
+    # firstChildOfType — a using_declaration, in the QUALIFIED spelling the tags query captures
+    w( "cppusing/n%d/big.cpp" % n, [ "namespace ns { namespace inner { int q; } }", "using" ] + [ C ] * n + [ "    namespace ns::inner;", "int f( void ) { return q; }" ] )
+    w( "cppusing_off/n%d/big.cpp" % n, [ "namespace ns { namespace inner { int q; } }", "using namespace ns::inner;" ] + [ C ] * n + [ "int f( void ) { return q; }" ] )
+    # rustItemCarriesTestAttr — an attribute_item; control flood AFTER the item (see the header)
+    w( "rustattr/n%d/big.rs" % n, [ "#[" ] + [ C ] * n + [ "test]", "fn t() { let a = 1; }" ] )
+    w( "rustattr_off/n%d/big.rs" % n, [ "#[test]", "fn t() { let a = 1; }" ] + [ C ] * n )
+    # csharpNodeCarriesTestAttr — a method_declaration's own children; control floods its body
+    w( "csattr/n%d/big.cs" % n, [ "namespace A { class K {", "public" ] + [ C ] * n + [ "void M() {}", "} }" ] )
+    w( "csattr_off/n%d/big.cs" % n, [ "namespace A { class K {", "public void M() {" ] + [ C ] * n + [ "}", "} }" ] )
+    # testMacroBlockPartsOf — the argument scan (flood inside the parens) and the MISSING-`;` probe (flood
+    # between `)` and `{`, which the recovered expression_statement owns); one control serves both
+    w( "testmacro/n%d/big.cpp" % n, [ "TEST_CASE(" ] + [ C ] * n + [ "    \"title\" ) { int a = 1; }" ] )
+    w( "testmacrosemi/n%d/big.cpp" % n, [ "TEST_CASE( \"title\" )" ] + [ C ] * n + [ "{ int a = 1; }" ] )
+    w( "testmacro_off/n%d/big.cpp" % n, [ "TEST_CASE( \"title\" ) { int a = 1; }" ] + [ C ] * n )
+    # childTokenAmong — a field_declaration with NO `static`, so the scan runs to the end
+    w( "fieldstatic/n%d/big.cpp" % n, [ "struct S", "{", "    int" ] + [ C ] * n + [ "    m;", "};" ] )
+    w( "fieldstatic_off/n%d/big.cpp" % n, [ "struct S", "{", "    int m;" ] + [ C ] * n + [ "};" ] )
+    # isPyEnumMemberTarget — the superclasses argument_list (W3's flood sat in the class body: flat)
+    w( "pyenum/n%d/big.py" % n, [ "from enum import Enum", "class C(" ] + [ H ] * n + [ "    Enum", "):", "    A = 1" ] )
+    w( "pyenum_off/n%d/big.py" % n, [ "from enum import Enum", "class C( Enum ):", "    A = 1" ] + [ H ] * n )
+    # elixirKeywordValue — a def's arguments between the head and `do:`
+    w( "exkw/n%d/big.ex" % n, [ "defmodule M do", "  def f(x)," ] + [ "  " + H ] * n + [ "    do: x", "end" ] )
+    w( "exkw_off/n%d/big.ex" % n, [ "defmodule M do", "  def f(x), do: x" ] + [ "  " + H ] * n + [ "end" ] )
+    # elixirBody — a call's OWN child list: comments between the head and its do_block (attributed by
+    # `sample`: 3 441 of 3 441 busy samples under elixirBody -> ts_node_named_child)
+    w( "excall/n%d/big.ex" % n, [ "defmodule M do", "  def f(x)" ] + [ "  " + H ] * n + [ "  do", "    x", "  end", "end" ] )
+    w( "excall_off/n%d/big.ex" % n, [ "defmodule M do", "  def f(x) do", "    x", "  end" ] + [ "  " + H ] * n + [ "end" ] )
+    # ffiVisitNode, the pybind arm — `m.def(…)`'s argument_list (the file names pybind11, which arms it)
+    w( "pybind/n%d/big.cpp" % n, [ "#include <pybind11/pybind11.h>", "int f( int a );", "PYBIND11_MODULE( m, mod )", "{", "    mod.def(" ] + [ C ] * n + [ "        \"f\", &f );", "}" ] )
+    w( "pybind_off/n%d/big.cpp" % n, [ "#include <pybind11/pybind11.h>", "int f( int a );", "PYBIND11_MODULE( m, mod )", "{", "    mod.def( \"f\", &f );" ] + [ C ] * n + [ "}" ] )
+    # ffiVisitNode, the linkage-string scan — between `extern` and `"C"` (ffi/ above floods the BODY)
+    w( "externc/n%d/big.cpp" % n, [ "extern" ] + [ C ] * n + [ "\"C\" {", "int f0( int a );", "}", "int useit( void ) { return f0( 1 ); }" ] )
+    w( "externc_off/n%d/big.cpp" % n, [ C ] * n + [ "extern \"C\" {", "int f0( int a );", "}", "int useit( void ) { return f0( 1 ); }" ] )
+    # pyMethodsKeyword — a Flask route decorator's argument_list
+    w( "pyroute/n%d/big.py" % n, [ "from flask import Flask", "app = Flask( __name__ )", "@app.route( \"/x\"," ] + [ H ] * n + [ "    methods=[ \"POST\" ] )", "def h():", "    return 1" ] )
+    w( "pyroute_off/n%d/big.py" % n, [ "from flask import Flask", "app = Flask( __name__ )", "@app.route( \"/x\", methods=[ \"POST\" ] )", "def h():", "    return 1" ] + [ H ] * n )
+    # jsMethodProperty — fetch()'s options object
+    w( "jsfetch/n%d/big.js" % n, [ "function g() {", "    return fetch( '/x', {" ] + [ C ] * n + [ "        method: 'POST' } );", "}" ] )
+    w( "jsfetch_off/n%d/big.js" % n, [ "function g() {", "    return fetch( '/x', { method: 'POST' } );" ] + [ C ] * n + [ "}" ] )
+    # captureTagsFacts, the ObjC body fallback — a method_definition's own children before its `{`
+    w( "objcbody/n%d/big.m" % n, [ "@interface Foo", "@end", "@implementation Foo", "- (void) m" ] + [ C ] * n + [ "{ }", "@end" ] )
+    w( "objcbody_off/n%d/big.m" % n, [ "@interface Foo", "@end", "@implementation Foo", "- (void) m { }" ] + [ C ] * n + [ "@end" ] )
+    # nodesMatchExactly — two flooded argument_lists joined by a repeated metavariable (`$X == $X`)
+    w( "patmeta/n%d/big.c" % n, [ "int a( int x );", "int f( void )", "{", "    return a(" ] + [ C ] * n + [ "    1 ) == a(" ] + [ C ] * n + [ "    1 );", "}" ] )
 PY
 
 # user-CPU seconds (user+sys) of one cold run of "$@" against corpus $1
@@ -310,6 +403,32 @@ if [ "$( count_rows "$TMP/a_rd.xml" '<s l="2009" k="use" t="call-arg" rd="4,1007
 else
     no "(A10) SliceRdWalker: the reaching-def join is wrong — expected rd=\"4,1007\" on the line-2009 use row"
 fi
+# lane W4 — the four converted walks whose answer is visible in the map or a verb row
+"$BIN" "$TMP/externc/n1000" --no-cache --top-k=100000 >"$TMP/a_externc.xml" 2>/dev/null
+if [ "$( count_rows "$TMP/a_externc.xml" '<c n="f0"/>' )" = 1 ]; then
+    ok "(A11) ffiVisitNode/linkage: \`extern /*…*/ \"C\"\` is still read as C linkage past 1000 comments (f0 is a call target)"
+else
+    no "(A11) ffiVisitNode/linkage: the linkage string was not found past the flood — the extern \"C\" call edge is gone"
+fi
+"$BIN" "$TMP/pyenum/n1000" --no-cache --top-k=100000 >"$TMP/a_pyenum.xml" 2>/dev/null
+if [ "$( count_rows "$TMP/a_pyenum.xml" '<s t="var" n="A" id="big.py::C::A"' )" = 1 ]; then
+    ok "(A12) isPyEnumMemberTarget: \`A = 1\` is still an enum member when Enum sits past 1000 comments in the base list"
+else
+    no "(A12) isPyEnumMemberTarget: the Enum base was not found past the flood — the member row is gone"
+fi
+"$BIN" "$TMP/testmacro/n1000" --no-cache --top-k=100000 >"$TMP/a_tm.xml" 2>/dev/null
+"$BIN" "$TMP/testmacrosemi/n1000" --no-cache --top-k=100000 >"$TMP/a_tms.xml" 2>/dev/null
+if [ "$( count_rows "$TMP/a_tm.xml" '<s t="fn" n="title"' )" = 1 ] && [ "$( count_rows "$TMP/a_tms.xml" '<s t="fn" n="title"' )" = 1 ]; then
+    ok "(A13) testMacroBlockPartsOf: TEST_CASE still mints its \`title\` symbol with 1000 comments in the args AND with 1000 before the block"
+else
+    no "(A13) testMacroBlockPartsOf: the title string or the MISSING \`;\` was not found past the flood"
+fi
+"$BIN" "$TMP/patmeta/n1000" --no-cache --pattern='$X == $X' >"$TMP/a_pm.xml" 2>/dev/null
+if [ "$( count_rows "$TMP/a_pm.xml" '<m p="big.c:4" in="f">' )" = 1 ]; then
+    ok "(A14) nodesMatchExactly: \`\$X == \$X\` still unifies two calls whose argument lists each hold 1000 comments"
+else
+    no "(A14) nodesMatchExactly: the repeated metavariable no longer unifies across the flooded argument lists"
+fi
 "$BIN" "$TMP/slicew/n1000" --no-cache --slice=target >"$TMP/a_slice2.xml" 2>/dev/null
 if [ ! -s "$TMP/a_slice.xml" ]; then
     no "(A8) determinism (empty --slice answer)"
@@ -371,6 +490,40 @@ b_lcap_off="$(     usercpu "$TMP/lcap_off/n16000" "$BIN" --top-k=100000 )"
 b_lcap_on="$(      usercpu "$TMP/lcap/n16000"     "$BIN" --top-k=100000 )"
 arm "(B12) captureLambdaShadowDecls" "$b_lcap_off" "$b_lcap_on" 8 0.30 "a lambda capture list 16000 children wide vs the identical flood outside it"
 
+# lane W4 — one map-path pair per walk; `pair LABEL fixture control what` times both sides of one shape
+pair(){ # $1 = label, $2 = walk fixture, $3 = control fixture, $4 = what the pair is
+    local off on
+    off="$( usercpu "$TMP/$3/n16000" "$BIN" --top-k=100000 )"
+    on="$(  usercpu "$TMP/$2/n16000" "$BIN" --top-k=100000 )"
+    arm "$1" "$off" "$on" 8 0.30 "$4"
+}
+pair "(B13) captureMacroBodyCalls"      macroparams  macroparams_off "a preproc_params list 16000 children wide vs the identical flood outside the #define"
+pair "(B14) captureFields/type"         fieldtype    fieldtype_off   "a field's qualified_identifier type 16000 children wide vs the identical flood after the field"
+pair "(B15) captureFields/declarator"   fielddecl    fielddecl_off   "a field's reference_declarator 16000 children wide vs the identical flood after the field"
+pair "(B16) csharpUsingTarget"          csusing      csusing_off     "a using_directive 16000 children wide vs the identical flood inside a method body"
+pair "(B17) phpUseTarget"               phpuse       phpuse_off      "a namespace_use_declaration 16000 children wide vs the identical flood after it"
+pair "(B18) jsModuleLoadTarget"         jsrequire    jsrequire_off   "require()'s arguments 16000 children wide vs the identical flood after the statement"
+pair "(B19) rubyNamespaceOnly"          rubyns       rubyns_off      "a class body_statement 16000 children wide vs the identical flood after the class"
+pair "(B20) rubyMixinTargets"           rubymixin    rubymixin_off   "an include argument_list 16000 children wide vs the identical flood after the include"
+pair "(B21) elixirAliasGroup"           exalias      exalias_off     "an alias tuple 16000 children wide vs the identical flood after the alias"
+pair "(B22) firstChildOfType"           cppusing     cppusing_off    "a using_declaration 16000 children wide vs the identical flood after it"
+pair "(B23) rustItemCarriesTestAttr"    rustattr     rustattr_off    "an attribute_item 16000 children wide vs the identical flood after the item"
+pair "(B24) csharpNodeCarriesTestAttr"  csattr       csattr_off      "a method_declaration 16000 children wide vs the identical flood inside its body"
+pair "(B25) testMacroBlockPartsOf/args" testmacro    testmacro_off   "a TEST_CASE argument_list 16000 children wide vs the identical flood after the block"
+pair "(B26) testMacroBlockPartsOf/;"    testmacrosemi testmacro_off  "16000 comments between TEST_CASE(…) and its block vs the identical flood after the block"
+pair "(B27) childTokenAmong"            fieldstatic  fieldstatic_off "a field_declaration 16000 children wide vs the identical flood after the field"
+pair "(B28) isPyEnumMemberTarget"       pyenum       pyenum_off      "a superclasses argument_list 16000 children wide vs the identical flood after the class"
+pair "(B29) elixirKeywordValue"         exkw         exkw_off        "a def's arguments 16000 children wide vs the identical flood after the def"
+pair "(B30) elixirBody"                 excall       excall_off      "a def call 16000 children wide (comments before its do) vs the identical flood after the def"
+pair "(B31) ffiVisitNode/pybind"        pybind       pybind_off      "m.def()'s argument_list 16000 children wide vs the identical flood after the call"
+pair "(B32) ffiVisitNode/linkage"       externc      externc_off     "a linkage_specification 16000 children wide (before its \"C\") vs the identical flood before it"
+pair "(B33) pyMethodsKeyword"           pyroute      pyroute_off     "a route decorator's argument_list 16000 children wide vs the identical flood after the def"
+pair "(B34) jsMethodProperty"           jsfetch      jsfetch_off     "fetch()'s options object 16000 children wide vs the identical flood after the call"
+pair "(B35) captureTagsFacts/objc-body" objcbody     objcbody_off    "an ObjC method_definition 16000 children wide vs the identical flood after the method"
+b_pm_map="$(  usercpu "$TMP/patmeta/n16000" "$BIN" --top-k=100000 )"
+b_pm_walk="$( usercpu "$TMP/patmeta/n16000" "$BIN" --pattern='$X == $X' )"
+arm "(B36) nodesMatchExactly" "$b_pm_map" "$b_pm_walk" 8 0.30 "--pattern='\$X == \$X' over two 16000-comment argument lists vs the plain map"
+
 # ── (C) byte-identical against a reference binary ────────────────────────────────────────────────────
 echo
 echo "=== (C) byte-identical output vs RIPWIRE_REF_BIN ==="
@@ -394,9 +547,15 @@ else
     }
     for n in n1000 n16000; do
         for d in slicew slicepp span health health_off ffi ffi_off locals pat binds binds_off slicerd \
-                 bases bases_off args args_off lcap lcap_off; do
+                 bases bases_off args args_off lcap lcap_off \
+                 macroparams macroparams_off fieldtype fieldtype_off fielddecl fielddecl_off csusing csusing_off \
+                 phpuse phpuse_off jsrequire jsrequire_off rubyns rubyns_off rubymixin rubymixin_off exalias exalias_off \
+                 cppusing cppusing_off rustattr rustattr_off csattr csattr_off testmacro testmacrosemi testmacro_off \
+                 fieldstatic fieldstatic_off pyenum pyenum_off exkw exkw_off excall excall_off pybind pybind_off \
+                 externc externc_off pyroute pyroute_off jsfetch jsfetch_off objcbody objcbody_off patmeta; do
             cmp_pair "$TMP/$d/$n" --top-k=100000
         done
+        cmp_pair "$TMP/patmeta/$n" --pattern='$X == $X'
         cmp_pair "$TMP/slicew/$n"  --slice=target
         cmp_pair "$TMP/slicepp/$n" --slice=target
         cmp_pair "$TMP/span/$n"    --grep=needle_marker
@@ -445,6 +604,14 @@ esac
 case "$( verdict 0.03 2.52 8 0.30 )" in
     quad\ *) ok "(D) the measured pre-change SliceRdWalker pair (0.03s vs 2.52s) IS called quad";;
     *)       no "(D) the isolation verdict cannot see the SliceRdWalker pathology";;
+esac
+case "$( verdict 0.03 2.57 8 0.30 )" in
+    quad\ *) ok "(D) the measured pre-change elixirAliasGroup pair (0.03s vs 2.57s) IS called quad";;
+    *)       no "(D) the isolation verdict cannot see the elixirAliasGroup pathology";;
+esac
+case "$( verdict 0.09 1.13 8 0.30 )" in
+    quad\ *) ok "(D) the measured pre-change linkage-string pair (0.09s vs 1.13s, the smallest W4 ratio) IS called quad";;
+    *)       no "(D) the isolation verdict cannot see the smallest W4 pathology";;
 esac
 case "$( verdict 0.10 0.70 8 0.30 )" in
     linear\ *) ok "(D) a 7x pair (0.10s vs 0.70s) IS called linear, not quad";;

--- a/test/patterncheck.sh
+++ b/test/patterncheck.sh
@@ -339,10 +339,12 @@ cmp -s "$TMP/d1" "$TMP/d2" && ok "determinism: two runs byte-identical" || no "d
 hr="$( hitsOf "$TMP/d1" )"
 [ "${hr:-0}" -ge 1 ] 2>/dev/null && ok "found ts_node_child(\$A, \$B) in ripwire's own src (hits=$hr)" \
     || no "ts_node_child(\$A, \$B) found nothing in src/ — it is called there (presence guard below)"
-# (the 2026-08-29 split moved ingest.cpp's tree walkers into its ingest_*.h sections — the probe's
-# ground truth lives in ingest_sidecap.h now)
-grep -qF 'ts_node_child(' "$ROOT/src/ingest_sidecap.h" && ok "presence guard: src/ingest_sidecap.h really calls ts_node_child(" \
-    || no "presence guard: src/ingest_sidecap.h no longer calls ts_node_child( — pick another probe"
+# (the 2026-08-29 split moved ingest.cpp's tree walkers into its ingest_*.h sections; the 2026-09-10
+# child-walk lanes then converted every UNBOUNDED indexed call in ingest_sidecap.h to a cursor, so the
+# probe's ground truth is ingest_binds.h now — its fixed-index probes such as `ts_node_child( value, 0 )`
+# are the form src/infra/tschildren.h keeps, and they stay)
+grep -qF 'ts_node_child(' "$ROOT/src/ingest_binds.h" && ok "presence guard: src/ingest_binds.h really calls ts_node_child(" \
+    || no "presence guard: src/ingest_binds.h no longer calls ts_node_child( — pick another probe"
 if command -v xmllint >/dev/null 2>&1; then
     xmllint --noout "$TMP/d1" 2>"$TMP/xmlerr" && ok "output is well-formed XML" || no "xmllint rejected the output: $( head -c 200 "$TMP/xmlerr" )"
 else


### PR DESCRIPTION
## What

Closes out the class of indexed tree-sitter child loops that lane W3 (`ab0d608d`, in #127) handed over unaudited: the ~25 `ts_node_child( n, i )` / `ts_node_named_child( n, i )` loops across `src/ingest_relations.h`, `ingest_names.h`, `ingest_elixir.h`, `ingest_sidecap.h`, `ingest_docs.h` and `pattern.h`. Stacks on #127's head (`17058123`), so the base is the integration branch and the diff is this lane alone.

Under the rule at the top of `src/infra/tschildren.h` — a cursor, or the one-line reason a comment cannot reach that list — the outcome is:

- **22 walks converted**, every one proven quadratic on the pre-change binary first (`test/childwalkscalecheck.sh`, new arms **B13..B36**, 13x..126x its control under a 16 000-comment flood inside ONE node's child list vs the identical flood placed where no walk under test owns it).
- **3 loops stay indexed** with the reason written at the loop: `mdWalk` (the markdown grammar declares no extras — its `parser.c` has zero `SHIFT_EXTRA` actions), `stringLiteralText` and the Elixir test-title interpolation scan (a string's children come from the external scanner, which owns every byte between the delimiters).
- Fixed-index probes (`ts_node_named_child( args, 0 )` and the like) are untouched — the rule keeps them.

| walk | pre-change | now |
| --- | --- | --- |
| captureMacroBodyCalls (B13) | 58x | flat |
| captureFields type / declarator (B14/B15) | 15x / 14x | flat |
| csharpUsingTarget (B16) · phpUseTarget (B17) · jsModuleLoadTarget (B18) | 36x · 54x · 53x | flat |
| rubyNamespaceOnly (B19) · rubyMixinTargets (B20) · elixirAliasGroup (B21) | 58x · 55x · 84x | flat |
| firstChildOfType (B22) — W3 kept it indexed on the refuted "width from the grammar" reason | 14x | flat |
| rustItemCarriesTestAttr (B23) · csharpNodeCarriesTestAttr (B24) | 55x · 37x | flat |
| testMacroBlockPartsOf args (B25) and the MISSING-`;` probe (B26) | 27x · 29x | flat |
| childTokenAmong (B27) · isPyEnumMemberTarget (B28) | 15x · 54x | flat |
| elixirKeywordValue (B29) · elixirBody (B30) | 81x · 82x | flat |
| ffiVisitNode pybind (B31) / linkage string (B32) | 13x · 13x | flat |
| pyMethodsKeyword (B33) · jsMethodProperty (B34) · captureTagsFacts ObjC body (B35) | 58x · 55x · 24x | flat |
| nodesMatchExactly, `--pattern='$X == $X'` (B36) | 126x | flat |

## Gate discipline

- RED first: the extended gate against the pre-change build — all 24 new arms FAIL, all 31 existing arms PASS.
- GREEN: 61 arms pass on the converted build. Arm (C) with `RIPWIRE_REF_BIN` = the pre-change build: **156 generated fixture × verb pairs and the 21 committed ones are byte-identical**. Four answer arms (A11..A14) prove the converted walks still produce their answer on the flooded fixture.
- What the fixtures taught is in the gate's header: a FLAT measurement proves the fixture missed the list, never that the loop is safe (W3's sweep flooded a Python class BODY: flat; the superclasses parens: 54x). Leading comments belong to the PARENT — a body that has not started is not the node being built (Ruby, B19). An uncaptured form never enters the walk (the unqualified C++ `using`, B22). And a control can be quadratic in its own right when the walk runs on every ancestor of a def (the C# controls now flood a method body). Two owners were attributed by CPU `sample`: comments before an Elixir do-block are the call's own children; comments between `TEST_CASE(…)` and its block belong to the recovered expression_statement.
- Also run locally: padscalecheck, preprocdeadscalecheck, langcheck, routecheck, elixircheck, patterncheck, and the seven gates `--test-gate` names — all PASS. Determinism and `xmllint` on the fixture tree: identical, well-formed. `docs/limits_build.py --check`: matches. Gate count unchanged (no new script).

## Quality

`src/infra/tschildren.h` gains `firstChildOfKind` — the first-child-of-kind probe six of the converted sites spelled identically — and ffiVisitNode's pybind argument scan is its own function (`pybindDefParts`). That is what keeps `--quality-delta`'s nesting and duplication rows at zero for this change. The ten rows it still reports are all `short-horizon-churn` (`churn="self"`) on the very functions this lane was asked to finish; nothing was acked.

`test/patterncheck.sh`'s presence guard probed `ingest_sidecap.h` for a `ts_node_child(` call; none is left there, so the guard reads `ingest_binds.h` now, whose fixed-index probes are the form the rule keeps.

## Not in this lane (recorded for the next one)

- `ts_node_prev_sibling` restarts from the parent's first child on every call — `rustItemCarriesTestAttr`'s sibling climb is a second restarting scan of the parent-chain family (the Rust control floods AFTER the item for that reason).
- The parent-chain family from the W3 readout (`ts_node_parent` re-descending through `ts_node_child_with_descendant`; bindsVisitNode, qualifierOf, enclosingScopeOf) is the larger remaining cold-llvm cost and is untouched here.
- CI on the integration head is red in other lanes' surfaces (w3fixlegendcheck legend sizes, a `--uses` count, situ's 25-row disclosure); this branch inherits those until #127's owner lands the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
