### PR TITLE
fix(install): an x86-64 CPU below v3 is told so, not 'version mismatch' — pre-check before download, SIGILL named after

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,12 +23,17 @@ The installer:
 
 Linux builds run on RHEL 8 and later; every release is smoke-tested on RHEL 9 before it publishes.
 
+From 0.6.0 the prebuilt x86-64 binaries need an x86-64-v3 CPU (AVX2, BMI2, FMA and the rest of that level), roughly
+Intel Haswell (2013) or AMD Excavator (2015) and newer; the installer checks before it downloads. On an older CPU,
+[build from source](#build-from-source) with `./install.sh`, which builds for that machine's CPU (`-DRIPWIRE_NATIVE=ON`).
+
 | Variable | Effect |
 | --- | --- |
 | `RIPWIRE_REPO` | Required: `redhat-et/ripwire`. |
 | `RIPWIRE_VERSION` | Install a specific tag, e.g. `v0.5.0`. Default: the latest release. |
 | `RIPWIRE_INSTALL_PREFIX` | Install under this prefix instead of `~/.local`; the binary goes in `<prefix>/bin`. |
 | `RIPWIRE_INSTALL_YES=1` | Skip the confirmation prompt. |
+| `RIPWIRE_SKIP_CPU_CHECK=1` | Skip the x86-64-v3 CPU check. The binary is still test-run before it is installed. |
 | `RIPWIRE_NO_ACTIVATE=1` | Stage the skills without activating them. |
 
 Then try it in a repository:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,6 +55,9 @@ cmake -S . -B build && cmake --build build -j
 ./build/ripwire --version
 ```
 
+On x86-64 the default build targets x86-64-v3 as well, so on an older CPU add `-DRIPWIRE_NATIVE=ON` to the
+first command to build for that machine's own CPU, or use `./install.sh` below, which does so.
+
 To put a source build on your `PATH`, run `./install.sh` from the checkout. It builds a Release binary tuned
 for this machine's CPU in `build-install/` and installs it under `RIPWIRE_INSTALL_PREFIX`, or under
 `brew --prefix` when Homebrew is present, or else under `~/.local`. Like the prebuilt installer, it stages

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,6 +19,9 @@
 #                             ~/.local/bin (no sudo needed). Pass /usr/local for the traditional location
 #                             (may prompt for sudo to write there).
 #   RIPWIRE_INSTALL_YES=1     skip the interactive confirmation (for CI / scripted installs).
+#   RIPWIRE_SKIP_CPU_CHECK=1  skip the x86-64-v3 CPU pre-check ("CPU floor" below). The downloaded binary is
+#                             still run before it is installed, so a CPU that truly lacks v3 is still refused.
+#   RIPWIRE_CPUINFO           read the Linux CPU flags from this file instead of /proc/cpuinfo (test seam).
 set -eu
 
 # ── repo + version ───────────────────────────────────────────────────────────────────────────────────────
@@ -73,6 +76,75 @@ assetUrl="$( printf '%s' "$releaseJson" | grep -o "\"browser_download_url\": *\"
     echo "  (built for ${assetOs}/${assetArch} — this platform may not be published for this release)" >&2
     exit 1
 }
+
+# ── CPU floor: from 0.6.0 the prebuilt x86-64 binary requires x86-64-v3 ────────────────────────────────────
+# cmake/PortableFlags.cmake builds every non-native x86-64 binary with -march=x86-64-v3: AVX, AVX2, BMI1, BMI2,
+# F16C, FMA, LZCNT, MOVBE — the RHEL 10 floor, roughly Intel Haswell (2013) / AMD Excavator (2015) onward. On an
+# older CPU that binary dies with SIGILL the first time it runs, and this installer used to report that as
+# "refusing version mismatch" with an empty version. So the flags are read BEFORE the download, and a CPU below
+# the floor stops here naming what it lacks. Four rules keep the check from refusing a machine the binary runs on:
+#   * no guessing: unreadable flags (no /proc/cpuinfo, a sysctl key missing) give no verdict, and the
+#     verification run after the download names a SIGILL for what it is;
+#   * a Rosetta-translated shell is not judged: its feature bits describe the translator, not the machine;
+#   * releases up to 0.5.x were built without the floor, so pinning one with RIPWIRE_VERSION is not judged;
+#   * RIPWIRE_SKIP_CPU_CHECK=1 overrides a verdict the user knows is wrong (a VM hiding a flag its host has).
+# test/releaseinstallcheck.sh arms (G1)-(G12) pin all of it.
+sourceBuildHint()
+{
+    echo "  Build from source instead, tuned for this CPU (https://github.com/${repo}/blob/main/INSTALL.md#build-from-source):" >&2
+    echo "    git clone https://github.com/${repo}.git && cd ${repo##*/} && ./install.sh" >&2
+    echo "  ./install.sh configures -DRIPWIRE_NATIVE=ON (-march=native); a plain cmake build keeps the x86-64-v3 floor." >&2
+}
+cpuFloor=0
+case "$resolvedVersion" in
+    0.[0-5].*) ;;
+    *) if [ "$assetArch" = x64 ]; then cpuFloor=1; fi ;;
+esac
+cpuTranslated=0
+if [ "$cpuFloor" = 1 ] && [ "$osName" = Darwin ] && [ "$( sysctl -n sysctl.proc_translated 2>/dev/null || true )" = 1 ]; then
+    cpuTranslated=1
+fi
+if [ "$cpuFloor" = 1 ] && [ "$cpuTranslated" = 0 ] && [ "${RIPWIRE_SKIP_CPU_CHECK:-0}" != 1 ]; then
+    cpuFlags=""
+    if [ "$osName" = Linux ]; then
+        # Names as the kernel prints them (arch/x86/include/asm/cpufeatures.h): LZCNT is "abm". "lzcnt" is taken
+        # as well, so a synthetic cpuinfo that spells the instruction's own name is never refused over it.
+        cpuSource="${RIPWIRE_CPUINFO:-/proc/cpuinfo}"
+        cpuNeed="avx:AVX avx2:AVX2 bmi1:BMI1 bmi2:BMI2 f16c:F16C fma:FMA movbe:MOVBE abm:LZCNT"
+        cpuFlags="$( grep -m1 '^flags[[:space:]]*:' "$cpuSource" 2>/dev/null || true )"
+        [ -z "$cpuFlags" ] || cpuFlags=" ${cpuFlags#*:} "
+        case "$cpuFlags" in *" lzcnt "*) cpuFlags="$cpuFlags abm " ;; esac
+    else
+        # Names as XNU prints them (osfmk/i386/cpuid.c): AVX is "AVX1.0", AVX2/BMI1/BMI2 are leaf-7 bits and LZCNT
+        # an extended one. A key that is missing or empty leaves no verdict, never a list of "missing" features.
+        cpuSource="sysctl machdep.cpu"
+        cpuNeed="AVX1.0:AVX AVX2:AVX2 BMI1:BMI1 BMI2:BMI2 F16C:F16C FMA:FMA MOVBE:MOVBE LZCNT:LZCNT"
+        for cpuKey in machdep.cpu.features machdep.cpu.leaf7_features machdep.cpu.extfeatures; do
+            cpuValue="$( sysctl -n "$cpuKey" 2>/dev/null || true )"
+            if [ -z "$cpuValue" ]; then cpuFlags=""; break; fi
+            cpuFlags="$cpuFlags $cpuValue "
+        done
+    fi
+    cpuLacks=""
+    if [ -n "$cpuFlags" ]; then
+        for cpuPair in $cpuNeed; do
+            case "$cpuFlags" in
+                *" ${cpuPair%%:*} "*) ;;
+                *) cpuLacks="$cpuLacks ${cpuPair#*:}" ;;
+            esac
+        done
+    fi
+    if [ -n "$cpuLacks" ]; then
+        echo "install.sh: this CPU is below x86-64-v3, which the prebuilt x86-64 ripwire ${resolvedTag} requires." >&2
+        echo "  missing:${cpuLacks} (read from ${cpuSource})" >&2
+        echo "  x86-64-v3 is AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT and MOVBE: roughly Intel Haswell (2013) or AMD Excavator (2015) and newer." >&2
+        echo "  That binary would die with SIGILL (illegal instruction) here, so nothing was downloaded." >&2
+        sourceBuildHint
+        echo "  If this verdict is wrong for this machine (a VM that hides a flag its host has), RIPWIRE_SKIP_CPU_CHECK=1 skips it;" >&2
+        echo "  the binary is still test-run before it is installed." >&2
+        exit 1
+    fi
+fi
 
 # ── install location + consent ──────────────────────────────────────────────────────────────────────────
 prefix="${RIPWIRE_INSTALL_PREFIX:-$HOME/.local}"
@@ -140,7 +212,34 @@ extractedDir="$work/$expectedDirName"
 [ -d "$extractedDir" ] || { echo "install.sh: unexpected archive layout — no $expectedDirName directory found" >&2; exit 1; }
 [ -x "$extractedDir/ripwire" ] || { echo "install.sh: extracted archive has no executable ripwire binary" >&2; exit 1; }
 
-binaryVersion="$( "$extractedDir/ripwire" --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 )"
+# RUN IT BEFORE INSTALLING IT, AND READ HOW IT EXITED. This was `ripwire --version 2>&1 | grep | head -1`, and a
+# pipeline's status is its last command's: a binary that could not run at all — SIGILL below the x86-64 floor,
+# a loader refusing an older glibc — left an empty version and the report "refusing version mismatch". A
+# mismatch now means one thing only: a binary that RAN and named another version (releaseinstallcheck (G1)-(G4)).
+verifyRc=0
+verifyOut="$( "$extractedDir/ripwire" --version 2>&1 )" || verifyRc=$?
+if [ "$verifyRc" -ne 0 ]; then
+    if [ "$verifyRc" -eq 132 ]; then
+        verifyHow="was killed by SIGILL (illegal instruction)"
+    elif [ "$verifyRc" -gt 128 ]; then
+        verifyHow="was killed by signal $(( verifyRc - 128 ))"
+    else
+        verifyHow="exited $verifyRc"
+    fi
+    echo "install.sh: the ripwire binary in release $resolvedTag $verifyHow when run as \`ripwire --version\`; nothing was installed." >&2
+    [ -z "$verifyOut" ] || printf '%s\n' "$verifyOut" | head -5 | sed 's/^/  | /' >&2
+    if [ "$verifyRc" -eq 132 ] && [ "$cpuFloor" = 1 ]; then
+        if [ "$cpuTranslated" = 1 ]; then
+            echo "  This shell runs under Rosetta, and the x86-64 binary requires x86-64-v3 instructions (AVX2, BMI2, FMA, ...)." >&2
+            echo "  Run the installer from a native arm64 shell to install the arm64 binary instead." >&2
+        else
+            echo "  This binary requires an x86-64-v3 CPU (AVX2, BMI2, FMA, ...); this CPU may be older." >&2
+            sourceBuildHint
+        fi
+    fi
+    exit 1
+fi
+binaryVersion="$( printf '%s\n' "$verifyOut" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 )"
 [ "$binaryVersion" = "$resolvedVersion" ] || {
     echo "install.sh: release $resolvedTag contains ripwire ${binaryVersion:-<unknown>} — refusing version mismatch" >&2
     exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,13 +82,15 @@ assetUrl="$( printf '%s' "$releaseJson" | grep -o "\"browser_download_url\": *\"
 # F16C, FMA, LZCNT, MOVBE — the RHEL 10 floor, roughly Intel Haswell (2013) / AMD Excavator (2015) onward. On an
 # older CPU that binary dies with SIGILL the first time it runs, and this installer used to report that as
 # "refusing version mismatch" with an empty version. So the flags are read BEFORE the download, and a CPU below
-# the floor stops here naming what it lacks. Four rules keep the check from refusing a machine the binary runs on:
+# the floor stops here naming what it lacks. On Linux that means EVERY processor's flags, not the first record's:
+# the scheduler can run the binary on any online processor, so a feature counts only if all of them carry it.
+# Four rules keep the check from refusing a machine the binary runs on:
 #   * no guessing: unreadable flags (no /proc/cpuinfo, a sysctl key missing) give no verdict, and the
 #     verification run after the download names a SIGILL for what it is;
 #   * a Rosetta-translated shell is not judged: its feature bits describe the translator, not the machine;
 #   * releases up to 0.5.x were built without the floor, so pinning one with RIPWIRE_VERSION is not judged;
 #   * RIPWIRE_SKIP_CPU_CHECK=1 overrides a verdict the user knows is wrong (a VM hiding a flag its host has).
-# test/releaseinstallcheck.sh arms (G1)-(G12) pin all of it.
+# test/releaseinstallcheck.sh arms (G1)-(G15) pin all of it.
 sourceBuildHint()
 {
     echo "  Build from source instead, tuned for this CPU (https://github.com/${repo}/blob/main/INSTALL.md#build-from-source):" >&2
@@ -105,18 +107,20 @@ if [ "$cpuFloor" = 1 ] && [ "$osName" = Darwin ] && [ "$( sysctl -n sysctl.proc_
     cpuTranslated=1
 fi
 if [ "$cpuFloor" = 1 ] && [ "$cpuTranslated" = 0 ] && [ "${RIPWIRE_SKIP_CPU_CHECK:-0}" != 1 ]; then
+    # cpuFlags holds ONE RECORD PER LINE, each padded with spaces so " name " only ever matches a whole flag.
     cpuFlags=""
     if [ "$osName" = Linux ]; then
         # Names as the kernel prints them (arch/x86/include/asm/cpufeatures.h): LZCNT is "abm". "lzcnt" is taken
-        # as well, so a synthetic cpuinfo that spells the instruction's own name is never refused over it.
+        # as well, so a synthetic cpuinfo that spells the instruction's own name is never refused over it. The kernel
+        # prints a "flags" line per online processor and each stays its own record ("vmx flags" is not one); the
+        # alias is added inside each record, so two records that spell LZCNT differently still agree.
         cpuSource="${RIPWIRE_CPUINFO:-/proc/cpuinfo}"
         cpuNeed="avx:AVX avx2:AVX2 bmi1:BMI1 bmi2:BMI2 f16c:F16C fma:FMA movbe:MOVBE abm:LZCNT"
-        cpuFlags="$( grep -m1 '^flags[[:space:]]*:' "$cpuSource" 2>/dev/null || true )"
-        [ -z "$cpuFlags" ] || cpuFlags=" ${cpuFlags#*:} "
-        case "$cpuFlags" in *" lzcnt "*) cpuFlags="$cpuFlags abm " ;; esac
+        cpuFlags="$( grep '^flags[[:space:]]*:' "$cpuSource" 2>/dev/null | sed 's/^[^:]*:/ /; s/$/ /; s/ lzcnt / lzcnt abm /' || true )"
     else
         # Names as XNU prints them (osfmk/i386/cpuid.c): AVX is "AVX1.0", AVX2/BMI1/BMI2 are leaf-7 bits and LZCNT
         # an extended one. A key that is missing or empty leaves no verdict, never a list of "missing" features.
+        # The three keys describe one CPU model, so they join into a single record.
         cpuSource="sysctl machdep.cpu"
         cpuNeed="AVX1.0:AVX AVX2:AVX2 BMI1:BMI1 BMI2:BMI2 F16C:F16C FMA:FMA MOVBE:MOVBE LZCNT:LZCNT"
         for cpuKey in machdep.cpu.features machdep.cpu.leaf7_features machdep.cpu.extfeatures; do
@@ -125,18 +129,19 @@ if [ "$cpuFloor" = 1 ] && [ "$cpuTranslated" = 0 ] && [ "${RIPWIRE_SKIP_CPU_CHEC
             cpuFlags="$cpuFlags $cpuValue "
         done
     fi
+    # A feature is missing when ANY record lacks it: grep -v counts the records without the name. -c reads to the
+    # end (-q would exit at the first hit and SIGPIPE the printf on a many-core cpuinfo); a grep that fails prints
+    # no count, and no count names nothing missing.
     cpuLacks=""
     if [ -n "$cpuFlags" ]; then
         for cpuPair in $cpuNeed; do
-            case "$cpuFlags" in
-                *" ${cpuPair%%:*} "*) ;;
-                *) cpuLacks="$cpuLacks ${cpuPair#*:}" ;;
-            esac
+            cpuWithout="$( printf '%s\n' "$cpuFlags" | grep -vcF " ${cpuPair%%:*} " )" || true
+            [ "${cpuWithout:-0}" = 0 ] || cpuLacks="$cpuLacks ${cpuPair#*:}"
         done
     fi
     if [ -n "$cpuLacks" ]; then
         echo "install.sh: this CPU is below x86-64-v3, which the prebuilt x86-64 ripwire ${resolvedTag} requires." >&2
-        echo "  missing:${cpuLacks} (read from ${cpuSource})" >&2
+        echo "  missing on at least one CPU:${cpuLacks} (read from ${cpuSource})" >&2
         echo "  x86-64-v3 is AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT and MOVBE: roughly Intel Haswell (2013) or AMD Excavator (2015) and newer." >&2
         echo "  That binary would die with SIGILL (illegal instruction) here, so nothing was downloaded." >&2
         sourceBuildHint

--- a/test/releaseinstallcheck.sh
+++ b/test/releaseinstallcheck.sh
@@ -292,10 +292,13 @@ fi
 #   * AFTER the download, a verification run that dies or exits non-zero is a binary that COULD NOT RUN
 #     (G1)-(G3); only a binary that ran and printed another version is a mismatch (G4);
 #   * BEFORE the download, on x86_64, the CPU's flags are read and a CPU below v3 stops the install naming
-#     what it lacks: Linux /proc/cpuinfo (G5), Intel-Mac sysctl (G9).
+#     what it lacks: Linux /proc/cpuinfo (G5), Intel-Mac sysctl (G9). On Linux that is EVERY processor's
+#     flags record, since the binary can be scheduled on any of them: one below v3 stops it wherever it
+#     sits in the file (G13, G14).
 # The rest are controls, because a floor check that blocks a machine the binary runs on is worse than none:
-# a v3 CPU installs (G6, G10); unreadable flags never block (G1, G12); RIPWIRE_SKIP_CPU_CHECK=1 wins (G7); a
-# pre-floor release installs on an old CPU (G8); Rosetta's translated bits are not judged (G11).
+# a v3 CPU installs (G6, G10), and so do processors whose records differ but each carry v3 (G15); unreadable
+# flags never block (G1, G12); RIPWIRE_SKIP_CPU_CHECK=1 wins (G7); a pre-floor release installs on an old CPU
+# (G8); Rosetta's translated bits are not judged (G11).
 # Fixture flags use the names the platforms print: the kernel's arch/x86/include/asm/cpufeatures.h (LZCNT
 # is "abm") and XNU's osfmk/i386/cpuid.c (AVX is "AVX1.0"; LZCNT sits in machdep.cpu.extfeatures).
 GDIR="$TMP/cpufloor"
@@ -451,6 +454,61 @@ g_install g12 Darwin x86_64 FAKE_SYSCTL_DIR="$GDIR/sysctl-partial"
 [ "$G_RC" -eq 0 ] && [ -x "$GDIR/g12.prefix/bin/ripwire" ] \
     && ok "(G12) a Mac whose sysctl lacks the leaf7/extfeatures keys is not refused" \
     || no "(G12) missing sysctl keys were judged as missing features: $( g_said g12 ) (rc=$G_RC)"
+
+# (G13)-(G15) EVERY PROCESSOR, NOT THE FIRST. /proc/cpuinfo carries one "flags" record per online processor, and
+# the binary can be scheduled on any of them: a feature one processor lacks is a SIGILL the first time the
+# scheduler lands there. The records below are the Haswell one and edits of it; each keeps its "vmx flags"
+# line, which a check that matched "flags" anywhere on a line would take for a processor lacking everything.
+g_cpuinfo2()
+{
+    # g_cpuinfo2 FILE FLAGS0 FLAGS1 -> a two-processor cpuinfo (the format is applied once per processor)
+    printf 'processor\t: %s\nvendor_id\t: GenuineIntel\nflags\t\t: %s\nvmx flags\t: vnmi preemption_timer\nbugs\t\t: cpu_meltdown\n\n' \
+        0 "$2" 1 "$3" >"$1"
+}
+g_names_exactly()
+{
+    # g_names_exactly NAME FEATURE... -> 0 when the refusal's "missing" line names exactly those v3 features
+    _line=" $( grep -i 'missing' "$GDIR/$1.err" | head -1 ) "; shift
+    for _f in AVX AVX2 BMI1 BMI2 F16C FMA MOVBE LZCNT; do
+        case " $* " in *" $_f "*) _want=1 ;; *) _want=0 ;; esac
+        case "$_line" in *" $_f "*) _has=1 ;; *) _has=0 ;; esac
+        [ "$_want" = "$_has" ] || return 1
+    done
+}
+gV3Flags="$( sed -n 's/^flags[[:space:]]*: //p' "$GDIR/cpuinfo-haswell" )"
+gV3Other="${gV3Flags/ abm / lzcnt }"; gV3Other="${gV3Other/ vmx / } hypervisor"
+[ "${gV3Flags/ avx2 / }" != "$gV3Flags" ] && [ "${gV3Flags/ fma / }" != "$gV3Flags" ] \
+    || no "(G13)-(G14) fixture: the Haswell flags record was not read back, so no record lacks avx2 or fma"
+case " $gV3Other " in *" abm "*|*" vmx "*) no "(G15) fixture: the second complete record did not diverge from the first" ;; esac
+g_cpuinfo2 "$GDIR/cpuinfo-second-lacks" "$gV3Flags" "${gV3Flags/ avx2 / }"
+g_cpuinfo2 "$GDIR/cpuinfo-first-lacks" "${gV3Flags/ fma / }" "$gV3Flags"
+g_cpuinfo2 "$GDIR/cpuinfo-both-v3" "$gV3Flags" "$gV3Other"
+g_release 0.6.0 linux x64 'echo "ripwire 0.6.0 (Release, Test)"'
+
+# (G13) THE REVIEWED DEFECT. Processor 0 has all of v3, processor 1 lacks avx2. Reading only the first record
+# approved it; the install must stop before the download naming AVX2, and only AVX2 — the rest are on both.
+g_install g13 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-second-lacks"
+if [ "$G_RC" -ne 0 ] && g_names_exactly g13 AVX2 && ! grep -q 'tar\.gz' "$GDIR/g13.curl" && [ ! -e "$GDIR/g13.prefix/bin/ripwire" ]; then
+    ok "(G13) a second processor without avx2 stops the install before the download, naming exactly AVX2"
+else
+    no "(G13) a second processor without avx2 was not refused before the download: $( g_said g13 ) (rc=$G_RC)"
+fi
+
+# (G14) The same verdict when the lacking processor comes FIRST: the intersection decides, not the file order,
+# so a check that reads only the last record (or any one record that has the feature) fails here.
+g_install g14 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-first-lacks"
+if [ "$G_RC" -ne 0 ] && g_names_exactly g14 FMA && ! grep -q 'tar\.gz' "$GDIR/g14.curl" && [ ! -e "$GDIR/g14.prefix/bin/ripwire" ]; then
+    ok "(G14) a first processor without fma stops the install before the download, naming exactly FMA"
+else
+    no "(G14) a first processor without fma was not refused before the download: $( g_said g14 ) (rc=$G_RC)"
+fi
+
+# (G15) CONTROL: two records that DIFFER but each carry all of v3 install. The second spells LZCNT "lzcnt" where
+# the first says "abm", so a check that intersects the raw names before accepting either spelling refuses it.
+g_install g15 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-both-v3"
+[ "$G_RC" -eq 0 ] && [ -x "$GDIR/g15.prefix/bin/ripwire" ] \
+    && ok "(G15) two different processor records that each carry v3 (LZCNT as abm on one, lzcnt on the other) install" \
+    || no "(G15) processors that each carry v3 were refused: $( g_said g15 ) (rc=$G_RC)"
 
 if [ "${1:-}" != "--isolation-child" ]; then
     python3 "$ROOT/test/installer_isolation.py" "${RIPWIRE_BIN:-$ROOT/build/ripwire}" \

--- a/test/releaseinstallcheck.sh
+++ b/test/releaseinstallcheck.sh
@@ -12,7 +12,7 @@ no(){ printf '  FAIL  %s\n' "$*"; fail=1; }
 
 TMP="$( mktemp -d )"; trap 'rm -rf "$TMP"' EXIT
 # Detection and activation must use only the per-invocation homes below.
-unset CODEX_HOME AGENTS_HOME HERMES_HOME RIPWIRE_NO_ACTIVATE
+unset CODEX_HOME AGENTS_HOME HERMES_HOME RIPWIRE_NO_ACTIVATE RIPWIRE_SKIP_CPU_CHECK RIPWIRE_CPUINFO
 FAKE="$TMP/fake"; mkdir -p "$FAKE" "$TMP/assets/ripwire-0.3.6-macos-arm64/skills/ripwire-router" "$TMP/assets/ripwire-0.3.6-macos-arm64/hooks"
 
 printf '#!/bin/sh\necho "ripwire 0.3.6 (Release, Test)"\n' >"$TMP/assets/ripwire-0.3.6-macos-arm64/ripwire"
@@ -41,6 +41,7 @@ while [ "$#" -gt 0 ]; do
         *) url="$1"; shift ;;
     esac
 done
+[ -z "${CURL_LOG:-}" ] || printf '%s\n' "$url" >>"$CURL_LOG"
 case "$url" in
     *api.github.com*) src="$RELEASE_FIXTURE" ;;
     *.sha256) src="$ASSET_FIXTURE.sha256" ;;
@@ -50,9 +51,18 @@ if [ -n "$out" ]; then cp "$src" "$out"; else cat "$src"; fi
 EOF
 cat >"$FAKE/uname" <<'EOF'
 #!/bin/sh
-case "$1" in -s) echo Darwin;; -m) echo arm64;; *) /usr/bin/uname "$@";; esac
+case "$1" in -s) echo "${FAKE_UNAME_S:-Darwin}";; -m) echo "${FAKE_UNAME_M:-arm64}";; *) /usr/bin/uname "$@";; esac
 EOF
-chmod +x "$FAKE/curl" "$FAKE/uname"
+# `sysctl -n KEY` answers from $FAKE_SYSCTL_DIR/KEY. An absent file is an unknown oid, rc 1 — what macOS
+# itself does for a key its kernel lacks. Only the (G) arms set FAKE_SYSCTL_DIR.
+cat >"$FAKE/sysctl" <<'EOF'
+#!/bin/sh
+[ "$1" = -n ] && shift
+if [ -n "${FAKE_SYSCTL_DIR:-}" ] && [ -f "$FAKE_SYSCTL_DIR/$1" ]; then cat "$FAKE_SYSCTL_DIR/$1"; exit 0; fi
+echo "sysctl: unknown oid '$1'" >&2
+exit 1
+EOF
+chmod +x "$FAKE/curl" "$FAKE/uname" "$FAKE/sysctl"
 
 # ── HOME ISOLATION (2026-09-06). The installer now ACTIVATES skills for the agents it detects, so a
 # run with the operator's real $HOME would symlink into their live ~/.claude/skills. Every invocation
@@ -272,6 +282,175 @@ if grep -qE 'cp[^|;]*"\$binDir/ripwire"' "$INSTALL"; then
 else
     ok "(F3) nothing cp's onto the destination path; the temp file is the only thing copied"
 fi
+
+# ── (G) A CPU BELOW THE x86-64 FLOOR IS NAMED, NEVER REPORTED AS A VERSION MISMATCH ────────────────────
+# From 0.6.0 every non-native x86-64 build carries -march=x86-64-v3 (cmake/PortableFlags.cmake): AVX, AVX2,
+# BMI1, BMI2, F16C, FMA, LZCNT, MOVBE. On an older CPU the prebuilt binary dies with SIGILL the first time it
+# runs, and its first run is this installer's version check. That check was `--version 2>&1 | grep | head
+# -1`: the pipeline took head's exit status, read an empty version, and told the user "refusing version
+# mismatch" — true that something was wrong, false about what. Two layers are pinned here:
+#   * AFTER the download, a verification run that dies or exits non-zero is a binary that COULD NOT RUN
+#     (G1)-(G3); only a binary that ran and printed another version is a mismatch (G4);
+#   * BEFORE the download, on x86_64, the CPU's flags are read and a CPU below v3 stops the install naming
+#     what it lacks: Linux /proc/cpuinfo (G5), Intel-Mac sysctl (G9).
+# The rest are controls, because a floor check that blocks a machine the binary runs on is worse than none:
+# a v3 CPU installs (G6, G10); unreadable flags never block (G1, G12); RIPWIRE_SKIP_CPU_CHECK=1 wins (G7); a
+# pre-floor release installs on an old CPU (G8); Rosetta's translated bits are not judged (G11).
+# Fixture flags use the names the platforms print: the kernel's arch/x86/include/asm/cpufeatures.h (LZCNT
+# is "abm") and XNU's osfmk/i386/cpuid.c (AVX is "AVX1.0"; LZCNT sits in machdep.cpu.extfeatures).
+GDIR="$TMP/cpufloor"
+mkdir -p "$GDIR/sysctl-ivy" "$GDIR/sysctl-haswell" "$GDIR/sysctl-rosetta" "$GDIR/sysctl-partial"
+# Ivy Bridge (2012) has avx and f16c but none of avx2 bmi1 bmi2 fma movbe abm; Haswell (2013) has all eight.
+printf 'processor\t: 0\nvendor_id\t: GenuineIntel\nmodel name\t: Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz\nflags\t\t: %s\nbugs\t\t: cpu_meltdown\n\n' \
+    'fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm fsgsbase smep erms xsaveopt' \
+    >"$GDIR/cpuinfo-ivy"
+printf 'processor\t: 0\nvendor_id\t: GenuineIntel\nmodel name\t: Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz\nflags\t\t: %s\nvmx flags\t: vnmi preemption_timer\nbugs\t\t: cpu_meltdown\n\n' \
+    'fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt' \
+    >"$GDIR/cpuinfo-haswell"
+printf '%s\n' 'FPU VME DE PSE TSC MSR PAE MCE CX8 APIC SEP MTRR PGE MCA CMOV PAT PSE36 CLFSH DS ACPI MMX FXSR SSE SSE2 SS HTT TM PBE SSE3 PCLMULQDQ DTES64 MON DSCPL VMX EST TM2 SSSE3 CX16 TPR PDCM SSE4.1 SSE4.2 x2APIC POPCNT AES PCID XSAVE OSXSAVE TSCTMR AVX1.0 RDRAND F16C' \
+    >"$GDIR/sysctl-ivy/machdep.cpu.features"
+printf '%s\n' 'RDWRFSGS SMEP ERMS' >"$GDIR/sysctl-ivy/machdep.cpu.leaf7_features"
+printf '%s\n' 'SYSCALL XD EM64T LAHF RDTSCP TSCI' >"$GDIR/sysctl-ivy/machdep.cpu.extfeatures"
+printf '%s\n' 'FPU VME DE PSE TSC MSR PAE MCE CX8 APIC SEP MTRR PGE MCA CMOV PAT PSE36 CLFSH DS ACPI MMX FXSR SSE SSE2 SS HTT TM PBE SSE3 PCLMULQDQ DTES64 MON DSCPL VMX EST TM2 SSSE3 FMA CX16 TPR PDCM SSE4.1 SSE4.2 x2APIC MOVBE POPCNT AES PCID XSAVE OSXSAVE SEGLIM64 TSCTMR AVX1.0 RDRAND F16C' \
+    >"$GDIR/sysctl-haswell/machdep.cpu.features"
+printf '%s\n' 'RDWRFSGS TSC_THREAD_OFFSET BMI1 HLE AVX2 SMEP BMI2 ERMS INVPCID RTM FPU_CSDS' >"$GDIR/sysctl-haswell/machdep.cpu.leaf7_features"
+printf '%s\n' 'SYSCALL XD 1GBPAGE EM64T LAHF LZCNT RDTSCP TSCI' >"$GDIR/sysctl-haswell/machdep.cpu.extfeatures"
+# Rosetta: a translated shell reads the translator's bits, here pre-v3. Partial: a v3 Mac whose kernel lacks
+# two of the three keys — a check that reads what it can and judges the rest as missing would refuse it.
+cp "$GDIR/sysctl-ivy/"* "$GDIR/sysctl-rosetta/"; printf '1\n' >"$GDIR/sysctl-rosetta/sysctl.proc_translated"
+cp "$GDIR/sysctl-haswell/machdep.cpu.features" "$GDIR/sysctl-partial/"
+
+g_release()
+{
+    # g_release VERSION OS ARCH BINARY-BODY -> a checksummed ripwire-VERSION-OS-ARCH archive + release JSON
+    _n="ripwire-$1-$2-$3"
+    rm -rf "${GDIR:?}/$_n"; mkdir -p "$GDIR/$_n"
+    printf '#!/bin/sh\n%s\n' "$4" >"$GDIR/$_n/ripwire"; chmod +x "$GDIR/$_n/ripwire"
+    tar -C "$GDIR" -czf "$GDIR/$_n.tar.gz" "$_n"
+    ( cd "$GDIR" && shasum -a 256 "$_n.tar.gz" >"$_n.tar.gz.sha256" )
+    printf '%s\n' "{\"tag_name\":\"v$1\",\"assets\":[" "{\"browser_download_url\":\"https://example.invalid/$_n.tar.gz\"}" ']}' >"$GDIR/release.json"
+    G_ASSET="$GDIR/$_n.tar.gz"; G_TAG="v$1"
+}
+g_install()
+{
+    # g_install NAME UNAME_S UNAME_M [env...] -> $GDIR/NAME.{out,err,curl,prefix}, rc in $G_RC. The CPU seams
+    # default to EMPTY so no arm reads the host's real CPU by accident; each arm names the one it tests.
+    _n="$1"; _s="$2"; _m="$3"; shift 3
+    rm -rf "${GDIR:?}/$_n.prefix"; : >"$GDIR/$_n.curl"
+    env RIPWIRE_CPUINFO= RIPWIRE_SKIP_CPU_CHECK= FAKE_SYSCTL_DIR= "$@" HOME="$SBHOME" PATH="$FAKE:$PATH" \
+        FAKE_UNAME_S="$_s" FAKE_UNAME_M="$_m" CURL_LOG="$GDIR/$_n.curl" RELEASE_FIXTURE="$GDIR/release.json" ASSET_FIXTURE="$G_ASSET" \
+        RIPWIRE_REPO=redhat-et/ripwire RIPWIRE_VERSION="$G_TAG" RIPWIRE_INSTALL_PREFIX="$GDIR/$_n.prefix" RIPWIRE_INSTALL_YES=1 \
+        RIPWIRE_NO_ACTIVATE=1 bash "$INSTALL" >"$GDIR/$_n.out" 2>"$GDIR/$_n.err"; G_RC=$?
+}
+g_said(){ tr '\n' ' ' <"$GDIR/$1.err" | cut -c1-260; }
+
+# (G1) THE REPORTED DEFECT. The binary dies with 132 at its verification run, and the CPU flags could not be
+# read, so nothing stopped the download: the verification run is the only layer left, and it must say CPU.
+g_release 0.6.0 linux x64 'exit 132'
+g_install g1 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/no-such-cpuinfo"
+if [ "$G_RC" -ne 0 ] && grep -q 'x86-64-v3' "$GDIR/g1.err" && ! grep -q 'version mismatch' "$GDIR/g1.err"; then
+    ok "(G1) a verification run that dies with 132 (SIGILL) names the x86-64-v3 requirement, not a version mismatch"
+else
+    no "(G1) a SIGILL at the verification run was reported as: $( g_said g1 ) (rc=$G_RC)"
+fi
+if grep -qF -e '-DRIPWIRE_NATIVE=ON' "$GDIR/g1.err" && grep -q 'tar\.gz' "$GDIR/g1.curl" && [ ! -e "$GDIR/g1.prefix/bin/ripwire" ]; then
+    ok "(G1) unreadable CPU flags did not block the download; the refusal names the native source build and installs nothing"
+else
+    no "(G1) unreadable flags blocked the download, the -DRIPWIRE_NATIVE=ON source build went unnamed, or a binary was installed"
+fi
+
+# (G2) SIGILL on arm64 is still a binary that could not run — but there is no x86-64 floor to blame.
+g_release 0.6.0 linux arm64 'exit 132'
+g_install g2 Linux aarch64
+if [ "$G_RC" -ne 0 ] && grep -q 'SIGILL' "$GDIR/g2.err" && ! grep -q 'x86-64-v3\|version mismatch' "$GDIR/g2.err"; then
+    ok "(G2) an arm64 SIGILL is named as SIGILL, with no x86-64-v3 claim and no version-mismatch claim"
+else
+    no "(G2) an arm64 SIGILL was reported as: $( g_said g2 ) (rc=$G_RC)"
+fi
+
+# (G3) A binary that exits non-zero on its own (a loader refusing an older glibc) could not run either; its
+# own words are the diagnosis, and a CPU claim would be as wrong as the version claim was.
+g_release 0.6.0 linux x64 'echo "ripwire: /lib64/libc.so.6: version GLIBC_2.38 not found (required by ripwire)" >&2; exit 1'
+g_install g3 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-haswell"
+if [ "$G_RC" -ne 0 ] && grep -q 'GLIBC_2.38 not found' "$GDIR/g3.err" && ! grep -q 'x86-64-v3\|version mismatch' "$GDIR/g3.err"; then
+    ok "(G3) a binary that exits 1 is reported with its own output, not as a version mismatch or a CPU floor"
+else
+    no "(G3) a binary that exits 1 was reported as: $( g_said g3 ) (rc=$G_RC)"
+fi
+
+# (G4) CONTROL: a binary that RAN and printed another version is still, and only, a version mismatch.
+g_release 0.6.0 linux x64 'echo "ripwire 0.5.9 (Release, Test)"'
+g_install g4 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-haswell"
+if [ "$G_RC" -ne 0 ] && grep -q 'version mismatch' "$GDIR/g4.err" && ! grep -q 'x86-64-v3\|SIGILL' "$GDIR/g4.err"; then
+    ok "(G4) a genuine tag/binary version mismatch is still reported as a version mismatch"
+else
+    no "(G4) a genuine version mismatch was reported as: $( g_said g4 ) (rc=$G_RC)"
+fi
+
+# (G5) Linux below v3 stops BEFORE the download and names exactly what the CPU lacks — avx and f16c are
+# present on Ivy Bridge, so naming them would be a detector reading the wrong line or the wrong names.
+g_release 0.6.0 linux x64 'echo "ripwire 0.6.0 (Release, Test)"'
+g_install g5 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-ivy"
+G5LINE=" $( grep -i 'missing' "$GDIR/g5.err" | head -1 ) "
+g5named=1
+for feature in AVX2 BMI1 BMI2 FMA MOVBE LZCNT; do
+    case "$G5LINE" in *" $feature "*) ;; *) g5named=0 ;; esac
+done
+case "$G5LINE" in *" AVX "*|*" F16C "*) g5named=0 ;; esac
+if [ "$G_RC" -ne 0 ] && [ "$g5named" -eq 1 ] && grep -q 'x86-64-v3' "$GDIR/g5.err"; then
+    ok "(G5) a below-v3 /proc/cpuinfo stops the install naming exactly AVX2 BMI1 BMI2 FMA MOVBE LZCNT"
+else
+    no "(G5) a below-v3 cpuinfo was reported as: $( g_said g5 ) (rc=$G_RC)"
+fi
+if ! grep -q 'tar\.gz' "$GDIR/g5.curl" && [ ! -e "$GDIR/g5.prefix/bin/ripwire" ] && grep -qF -e '-DRIPWIRE_NATIVE=ON' "$GDIR/g5.err"; then
+    ok "(G5) the refusal comes before the archive is downloaded, installs nothing, and names the native source build"
+else
+    no "(G5) a below-v3 CPU still downloaded the archive, installed it, or went without the source-build route"
+fi
+
+# (G6) CONTROL: a v3 cpuinfo, LZCNT spelled "abm" as the kernel prints it, installs.
+g_install g6 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-haswell"
+[ "$G_RC" -eq 0 ] && [ -x "$GDIR/g6.prefix/bin/ripwire" ] \
+    && ok "(G6) a v3 /proc/cpuinfo installs" || no "(G6) a v3 CPU was refused: $( g_said g6 ) (rc=$G_RC)"
+
+# (G7) CONTROL: the user's override wins over a verdict they know is wrong (a VM hiding a flag its host has).
+g_install g7 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-ivy" RIPWIRE_SKIP_CPU_CHECK=1
+[ "$G_RC" -eq 0 ] && [ -x "$GDIR/g7.prefix/bin/ripwire" ] \
+    && ok "(G7) RIPWIRE_SKIP_CPU_CHECK=1 skips the CPU check" || no "(G7) RIPWIRE_SKIP_CPU_CHECK=1 was ignored: $( g_said g7 ) (rc=$G_RC)"
+
+# (G8) CONTROL: 0.5.x and earlier were built without the floor, so pinning one on an old CPU still installs.
+g_release 0.5.0 linux x64 'echo "ripwire 0.5.0 (Release, Test)"'
+g_install g8 Linux x86_64 RIPWIRE_CPUINFO="$GDIR/cpuinfo-ivy"
+[ "$G_RC" -eq 0 ] && [ -x "$GDIR/g8.prefix/bin/ripwire" ] \
+    && ok "(G8) a pre-floor release (v0.5.0) installs on a below-v3 CPU" || no "(G8) a pre-floor release was refused: $( g_said g8 ) (rc=$G_RC)"
+
+# (G9) An Intel Mac below v3 stops before the download, read from sysctl.
+g_release 0.6.0 macos x64 'echo "ripwire 0.6.0 (Release, Test)"'
+g_install g9 Darwin x86_64 FAKE_SYSCTL_DIR="$GDIR/sysctl-ivy"
+if [ "$G_RC" -ne 0 ] && grep -q 'x86-64-v3' "$GDIR/g9.err" && grep -i 'missing' "$GDIR/g9.err" | grep -q 'AVX2.*LZCNT' \
+   && ! grep -q 'tar\.gz' "$GDIR/g9.curl"; then
+    ok "(G9) an Intel Mac below v3 (sysctl) stops before the download, naming AVX2 through LZCNT"
+else
+    no "(G9) an Intel Mac below v3 was reported as: $( g_said g9 ) (rc=$G_RC)"
+fi
+
+# (G10) CONTROL: an Intel Mac with v3 installs — the arm that fails if AVX is looked up by the wrong name.
+g_install g10 Darwin x86_64 FAKE_SYSCTL_DIR="$GDIR/sysctl-haswell"
+[ "$G_RC" -eq 0 ] && [ -x "$GDIR/g10.prefix/bin/ripwire" ] \
+    && ok "(G10) an Intel Mac with v3 (AVX1.0, leaf7 AVX2/BMI1/BMI2, extfeatures LZCNT) installs" \
+    || no "(G10) a v3 Intel Mac was refused: $( g_said g10 ) (rc=$G_RC)"
+
+# (G11) CONTROL: under Rosetta the feature bits describe the translator; the pre-check does not judge them.
+g_install g11 Darwin x86_64 FAKE_SYSCTL_DIR="$GDIR/sysctl-rosetta"
+[ "$G_RC" -eq 0 ] && [ -x "$GDIR/g11.prefix/bin/ripwire" ] \
+    && ok "(G11) a Rosetta-translated shell is not refused on the translator's feature bits" \
+    || no "(G11) a Rosetta shell was refused on translated bits: $( g_said g11 ) (rc=$G_RC)"
+
+# (G12) CONTROL: a sysctl key that does not exist means no verdict, not "every feature in it is missing".
+g_install g12 Darwin x86_64 FAKE_SYSCTL_DIR="$GDIR/sysctl-partial"
+[ "$G_RC" -eq 0 ] && [ -x "$GDIR/g12.prefix/bin/ripwire" ] \
+    && ok "(G12) a Mac whose sysctl lacks the leaf7/extfeatures keys is not refused" \
+    || no "(G12) missing sysctl keys were judged as missing features: $( g_said g12 ) (rc=$G_RC)"
 
 if [ "${1:-}" != "--isolation-child" ]; then
     python3 "$ROOT/test/installer_isolation.py" "${RIPWIRE_BIN:-$ROOT/build/ripwire}" \


