### PR TITLE
docs(readme): the head-to-head timings predate 0.6.0's speedups, and the INSTALL.md link comes back

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ your agent starts in the right place at all.
 | Aider repo-map 0.86.2 | 20.0% | 35.0% | *(inside query)* | 2.920 s |
 | codeseek 0.1.31 (better of its two arms) | 15.0% | 20.0% | 3.37 s | 0.040 s |
 
-*Measured 2026-08-08, before the performance work that ships in 0.6.0. ripwire has become faster since — llvm-project's cold parse fell from 194.1 s to 155.6 s of CPU, and `--pack-task` on a Go repository from 8.13 s to 5.88 s — but these timing columns have not been re-measured.*
+*Measured 2026-08-08, before the performance work that ships in 0.6.0. ripwire has become faster since — llvm-project's cold parse (182,555 files) fell from 194.1 s to 155.6 s of CPU, and `--pack-task` on a Go repository from 8.13 s to 5.88 s — but these timing columns have not been re-measured.*
 
 <details>
 <summary>What this table costs us — six paired losses named, a runner-up we had under-credited at <b>26.7%</b> and corrected to <b>40.0%</b>, and the multi-file stratum no arm solves</summary>
@@ -1384,7 +1384,7 @@ profile-guided release build that now ships), one evaluator, all arms re-run on 
 | codeseek 0.1.31 (ident-mention convention arm) | 15.0% | 20.0% | 3.37 s | 0.040 s |
 | codeseek 0.1.31 (raw issue text, keyless fallback) | 0.0%² | 0.0% | 3.37 s | 0.024 s |
 
-*Measured 2026-08-08, before the performance work that ships in 0.6.0. ripwire has become faster since — llvm-project's cold parse fell from 194.1 s to 155.6 s of CPU, and `--pack-task` on a Go repository from 8.13 s to 5.88 s — but these timing columns have not been re-measured.*
+*Measured 2026-08-08, before the performance work that ships in 0.6.0. ripwire has become faster since — llvm-project's cold parse (182,555 files) fell from 194.1 s to 155.6 s of CPU, and `--pack-task` on a Go repository from 8.13 s to 5.88 s — but these timing columns have not been re-measured.*
 
 <details>
 <summary>Round-4 method and the paired losses — one binary, one evaluator, what re-running cost us, and the three limits that travel with this table</summary>

--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ your agent starts in the right place at all.
 | Aider repo-map 0.86.2 | 20.0% | 35.0% | *(inside query)* | 2.920 s |
 | codeseek 0.1.31 (better of its two arms) | 15.0% | 20.0% | 3.37 s | 0.040 s |
 
+*Measured 2026-08-08, before the performance work that ships in 0.6.0. ripwire has become faster since — llvm-project's cold parse fell from 194.1 s to 155.6 s of CPU, and `--pack-task` on a Go repository from 8.13 s to 5.88 s — but these timing columns have not been re-measured.*
+
 <details>
 <summary>What this table costs us — six paired losses named, a runner-up we had under-credited at <b>26.7%</b> and corrected to <b>40.0%</b>, and the multi-file stratum no arm solves</summary>
 
@@ -1381,6 +1383,8 @@ profile-guided release build that now ships), one evaluator, all arms re-run on 
 | Aider repo-map 0.86.2 (no-personalization control) | 10.0% | 25.0% | *(inside query)* | 0.818 s |
 | codeseek 0.1.31 (ident-mention convention arm) | 15.0% | 20.0% | 3.37 s | 0.040 s |
 | codeseek 0.1.31 (raw issue text, keyless fallback) | 0.0%² | 0.0% | 3.37 s | 0.024 s |
+
+*Measured 2026-08-08, before the performance work that ships in 0.6.0. ripwire has become faster since — llvm-project's cold parse fell from 194.1 s to 155.6 s of CPU, and `--pack-task` on a Go repository from 8.13 s to 5.88 s — but these timing columns have not been re-measured.*
 
 <details>
 <summary>Round-4 method and the paired losses — one binary, one evaluator, what re-running cost us, and the three limits that travel with this table</summary>

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ cd your-repo
 ripwire . --for="<the change you are about to make, in words>"
 ```
 
+Every install route (prebuilt, from source, per-agent skills, hooks, the MCP server) is in [INSTALL.md](INSTALL.md).
+
 **Reach for the CLI first — it is the cheaper interface.** The MCP server is the optional second
 way in, and its convenience has a cost the shell pipe does not carry: its verb schemas sit in your
 agent's context every session, whether or not it calls them.


### PR DESCRIPTION
Two small README fixes that should land before 0.6.0 is tagged.

## 1. The head-to-head timings predate the 0.6.0 performance work, and now say so (5aea165a, 625a5c42)

The Round 4 tables were measured on 2026-08-08. Since then the performance round has made ripwire faster, so their timing columns understate it today. There is now an italic note beside both tables:

> *Measured 2026-08-08, before the performance work that ships in 0.6.0. ripwire has become faster since — llvm-project's cold parse (182,555 files) fell from 194.1 s to 155.6 s of CPU, and `--pack-task` on a Go repository from 8.13 s to 5.88 s — but these timing columns have not been re-measured.*

The note does not change any number in the tables, which still show what was measured on that date. The two "since" figures come from PR #127's measurements (llvm-project cold map `--no-cache`, 194.14 → 155.60 CPU s; go `--pack-task`, 8.13 → 5.88 s). The file count is from the same PR: "llvm-project (182,555 files) as the scale rung".

## 2. The README links INSTALL.md again (a34ae457)

Before #127, the quick-install block was followed by:

> Every install route (prebuilt, from source, per-agent skills, hooks, the MCP server) is in [INSTALL.md](INSTALL.md).

#127's branch never had that line, and its merge (b01df96e) took that side, so main has not linked INSTALL.md from the README since. This puts the sentence back where it was, under the install command.

## Checks

On this branch: `readmedriftcheck`, `crossrefcheck`, `docanchorcheck` and `ripwirepubliccheck` all pass. README.md is the only file changed (six added lines, nothing removed), and the branch merges cleanly into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
