### PR TITLE
fix(release): the macOS x86_64 binary gets x86-64-v3 flags and a runner whose Rosetta can train it — 0.6.0 would not build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ name: Release
 #
 # Every leg configures WITHOUT -DRIPWIRE_NATIVE=ON on purpose: a release binary must run on any machine of
 # its target arch, not just the exact CPU that happened to build it (see cmake/PortableFlags.cmake — the
-# portable default auto-applies safe generic Apple Silicon tuning on the two macOS-arm64 builders and
-# emits zero host-specific flags everywhere else).
+# portable default keys on the TARGET arch: generic Apple Silicon tuning for macos-arm64, the x86-64-v3
+# floor for both x64 legs, macos-x64's cross build included, and no host-specific flag anywhere).
 
 on:
   push:
@@ -36,16 +36,30 @@ jobs:
             asset_arch: arm64
             asset_os: macos
             pgo: true
+            developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
           - name: macos-x64
-            os: macos-14 # cross-compiled: the macos-13 Intel runner pool is retired — the v0.1.0 and
+            os: macos-26 # cross-compiled: the macos-13 Intel runner pool is retired — the v0.1.0 and
                          # first v0.2.0 runs both left its leg queued until the 24h auto-cancel. Built
-                         # as x86_64 on the arm64 runner; the smoke-test still executes for real via
-                         # Rosetta 2 (installed on GitHub's macos-14 images).
+                         # as x86_64 on the arm64 runner, then EXECUTED there under Rosetta 2: PGO
+                         # training, the determinism diff, --version, the smoke test. The binary is
+                         # x86-64-v3 (cmake/PortableFlags.cmake) and contains AVX2, BMI1/2, FMA, LZCNT
+                         # and MOVBE instructions, so the runner's Rosetta must execute all of them.
+                         # macos-14's cannot (SIGILL at the first vector instruction; test/strkerncheck.sh,
+                         # PR #127 run 4). macOS 15's gained AVX2, but its LZCNT/MOVBE coverage was never
+                         # verified. macOS 26's ran this leg's exact pgobuild, fixture and byte-identity
+                         # checks green with Xcode 26.6. Gated: test/portablebuildcheck.sh #2h.
             asset_arch: x64
             asset_os: macos
             pgo: true # trains under Rosetta 2 — instrumentation counts edges of the same code, so the
                       # profile is valid x86_64 data; it is just slower to collect
             cmake_extra: -DCMAKE_OSX_ARCHITECTURES=x86_64
+            # Xcode 26.6: the image default when this leg moved, and the toolchain it was verified on.
+            # Pinned so an image bump cannot change the compiler under a release.
+            developer_dir: /Applications/Xcode_26.6.app/Contents/Developer
+            # The minimum macOS, PINNED. With no deployment target clang takes the lower of the runner's
+            # macOS and the SDK default: 14.x on macos-14 but 26.0 here, so the runner move alone would
+            # have dropped every macOS 14/15 Intel user. 14.0 is the std::print floor src/infra/emit.h names.
+            deployment_target: "14.0"
           - name: linux-x64
             os: ubuntu-24.04
             # AlmaLinux-8-based manylinux container (glibc 2.28) with Red Hat gcc-toolset: newer
@@ -62,10 +76,11 @@ jobs:
             asset_os: linux
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container || '' }}
-    # Xcode 16.2 on the macOS legs (image default 15.4): its libc++ carries <print> at a macOS 14 deployment
-    # target — the std::print floor ci.yml holds. Empty on the container legs (gcc-toolset-14 already has it).
+    # Each macOS leg names its Xcode (matrix.developer_dir). macos-arm64 keeps Xcode 16.2 (image default
+    # 15.4): its libc++ carries <print> at a macOS 14 deployment target — the std::print floor ci.yml holds.
+    # Empty on the container legs (gcc-toolset-14 already has it).
     env:
-      DEVELOPER_DIR: ${{ matrix.os == 'macos-14' && '/Applications/Xcode_16.2.app/Contents/Developer' || '' }}
+      DEVELOPER_DIR: ${{ matrix.developer_dir || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -80,6 +95,12 @@ jobs:
             sudo apt-get install -y --no-install-recommends libxml2-utils
           fi
 
+      # The leg's pinned minimum macOS (matrix.deployment_target — see the macos-x64 entry), exported so both
+      # configures and every clang invocation see it. A leg without the key never gets the variable at all,
+      # not even as an empty string.
+      - name: Pin the macOS deployment target
+        if: ${{ matrix.deployment_target }}
+        run: echo "MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}" >> "$GITHUB_ENV"
 
       - name: Configure (portable — no RIPWIRE_NATIVE, this binary ships to other machines)
         if: ${{ !matrix.pgo }}
@@ -119,6 +140,13 @@ jobs:
         run: |
           ./build/ripwire --version
           ./build/ripwire --version | grep -q 'emit=std::print'
+
+      # The deployment-target pin, read off the shipped binary rather than trusted from the environment.
+      - name: The shipped binary's minimum macOS is the pinned one
+        if: ${{ matrix.deployment_target }}
+        run: |
+          otool -l build/ripwire | grep -E '^ *minos '
+          otool -l build/ripwire | grep -qE "^ *minos ${{ matrix.deployment_target }}$"
 
       - name: Smoke-test the freshly built binary
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ if(RIPWIRE_FUZZ)
 endif()
 
 # ---- optimization profile (portable by default) ----
-# default: arch-neutral on anything that isn't Apple Silicon; auto-detected apple-m1 tuning (safe generic
-# tuning, not a native-host bake-in) on real Apple Silicon. -DRIPWIRE_NATIVE=ON: dev-machine-only opt-in
+# default: the TARGET architecture decides — -march=x86-64-v3 for x86-64 (the owner's floor), generic apple-m1
+# tuning (not a native-host bake-in) for Apple Silicon, arch-neutral otherwise. -DRIPWIRE_NATIVE=ON: dev-machine-only opt-in
 # (-march=native bakes in host CPU extensions — never for a binary that ships or runs elsewhere).
 # See cmake/PortableFlags.cmake for the full rationale and the RIPWIRE_PRETEND_LINUX test-only hook.
 # DECLARED here, beside the other five options, rather than left to be conjured by a bare -D on the

--- a/cmake/PortableFlags.cmake
+++ b/cmake/PortableFlags.cmake
@@ -13,12 +13,15 @@
 #                         (owner, 2026-09-10 — see the branch below for why, and for the FMA caveat).
 #                         That is an architecture LEVEL, not a host bake-in, and it is what makes
 #                         src/infra/strkern.h's AVX2 kernels compile at all.
-#                         On real Apple Silicon, -mcpu=apple-m1 is safe GENERIC tuning (every
+#                         For an Apple Silicon TARGET, -mcpu=apple-m1 is safe GENERIC tuning (every
 #                         shipping Apple Silicon core, M1 through the current line, is an M1-superset —
-#                         this is not a native-host bake-in), so we auto-apply it there. The moment we are
-#                         NOT on Apple Silicon — any Linux, x86-64 macOS, or cross build — we must emit
+#                         this is not a native-host bake-in), so we auto-apply it there. The moment the
+#                         target is NOT Apple Silicon — any Linux, x86-64 macOS, a cross build — we must emit
 #                         ZERO Apple-specific flags: `-mcpu=apple-m1` is a hard configure/compile failure
-#                         on every other target (clang: "unknown target CPU"; gcc: flag not recognized).
+#                         on every other target (clang: "unknown target CPU", or on clang >= 17 for x86
+#                         "unsupported option '-mcpu=' for target"; gcc: flag not recognized).
+#   TARGET, NOT HOST      every branch keys on RIPWIRE_TARGET_ARCH, set below: CMAKE_OSX_ARCHITECTURES when
+#                         it names one arch, else CMAKE_SYSTEM_PROCESSOR.
 #
 # -fno-finite-math-only is load-bearing in EVERY branch: it keeps isnan/isinf live for isFiniteFast even
 # under -ffast-math. src/pagerank.cpp overrides all of this with -fno-fast-math regardless of branch
@@ -33,13 +36,37 @@ option(RIPWIRE_PRETEND_LINUX
   "TEST-ONLY (test/portablebuildcheck.sh): force the portable non-Apple-Silicon flag path for testability, even on real Apple Silicon"
   OFF)
 
+# ── the TARGET architecture — never the host's ─────────────────────────────────────────────────────────
+# CMAKE_SYSTEM_PROCESSOR names the HOST on a macOS cross build: CMake derives it from the running machine
+# (CMakeDetermineSystem honours only CMAKE_APPLE_SILICON_PROCESSOR) and never from CMAKE_OSX_ARCHITECTURES.
+# release.yml builds the macOS x86_64 binary on an arm64 runner with -DCMAKE_OSX_ARCHITECTURES=x86_64, and
+# keyed on CMAKE_SYSTEM_PROCESSOR that compile got -mcpu=apple-m1 and no -march: a hard driver error on
+# clang >= 17 (AppleClang 16, the Xcode 16.2 the release pins), and on clang 16 a baseline x86-64 binary
+# running strkern.h's scalar twins. test/portablebuildcheck.sh #2d-#2g hold both directions.
+set(RIPWIRE_TARGET_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+  list(LENGTH CMAKE_OSX_ARCHITECTURES _ripwire_osx_arch_count)
+  if(_ripwire_osx_arch_count EQUAL 1)
+    set(RIPWIRE_TARGET_ARCH "${CMAKE_OSX_ARCHITECTURES}")
+  elseif(NOT RIPWIRE_NATIVE)
+    # One add_compile_options() cannot give an x86_64 slice -march=x86-64-v3 and an arm64 slice
+    # -mcpu=apple-m1: a universal tree would hand both slices ONE arch's flags, which is the defect above on
+    # half the binary. Nothing here builds one; a universal binary is `lipo -create` of two single-arch trees.
+    message(FATAL_ERROR
+      "ripwire builds one architecture per build tree (CMAKE_OSX_ARCHITECTURES='${CMAKE_OSX_ARCHITECTURES}'): "
+      "configure one tree per architecture and combine the binaries with `lipo -create`.")
+  endif()
+  unset(_ripwire_osx_arch_count)
+endif()
+message(STATUS "RIPWIRE_TARGET_ARCH:${RIPWIRE_TARGET_ARCH}")
+
 set(RIPWIRE_IS_APPLE_SILICON OFF)
-if(APPLE AND NOT RIPWIRE_PRETEND_LINUX AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
+if(APPLE AND NOT RIPWIRE_PRETEND_LINUX AND RIPWIRE_TARGET_ARCH MATCHES "^(arm64|arm64e|aarch64)$")
   set(RIPWIRE_IS_APPLE_SILICON ON)
 endif()
 
 set(RIPWIRE_IS_X86_64 OFF)
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+if(RIPWIRE_TARGET_ARCH MATCHES "^(x86_64|x86_64h|amd64|AMD64)$")
   set(RIPWIRE_IS_X86_64 ON)
 endif()
 

--- a/src/infra/strkern.h
+++ b/src/infra/strkern.h
@@ -42,9 +42,9 @@
 // ── PORTABILITY ──────────────────────────────────────────────────────────────────────────────────────
 // arm64 has NEON in the baseline (`__ARM_NEON` is defined by every arm64 toolchain). x86-64 builds carry
 // `-march=x86-64-v3` unconditionally (CMakeLists.txt; owner decision 2026-09-10 — AVX2 + BMI1/2 + FMA +
-// LZCNT + MOVBE, the RHEL 10 floor), so `__AVX2__` is defined on every shipped x86-64 binary. Anything
-// else — a cross build, a hand-configured toolchain that overrides the arch flags — compiles the scalar
-// twins, which are the same functions with the same contracts and no ISA requirement at all.
+// LZCNT + MOVBE, the RHEL 10 floor), so `__AVX2__` is defined on every shipped x86-64 binary, the macOS one
+// cross-built on arm64 included (the floor keys on the TARGET arch). Anything else — a target that is neither,
+// a hand-configured toolchain that overrides the arch flags — compiles the scalar twins: same contracts, no ISA.
 //
 // The scalar twins are ALWAYS compiled, so nothing in them may be a GCC/Clang extension: the trailing-zero
 // count is `std::countr_zero` (<bit>, C++20) and not `__builtin_ctzll`, which MSVC — a supported compiler,

--- a/test/portablebuildcheck.sh
+++ b/test/portablebuildcheck.sh
@@ -242,6 +242,49 @@ else
     printf '  SKIP  #2d-#2g host is %s: CMAKE_OSX_ARCHITECTURES is Darwin-only (a no-op here); native Linux targets are #2b/#2c and the ubuntu CI legs\n' "$( uname -s )"
 fi
 
+# ── #2h: the release leg that CROSS-BUILDS x86_64 must run where Rosetta 2 executes the v3 floor ────────
+# #2d-#2g make the macos-x64 binary an x86-64-v3 binary, and release.yml then EXECUTES it on its arm64 runner
+# under Rosetta 2: scripts/pgobuild.sh's nine instrumented training runs, the determinism diff, --version and
+# the smoke test. Sonoma's Rosetta cannot — macos-14 runners SIGILL a -march=x86-64-v3 slice at its first
+# vector instruction (test/strkerncheck.sh, PR #127 run 4, rc 132); Rosetta gained AVX2 in macOS 15. And a
+# newer runner raises the binary's minimum macOS with it: with no deployment target clang takes the lower of
+# the runner's macOS and the SDK default (14.x on macos-14, 15.2 on macos-15 with Xcode 16.2), so the
+# deployment target must be PINNED, a decision rather than a side effect of the runner. Text-level; any host.
+cat >"$TMP/relverdict.py" <<'PY'
+import re, sys
+text = open( sys.argv[ 1 ] ).read()
+matrix = text.split( 'include:', 1 )[ 1 ].split( '\n    runs-on:', 1 )[ 0 ] if 'include:' in text else ''
+cross = [ leg for leg in re.split( r'\n\s*- name: ', matrix ) if 'CMAKE_OSX_ARCHITECTURES=x86_64' in leg ]
+if len( cross ) != 1:
+    print( 'FAIL expected exactly one release leg with CMAKE_OSX_ARCHITECTURES=x86_64, found %d — nothing was checked' % len( cross ) )
+else:
+    leg  = cross[ 0 ]
+    name = leg.split( '\n', 1 )[ 0 ].strip()
+    m    = re.search( r'^\s*os:\s*macos-(\d+)\b', leg, re.M )
+    if not m:
+        print( 'FAIL leg %s names no macos-N runner' % name )
+    elif int( m.group( 1 ) ) < 15:
+        print( 'FAIL leg %s runs on macos-%s, whose Rosetta 2 cannot execute the x86-64-v3 binary the leg builds and then runs (PGO training, determinism diff, smoke)' % ( name, m.group( 1 ) ) )
+    else:
+        print( 'PASS leg %s runs on macos-%s, where Rosetta 2 executes AVX2' % ( name, m.group( 1 ) ) )
+    # three spellings of a pin: a -D on the leg; the leg's `deployment_target:` exported by a step; a job-level env
+    pinned = ( re.search( r'CMAKE_OSX_DEPLOYMENT_TARGET=\d', leg )
+               or ( re.search( r'^\s*deployment_target:\s*"?\d', leg, re.M ) and 'MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}' in text )
+               or re.search( r'^\s*MACOSX_DEPLOYMENT_TARGET:\s*\S', text, re.M ) )
+    print( 'PASS leg %s pins its macOS deployment target' % name if pinned else
+           'FAIL leg %s does not pin its macOS deployment target — the runner\'s macOS, not a decision, sets the binary\'s minimum' % name )
+print( 'DONE' )
+PY
+relVerdict="$( python3 "$TMP/relverdict.py" "$ROOT/.github/workflows/release.yml" 2>&1 )"
+while IFS= read -r row; do
+    case "$row" in
+        PASS\ *) ok "#2h ${row#PASS }" ;;
+        FAIL\ *) no "#2h ${row#FAIL }" ;;
+    esac
+done <<<"$relVerdict"
+printf '%s\n' "$relVerdict" | grep -q '^DONE$' \
+    || no "#2h the release.yml verdict never finished — no evidence either way: $( printf '%s' "$relVerdict" | tail -3 )"
+
 # ── #3: RIPWIRE_NATIVE=ON stays opt-in and unaffected by the pretend-Linux hook ─────────────────────────
 nativeFlags="$( run_probe "$TMP/native" -DRIPWIRE_NATIVE=ON -DRIPWIRE_PRETEND_LINUX=ON )"
 if printf '%s' "$nativeFlags" | grep -q -- '-march=native'; then

--- a/test/portablebuildcheck.sh
+++ b/test/portablebuildcheck.sh
@@ -242,37 +242,66 @@ else
     printf '  SKIP  #2d-#2g host is %s: CMAKE_OSX_ARCHITECTURES is Darwin-only (a no-op here); native Linux targets are #2b/#2c and the ubuntu CI legs\n' "$( uname -s )"
 fi
 
-# ── #2h: the release leg that CROSS-BUILDS x86_64 must run where Rosetta 2 executes the v3 floor ────────
+# ── #2h: the release leg that CROSS-BUILDS x86_64 runs on the exact tuple it was verified on ──────────────────────
 # #2d-#2g make the macos-x64 binary an x86-64-v3 binary, and release.yml then EXECUTES it on its arm64 runner
 # under Rosetta 2: scripts/pgobuild.sh's nine instrumented training runs, the determinism diff, --version and
-# the smoke test. Sonoma's Rosetta cannot — macos-14 runners SIGILL a -march=x86-64-v3 slice at its first
-# vector instruction (test/strkerncheck.sh, PR #127 run 4, rc 132); Rosetta gained AVX2 in macOS 15. And a
-# newer runner raises the binary's minimum macOS with it: with no deployment target clang takes the lower of
-# the runner's macOS and the SDK default (14.x on macos-14, 15.2 on macos-15 with Xcode 16.2), so the
-# deployment target must be PINNED, a decision rather than a side effect of the runner. Text-level; any host.
+# the smoke test. So the runner's Rosetta must execute the v3 extensions the binary carries (AVX2, BMI1/2, FMA,
+# LZCNT, MOVBE). Sonoma's cannot — macos-14 runners SIGILL a -march=x86-64-v3 slice at its first vector
+# instruction (test/strkerncheck.sh, PR #127 run 4, rc 132); macOS 15's gained AVX2, but its LZCNT/MOVBE coverage
+# was never verified; macos-26 with Xcode 26.6 ran the leg green. And a newer runner raises the binary's minimum
+# macOS with it: with no deployment target clang takes the lower of the runner's macOS and the SDK default (14.x
+# on macos-14, 26.0 on macos-26), so the target is PINNED at 14.0, a decision rather than a side effect of the
+# runner. A bound is not enough — "macos-N with N >= 15" plus "any numeric target" passed a macos-15 leg pinned
+# at 26.0 — so the verdict holds the exact tuple. Text-level; any host.
 cat >"$TMP/relverdict.py" <<'PY'
 import re, sys
 text = open( sys.argv[ 1 ] ).read()
 matrix = text.split( 'include:', 1 )[ 1 ].split( '\n    runs-on:', 1 )[ 0 ] if 'include:' in text else ''
 cross = [ leg for leg in re.split( r'\n\s*- name: ', matrix ) if 'CMAKE_OSX_ARCHITECTURES=x86_64' in leg ]
+# The tuple the leg was VERIFIED on, held exactly. Changing the runner or the Xcode is a deliberate edit to release.yml AND
+# to this tuple, made together with fresh evidence: the runner's Rosetta 2 decides which x86-64-v3 instructions the PGO
+# training, determinism and smoke runs can execute, and the Xcode is the compiler that ran them green. The minimum macOS
+# stays "14.0" (the std::print floor src/infra/emit.h names), or macOS 14/15 Intel users are dropped without a word —
+# quoted, because a bare 14.0 is a YAML number, not the string the release's otool minos check matches.
+RUNNER, XCODE, MINOS = 'macos-26', '/Applications/Xcode_26.6.app/Contents/Developer', '14.0'
+EXPECT = ( ( 'os',                RUNNER, False, 'the runner whose Rosetta 2 ran this leg\'s x86-64-v3 PGO training and smoke green' ),
+           ( 'developer_dir',     XCODE,  False, 'the Xcode the leg was verified with' ),
+           ( 'deployment_target', MINOS,  True,  'the minimum macOS the release keeps' ) )
+def scalar( leg, key ):
+    m = re.search( r"""^[ \t]*%s:[ \t]*("[^"\n]*"|'[^'\n]*'|[^\s#]+)""" % key, leg, re.M )
+    if not m:
+        return None, False
+    raw    = m.group( 1 )
+    quoted = len( raw ) >= 2 and raw[ 0 ] == raw[ -1 ] and raw[ 0 ] in '"\''
+    return ( raw[ 1:-1 ] if quoted else raw ), quoted
+def shown( value, quoted ):
+    return '(absent)' if value is None else ( '"%s"' % value if quoted else value )
 if len( cross ) != 1:
     print( 'FAIL expected exactly one release leg with CMAKE_OSX_ARCHITECTURES=x86_64, found %d — nothing was checked' % len( cross ) )
 else:
     leg  = cross[ 0 ]
     name = leg.split( '\n', 1 )[ 0 ].strip()
-    m    = re.search( r'^\s*os:\s*macos-(\d+)\b', leg, re.M )
-    if not m:
-        print( 'FAIL leg %s names no macos-N runner' % name )
-    elif int( m.group( 1 ) ) < 15:
-        print( 'FAIL leg %s runs on macos-%s, whose Rosetta 2 cannot execute the x86-64-v3 binary the leg builds and then runs (PGO training, determinism diff, smoke)' % ( name, m.group( 1 ) ) )
+    for key, want, mustQuote, why in EXPECT:
+        got, quoted = scalar( leg, key )
+        if got == want and ( quoted or not mustQuote ):
+            print( 'PASS leg %s %s: %s, %s' % ( name, key, shown( want, mustQuote ), why ) )
+        else:
+            print( 'FAIL leg %s %s: %s%s, but the verified tuple is %s — %s; moving it edits release.yml and #2h\'s tuple together, deliberately'
+                   % ( name, key, shown( got, quoted ), ' (a bare YAML number)' if got == want else '', shown( want, mustQuote ), why ) )
+    # Each pin must also REACH the build. The deployment target through the step's export, with no -D on the leg that
+    # disagrees (CMake reads MACOSX_DEPLOYMENT_TARGET only when CMAKE_OSX_DEPLOYMENT_TARGET is not given); the Xcode
+    # through the job env's DEVELOPER_DIR, without which the image's default Xcode builds the release.
+    exported = 'MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}' in text
+    override = [ v for v in re.findall( r'CMAKE_OSX_DEPLOYMENT_TARGET=(\S+)', leg ) if v != MINOS ]
+    if not exported:
+        print( 'FAIL leg %s: no step exports matrix.deployment_target as MACOSX_DEPLOYMENT_TARGET — the key pins nothing; the runner\'s macOS sets the minimum' % name )
+    elif override:
+        print( 'FAIL leg %s: -DCMAKE_OSX_DEPLOYMENT_TARGET=%s on the leg overrides the exported %s — the pinned minimum is not what ships' % ( name, override[ 0 ], MINOS ) )
     else:
-        print( 'PASS leg %s runs on macos-%s, where Rosetta 2 executes AVX2' % ( name, m.group( 1 ) ) )
-    # three spellings of a pin: a -D on the leg; the leg's `deployment_target:` exported by a step; a job-level env
-    pinned = ( re.search( r'CMAKE_OSX_DEPLOYMENT_TARGET=\d', leg )
-               or ( re.search( r'^\s*deployment_target:\s*"?\d', leg, re.M ) and 'MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}' in text )
-               or re.search( r'^\s*MACOSX_DEPLOYMENT_TARGET:\s*\S', text, re.M ) )
-    print( 'PASS leg %s pins its macOS deployment target' % name if pinned else
-           'FAIL leg %s does not pin its macOS deployment target — the runner\'s macOS, not a decision, sets the binary\'s minimum' % name )
+        print( 'PASS leg %s: a step exports deployment_target as MACOSX_DEPLOYMENT_TARGET and no -D on the leg overrides it' % name )
+    wired = re.search( r'^[ \t]*DEVELOPER_DIR:[ \t]*\$\{\{[ \t]*matrix\.developer_dir\b', text, re.M )
+    print( 'PASS leg %s: the job env hands developer_dir to the toolchain as DEVELOPER_DIR' % name if wired else
+           'FAIL leg %s: nothing exports matrix.developer_dir as DEVELOPER_DIR — the image\'s default Xcode, not the pinned one, builds the release' % name )
 print( 'DONE' )
 PY
 relVerdict="$( python3 "$TMP/relverdict.py" "$ROOT/.github/workflows/release.yml" 2>&1 )"

--- a/test/portablebuildcheck.sh
+++ b/test/portablebuildcheck.sh
@@ -130,6 +130,118 @@ else
     ok "#2c aarch64 target stays generic (NEON is baseline there, no flag needed): '$armFlags'"
 fi
 
+# ── #2d-#2g: the TARGET architecture decides the floor, never the HOST ─────────────────────────────────
+# release.yml builds the macOS x86_64 binary ON an arm64 runner: `-DCMAKE_OSX_ARCHITECTURES=x86_64`. CMake
+# derives CMAKE_SYSTEM_PROCESSOR from the RUNNING machine there (arm64 — CMakeDetermineSystem honours only
+# CMAKE_APPLE_SILICON_PROCESSOR, never CMAKE_OSX_ARCHITECTURES), so a floor keyed on it handed every x86_64
+# compile `-mcpu=apple-m1` and no -march at all. Clang >= 17 (AppleClang 16 — the Xcode 16.2 release.yml
+# pins since c7982037) rejects that outright: "unsupported option '-mcpu=' for target". Clang 16 (AppleClang
+# 15, every release through v0.5.0) let it through, so the Intel-Mac binary could only ever have been the
+# x86-64 BASELINE — strkern.h's scalar twins, below the owner's v3 floor, and nothing else in the tree notices.
+# #2b cannot see this: it SETS CMAKE_SYSTEM_PROCESSOR=x86_64, which a real cross configure never does.
+# Darwin-only: CMAKE_OSX_ARCHITECTURES is a no-op everywhere else, and the Linux legs build natively (#2b/#2c).
+cat >"$TMP/ccverdict.py" <<'PY'
+# Reads a real configure's compile_commands.json; prints PASS/FAIL lines, then DONE (absent DONE = no verdict).
+import json, shlex, subprocess, sys
+ccPath, srcPrefix = sys.argv[ 1 ], sys.argv[ 2 ]
+def argv( e ):
+    return list( e[ 'arguments' ] ) if 'arguments' in e else shlex.split( e[ 'command' ] )
+def targetsX86( a ):
+    return any( a[ i ] == '-arch' and i + 1 < len( a ) and a[ i + 1 ] == 'x86_64' for i in range( len( a ) ) )
+try:
+    entries = [ e for e in json.load( open( ccPath ) ) if e.get( 'file', '' ).startswith( srcPrefix ) ]
+except Exception as exc:
+    entries = None
+    print( 'FAIL compile_commands.json unreadable: %s' % exc )
+if entries is not None and not entries:
+    print( 'FAIL compile_commands.json lists no src/ translation unit — nothing was checked' )
+elif entries:
+    n   = len( entries )
+    rel = lambda e: 'src/' + e[ 'file' ][ len( srcPrefix ): ]
+    x86 = [ e for e in entries if targetsX86( argv( e ) ) ]
+    v3  = [ e for e in entries if '-march=x86-64-v3' in argv( e ) ]
+    m1  = [ e for e in entries if '-mcpu=apple-m1' in argv( e ) ]
+    print( '%s %d of %d src/ compile lines target -arch x86_64 (the cross configure reached the compiler)' % ( 'PASS' if len( x86 ) == n else 'FAIL', len( x86 ), n ) )
+    missing = [ rel( e ) for e in entries if '-march=x86-64-v3' not in argv( e ) ]
+    print( '%s %d of %d src/ compile lines carry -march=x86-64-v3%s' % ( 'PASS' if not missing else 'FAIL', len( v3 ), n, ' (first without: %s)' % missing[ 0 ] if missing else '' ) )
+    print( '%s %d of %d src/ compile lines carry -mcpu=apple-m1%s' % ( 'FAIL' if m1 else 'PASS', len( m1 ), n, ' (first: %s)' % rel( m1[ 0 ] ) if m1 else '' ) )
+    # The macros the compiler DEFINES on one shipped TU's exact line (ingest.cpp includes strkern.h): the
+    # flag list proves intent, only the preprocessor proves strkern.h's `#elif defined( __AVX2__ )` is taken.
+    probe = next( ( e for e in entries if e[ 'file' ].endswith( '/src/ingest.cpp' ) ), entries[ 0 ] )
+    line, skipNext = [], False
+    for tok in argv( probe ):
+        if skipNext:
+            skipNext = False
+        elif tok in ( '-o', '-MT', '-MF' ):
+            skipNext = True
+        elif tok not in ( '-c', '-MD', probe[ 'file' ] ):
+            line.append( tok )
+    r = subprocess.run( line + [ '-dM', '-E', '-x', 'c++', '/dev/null' ], cwd=probe.get( 'directory' ), capture_output=True, text=True )
+    defs = { l.split()[ 1 ] for l in r.stdout.splitlines() if l.startswith( '#define ' ) and len( l.split() ) > 1 }
+    if r.returncode != 0:
+        print( 'FAIL the compiler REJECTED %s\'s exact x86_64 command line (rc=%d): %s' % ( rel( probe ), r.returncode, ( r.stderr.strip().splitlines() or [ '(no stderr)' ] )[ 0 ] ) )
+    elif '__x86_64__' in defs and '__AVX2__' in defs:
+        print( 'PASS %s\'s exact command line defines __x86_64__ and __AVX2__ — strkern.h compiles its AVX2 path' % rel( probe ) )
+    else:
+        print( 'FAIL %s\'s exact command line: __x86_64__=%s __AVX2__=%s — the shipped x86_64 binary would carry the SCALAR twins' % ( rel( probe ), '__x86_64__' in defs, '__AVX2__' in defs ) )
+print( 'DONE' )
+PY
+if [ "$( uname -s )" = "Darwin" ]; then
+    hostCpu="$( uname -m )"
+    # #2d: module level, the host's own CMAKE_SYSTEM_PROCESSOR left alone — only the TARGET is named
+    osxX86Flags="$( run_probe "$TMP/osx-x86" -DCMAKE_OSX_ARCHITECTURES=x86_64 )"
+    if [ "$osxX86Flags" = "CONFIGURE_FAILED" ]; then
+        no "#2d CMAKE_OSX_ARCHITECTURES=x86_64 probe configure failed outright: $(tail -5 "$TMP/osx-x86/configure.log" 2>/dev/null)"
+    elif printf '%s' "$osxX86Flags" | grep -q -- '-mcpu=apple-m1'; then
+        no "#2d an x86_64 target on a $hostCpu host was handed -mcpu=apple-m1 — the HOST chose the flags, not the target: '$osxX86Flags'"
+    elif ! printf '%s' "$osxX86Flags" | grep -q -- '-march=x86-64-v3'; then
+        no "#2d an x86_64 target on a $hostCpu host did NOT get the -march=x86-64-v3 floor: '$osxX86Flags'"
+    else
+        ok "#2d CMAKE_OSX_ARCHITECTURES=x86_64 on a $hostCpu host carries the v3 floor and nothing Apple-specific: '$osxX86Flags'"
+    fi
+    # #2e: the other direction — an arm64 target keeps its Apple Silicon tuning whatever the host is
+    osxArmFlags="$( run_probe "$TMP/osx-arm" -DCMAKE_OSX_ARCHITECTURES=arm64 )"
+    if [ "$osxArmFlags" = "CONFIGURE_FAILED" ]; then
+        no "#2e CMAKE_OSX_ARCHITECTURES=arm64 probe configure failed outright: $(tail -5 "$TMP/osx-arm/configure.log" 2>/dev/null)"
+    elif printf '%s' "$osxArmFlags" | grep -q -- '-march=x86'; then
+        no "#2e an arm64 target on a $hostCpu host was handed an x86 architecture flag: '$osxArmFlags'"
+    elif ! printf '%s' "$osxArmFlags" | grep -q -- '-mcpu=apple-m1'; then
+        no "#2e an arm64 target on a $hostCpu host lost its Apple Silicon tuning: '$osxArmFlags'"
+    else
+        ok "#2e CMAKE_OSX_ARCHITECTURES=arm64 on a $hostCpu host keeps -mcpu=apple-m1: '$osxArmFlags'"
+    fi
+    # #2f: a universal tree cannot give one slice -march=x86-64-v3 and the other -mcpu=apple-m1 through one
+    # add_compile_options(), and release.yml never builds one — the module must REFUSE it by name rather than
+    # hand both slices one arch's flags (this same defect, on half the binary)
+    fatFlags="$( run_probe "$TMP/osx-fat" '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64' )"
+    if [ "$fatFlags" = "CONFIGURE_FAILED" ] && grep -q 'one architecture per build tree' "$TMP/osx-fat/configure.log"; then
+        ok "#2f a universal CMAKE_OSX_ARCHITECTURES=x86_64;arm64 configure is refused by name, not given one slice's flags"
+    elif [ "$fatFlags" = "CONFIGURE_FAILED" ]; then
+        no "#2f the universal configure failed, but not with the refusal: $(tail -5 "$TMP/osx-fat/configure.log" 2>/dev/null)"
+    else
+        no "#2f a universal CMAKE_OSX_ARCHITECTURES=x86_64;arm64 configure was ACCEPTED with one flag set for both slices: '$fatFlags'"
+    fi
+    # #2g: the REAL project, exactly as release.yml configures its macos-x64 leg — every src/ compile line, and
+    # the macros the compiler defines on one of them
+    if ! cmake -S "$ROOT" -B "$TMP/real-x86" -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON >"$TMP/real-x86.log" 2>&1; then
+        no "#2g the real project's x86_64-target configure failed: $(tail -5 "$TMP/real-x86.log" 2>/dev/null)"
+    else
+        realVerdict="$( python3 "$TMP/ccverdict.py" "$TMP/real-x86/compile_commands.json" "$ROOT/src/" 2>&1 )"
+        # a here-string, not a pipe: rows read in a pipeline subshell would print FAIL and leave fail=0
+        while IFS= read -r row; do
+            case "$row" in
+                PASS\ *) ok "#2g ${row#PASS }" ;;
+                FAIL\ *) no "#2g ${row#FAIL }" ;;
+            esac
+        done <<<"$realVerdict"
+        printf '%s\n' "$realVerdict" | grep -q '^DONE$' \
+            || no "#2g the compile_commands verdict never finished — no evidence either way: $( printf '%s' "$realVerdict" | tail -3 )"
+    fi
+else
+    printf '  SKIP  #2d-#2g host is %s: CMAKE_OSX_ARCHITECTURES is Darwin-only (a no-op here); native Linux targets are #2b/#2c and the ubuntu CI legs\n' "$( uname -s )"
+fi
+
 # ── #3: RIPWIRE_NATIVE=ON stays opt-in and unaffected by the pretend-Linux hook ─────────────────────────
 nativeFlags="$( run_probe "$TMP/native" -DRIPWIRE_NATIVE=ON -DRIPWIRE_PRETEND_LINUX=ON )"
 if printf '%s' "$nativeFlags" | grep -q -- '-march=native'; then


