### PR TITLE
docs: three accuracy fixes — the Markdown grammar's attribution row, Hermes's live verification, PageRank's threading

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,8 +72,10 @@ you changed it):
 | openclaw (initial support) | `bash ~/.local/share/ripwire/skills/install.sh --openclaw` | `~/.agents/skills` |
 | Anything else | `bash ~/.local/share/ripwire/skills/install.sh <dir>` | `<dir>` |
 
-Hermes and openclaw support is initial. CI checks what the installers write on disk, but neither has been
-verified against a real Hermes or openclaw install yet. If you use one, the help-wanted issues
+Hermes and openclaw support is initial. CI checks what the installers write on disk. For Hermes, a contributor
+also ran the installer and the MCP registration against a real Hermes install when support landed
+([#51](https://github.com/redhat-et/ripwire/pull/51)), but the maintainers have not re-verified it since. openclaw
+has not been verified against a real install yet. If you use one, the help-wanted issues
 [#69 (Hermes)](https://github.com/redhat-et/ripwire/issues/69) and
 [#68 (openclaw)](https://github.com/redhat-et/ripwire/issues/68) ask for exactly that check.
 

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -67,6 +67,7 @@ is why the sizes are what they are — `parser.c` is one big static table, not h
 | `deps/swift` | tree-sitter-swift | Alex Pinkus | MIT | `31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5` | https://github.com/alex-pinkus/tree-sitter-swift | 20 MB |
 | `deps/php` | tree-sitter-php (v0.24.2; the `php/` sub-grammar only) | Josh Vera, GitHub | MIT | `5b5627faaa290d89eb3d01b9bf47c3bb9e797dea` | https://github.com/tree-sitter/tree-sitter-php | 6.9 MB |
 | `deps/lua` | tree-sitter-lua (v0.5.0) | Munif Tanjim | MIT | `10fe0054734eec83049514ea2e718b2a56acd0c9` | https://github.com/tree-sitter-grammars/tree-sitter-lua | 392 KB |
+| `deps/markdown` | tree-sitter-markdown (v0.5.3; the block grammar `tree-sitter-markdown/` only) | Matthias Deiml | MIT | `f969cd3ae3f9fbd4e43205431d0ae286014c05b5` | https://github.com/tree-sitter-grammars/tree-sitter-markdown | 2.1 MB |
 | `deps/doctest` | doctest (v2.4.12) | Viktor Kirilov | MIT | `1da23a3e8119ec5cce4f9388e91b065e20bf06f5` | https://github.com/doctest/doctest | 0.7 MB |
 
 Notes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,7 +247,9 @@ Edge rules:
 
 ### rank — Personalized PageRank
 
-Power iteration over the in-edge CSR, parallelized over **fixed contiguous row blocks**. Constants
+Power iteration over the in-edge CSR, single-threaded. Every reduction (the dangling mass, the L1 residual)
+folds **fixed contiguous blocks** of `kReductionBlockSize = 1024` in canonical index order, so the summation tree
+is a property of the source, never of thread count or timing. Constants
 live in a named configuration struct, not as literals in the loop: damping `α = 0.85`, L1 residual
 tolerance `τ = 1e-6`, `maxIter = 100`, diff-teleport concentration `β = 0.7`.
 

--- a/test/dependencypincheck.sh
+++ b/test/dependencypincheck.sh
@@ -83,6 +83,23 @@ else
     ok "every vendored dependency ships its compiled sources and its LICENSE"
 fi
 
+# ── (A') attribution: every vendored tree has its THIRD_PARTY.md row ────────────────────────────────
+# The list is the POPULATION under third_party/deps/, never a hand-kept name list — a hand list is how
+# deps/markdown came to ship with its sources, its LICENSE and its CMake pin but no attribution row.
+THIRD="$ROOT/THIRD_PARTY.md"
+norow=""
+for d in "$DEPS"/*/; do
+    name="$( basename "$d" )"
+    grep -q "^| \`deps/$name\` |" "$THIRD" || norow="$norow$name
+"
+done
+if [ -n "$norow" ]; then
+    no "vendored dependency with no THIRD_PARTY.md row (its licence attribution is missing):"
+    printf '%s' "$norow" | sed 's/^/          /'
+else
+    ok "every vendored dependency under third_party/deps/ has its THIRD_PARTY.md row"
+fi
+
 # ── (B') the hermeticity proof: a real disconnected configure ─────────────────────────────────────
 if ! command -v cmake >/dev/null 2>&1; then
     no "cmake not found — the disconnected-configure proof cannot run (a skip here would be a green lie)"


### PR DESCRIPTION
Three places where the docs said something the repository contradicts. Each was checked against its source before editing.

## 1. `THIRD_PARTY.md`: `deps/markdown` gets the attribution row it shipped without

`tree-sitter-markdown` is vendored under `third_party/deps/markdown`. Its sources and LICENSE are there, and `CMakeLists.txt:435` pins it at `f969cd3a` (v0.5.3, block grammar only). But the licence table had no row, so its MIT attribution (Matthias Deiml) appeared nowhere.

**Gate first.** `test/dependencypincheck.sh` gains arm (A'): every directory under `third_party/deps/` must have its `THIRD_PARTY.md` row.
- The list comes from the directory population, not a hand-kept list of names.
- On the tree before this change it was red with exactly one row missing, `markdown`. With the row added, all 9 arms pass.

**Size** is `du -sk`, the way the existing rows were measured (lua 392 KB, json 56 KB and toml 164 KB all match), so 2120 KB is written 2.1 MB.

**Not fixed here.** Arm (A)'s completeness loop still iterates a hand-written list that omits `lua` and `php`.

## 2. `INSTALL.md`: Hermes was run live when it landed; openclaw has not been

`INSTALL.md` (#121) said neither Hermes nor openclaw "has been verified against a real install yet". That is true for openclaw but not for Hermes: #51's own "Verified" section records a live run against a real Hermes by @ashutoshsinghpr7. The installer enabled the shipped skills, and `hermes mcp add` connected and discovered the MCP tools.

The paragraph now says:
- a contributor ran the Hermes installer and MCP registration live when support landed;
- the maintainers have not re-verified it since;
- openclaw has not been verified against a real install.

"Initial support" and the help-wanted issues #68 and #69 stay. `deckcheck` (which scans INSTALL.md) passes.

## 3. `docs/ARCHITECTURE.md`: PageRank's power iteration is single-threaded

The doc said the iteration is "parallelized over fixed contiguous row blocks". `src/pagerank.cpp` is serial: the iteration loop, the dangling-mass fold and the L1 residual run on one thread, and neither `pagerank.h` nor its caller in `graph.h` starts a thread.

The fixed blocks (`kReductionBlockSize = 1024`) exist for determinism, not parallelism. They fix the fold order, so the summation tree is a property of the source; that is the "fixed block partials in canonical order" rule in CLAUDE.md. The five gates that read ARCHITECTURE.md (`agentloopgradercheck`, `cacheidentitycheck`, `elixircheck`, `recallpassagecheck`, `resolverhonestycheck`) all pass.

Findings 1 and 2 came up while preparing the 0.6.0 release notes. Finding 3 came from a read-only probe of memgraph, used as a C++20 test corpus. No code changes, and no gate count or LIMITS.md changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