### PR DESCRIPTION
## The problem
PR #127 made `-march=x86-64-v3` the floor for prebuilt x86-64 binaries (AVX2, BMI1/BMI2, FMA, LZCNT, MOVBE). On an older CPU, `scripts/install.sh` downloads the binary, runs `--version` to verify it, and the binary dies with SIGILL. The version check sits in a pipeline, so the pipeline's exit status comes from `head` and `set -e` never fires. The user sees:

```
release vX contains ripwire <unknown> — refusing version mismatch
```

That is wrong, and it never names the actual requirement.

## The fix (`scripts/install.sh`)
**(a) Before downloading, on x86_64** (0.6.0 and later only; v0.5.x had no floor):
- Linux reads the `flags` line of `/proc/cpuinfo`: `avx avx2 bmi1 bmi2 f16c fma movbe abm`. The kernel names LZCNT `abm`; `lzcnt` is also accepted.
- Intel Macs read `machdep.cpu.features`, `leaf7_features` and `extfeatures`.
- Below v3, it stops before the download, lists the missing features, and points to a source build with `./install.sh`, which builds for the local CPU (`-DRIPWIRE_NATIVE=ON`).
- It never blocks when the flags can't be read, under Rosetta, for 0.5.x and older, or with `RIPWIRE_SKIP_CPU_CHECK=1`.