### PR DESCRIPTION
## Why this blocks 0.6.0
PR #127 made `-march=x86-64-v3` the x86-64 floor. `release.yml` builds the macOS x86_64 binary by cross-compiling on an arm64 `macos-14` runner (`-DCMAKE_OSX_ARCHITECTURES=x86_64`). `cmake/PortableFlags.cmake` picked its flags from `CMAKE_SYSTEM_PROCESSOR`, which CMake sets from the build host, so it read `arm64` and ignored the target architecture. Every x86_64 compile line got `-mcpu=apple-m1` and no `-march` at all.

- **Before 0.6.0:** v0.5.0 and earlier used AppleClang 15, which accepted that flag, so those releases almost certainly shipped a plain x86-64 binary below the intended floor. That is an inference: pgobuild.sh deletes its configure log, so no release log shows the flags.
- **Now:** Xcode 16.2 was pinned after v0.5.0. Its AppleClang 16 is LLVM-17 generation, and clang 17 made this a hard error: `unsupported option '-mcpu=' for target` ([LLVM #64958](https://github.com/llvm/llvm-project/issues/64958)). Reproduced locally, `ingest.cpp` and `pagerank.cpp` both fail to compile. The macos-x64 job would fail, and `publish` needs every build job, so **the tag would not ship**.

## What changes

### `fix(cmake)`: flags follow the target architecture (88a8f652)
`cmake/PortableFlags.cmake` now decides from `CMAKE_OSX_ARCHITECTURES` when it names exactly one architecture, and from `CMAKE_SYSTEM_PROCESSOR` otherwise.

| Case | Before | After |
|---|---|---|
| Linux x86_64 native | `-O2 -march=x86-64-v3` | unchanged |
| Linux arm64 | `-O2` | unchanged |
| macOS arm64 native | `-O2 -mcpu=apple-m1` | unchanged |
| **macOS x86_64 cross-built on arm64** | `-mcpu=apple-m1`, no `-march` | **`-march=x86-64-v3`** |
| universal (multi-arch) build tree | host flags applied to both slices | configure stops with "ripwire builds one architecture per build tree"; `RIPWIRE_NATIVE` keeps `-march=native` |

**New gate arms** `#2d`–`#2g` in `test/portablebuildcheck.sh`:
- They run on macOS and skip elsewhere with a stated reason.
- `#2g` configures exactly as the release job does, then checks `compile_commands.json` and the compiler's defined macros.
- Red on main (5 FAIL), green here, about 1.7 s, and they also pass under stock `/bin/bash` 3.2.

After the fix, `ingest.cpp`'s real compile line defines `__x86_64__` and `__AVX2__`, so the string kernels take their AVX2 path. The x86_64 binary contains ymm, `vfmadd`, `lzcnt` and `movbe` opcodes, and no zmm.

### `ci(release)`: build and train the x86_64 binary where Rosetta can run v3 (07039eb5)
The macOS x86_64 job moves to `macos-26`, pins Xcode 26.6, and pins `MACOSX_DEPLOYMENT_TARGET=14.0`. A new step reads `minos` back off the binary. Each macOS job now names its own Xcode; macos-arm64 is unchanged.
- **Why not `macos-14`:** its Rosetta crashes with SIGILL on x86-64-v3 code (see PR #127's strkerncheck history), and the PGO training runs the x86_64 binary under Rosetta.
- **Why not `macos-15`:** Rosetta there gained AVX2, but nothing found confirms LZCNT/MOVBE, which this binary uses.
- **Why pin 14.0:** without it, moving to `macos-26` would silently raise the minimum macOS to 26 and drop macOS 14 and 15 Intel users.
- **New arm `#2h`** checks release.yml's text on every host: red before this commit, green after. actionlint is clean and `releaseinstallcheck.sh` passes.

## Verified locally
Host: arm64 Mac, macOS 26.5.1, Xcode 26.6 build 17F113, the build the macos-26 runner defaults to.
- **Configure:** the release job's exact configure picks `-march=x86-64-v3`.
- **PGO pipeline:** the release job's exact pipeline ran under Rosetta with `MACOSX_DEPLOYMENT_TARGET=14.0` (`scripts/pgobuild.sh`, Release, `-DCMAKE_OSX_ARCHITECTURES=x86_64`). It exited 0 and collected a profile.
- **The resulting binary** passes the release job's checks: `emit=std::print`, `minos 14.0`, a clean determinism diff, xmllint.
- **Byte-identity:** the plain and PGO x86_64 binaries match the arm64 build on `test/fixture`, the repo map and a `--for` query.
- **Not verified:** nothing ran on GitHub's macos-26 runner (26.6.2). The first real cross-compile there is still the tag push. `workflow_dispatch` publishes to the tag it's given, so it is not a safe dry run.

## Follow-ups (not in this PR)
- **`macos-14` retirement:** brownouts on 8 days between 2026-10-05 and 2026-10-30, removal 2026-11-02 ([runner-images #13518](https://github.com/actions/runner-images/issues/13518)). The macos-arm64 release job and every macOS CI job still use it.
- **Log the flags:** have pgobuild.sh print `RIPWIRE_ARCH_FLAGS`, so a release log shows what was actually used.
- **Installer message:** on an x86-64 CPU below v3, `scripts/install.sh` reports a version mismatch instead of the CPU requirement. That fix is in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