**(b) After downloading**, the verification run's exit code is read:
- **132 (SIGILL):** on x86-64 from 0.6.0 the message names the v3 requirement and the source-build route. Under Rosetta it suggests a native arm64 shell.
- **Any other failure** (e.g. a glibc loader error, which main also mislabelled as a mismatch): shown with the binary's own output.
- **"Version mismatch"** is only reported when the binary actually ran and printed a different version.

## Docs (`INSTALL.md`)
- Quick install states the x86-64-v3 requirement: roughly Intel Haswell (2013) or AMD Excavator (2015) and newer, per [Red Hat's x86-64-v3 note](https://developers.redhat.com/articles/2024/01/02/exploring-x86-64-v3-red-hat-enterprise-linux-10). It adds the new `RIPWIRE_SKIP_CPU_CHECK` variable row.
- "Build from source" notes that a plain cmake build on x86-64 is also v3-floored, and older CPUs should add `-DRIPWIRE_NATIVE=ON` or use `./install.sh`.

## Evidence
All arms are in the existing `test/releaseinstallcheck.sh` (section G); no new gate file. The `uname`/`sysctl`/`curl` stubs are extended to simulate hosts.

| Arm | Case | main | this PR |
|---|---|---|---|
| G1 | Linux x64 binary exits 132, flags unreadable → names x86-64-v3 and `-DRIPWIRE_NATIVE=ON`, installs nothing | FAIL | PASS |
| G2 | arm64 binary exits 132 → SIGILL, no v3 claim | FAIL | PASS |
| G3 | binary exits 1 with a loader error → its output shown, no mismatch claim | FAIL | PASS |
| G4 | a real mismatch still says mismatch | PASS (control) | PASS |
| G5 | below-v3 cpuinfo → stops before download, lists exactly the six missing features | FAIL | PASS |
| G6 | v3 cpuinfo installs | PASS (control) | PASS |
| G7 | `RIPWIRE_SKIP_CPU_CHECK=1` installs | PASS (control) | PASS |
| G8 | v0.5.0 on an old CPU installs | PASS (control) | PASS |
| G9 | Intel Mac below v3 → stops before download | FAIL | PASS |
| G10 | Intel Mac with v3 installs | PASS (control) | PASS |
| G11 | a Rosetta shell isn't judged | PASS (control) | PASS |
| G12 | a Mac missing the sysctl keys isn't judged | PASS (control) | PASS |

The controls pass on main because main has no pre-check. Their non-vacuity was shown by breaking the installer eight different ways, each turning its targeted arm red. `releaseinstallcheck` passes 44 checks, and `readmedriftcheck`, `ripwirepubliccheck`, `manifestcheck`, `claudeconfigdircheck` and `hermesinstallcheck` pass. shellcheck and `bash -n` are clean.

## Ordering
Land after **#137** (macOS x86_64 release flags). The Intel Mac check and the INSTALL.md wording assume the macOS x86-64 binary also carries the v3 floor.

## Risks
- **False refusal:** a VM that hides BMI/MOVBE/FMA flags while the host still executes them. `RIPWIRE_SKIP_CPU_CHECK=1` covers it, and the refusal message names that variable.
- **Missed old CPU:** unreadable flags, Rosetta, or a pinned old release skip the pre-check. Step (b) then names the SIGILL after the download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
