### PR TITLE
fix(legend): graph_unindexed= shipped a number the document never defined

### DIFF
--- a/src/compactlegend.h
+++ b/src/compactlegend.h
@@ -139,6 +139,14 @@ inline constexpr std::string_view kCompactProsePrefixes[] =
                                        // native compact legends of grep/slice (`<!-- ripwire slice ripwire.slice/v1: …`),
                                        // which this layer restates at ≤400 B; --for's is never routed here (main.cpp)
     "<!-- root= ",                     // the shared root-relative-paths block (graphlegend.h)
+    "<!-- graph_unindexed=",           // the #66 third-gauge clause where it rides as its OWN comment
+                                       // (graphlegend.h graphUnindexedLegendComment — connect/lego/verify/
+                                       // nonlocal-state): prose like every other legend sentence, and the
+                                       // completeness table below carries its compact reading. Without this
+                                       // row the full ~200 B sentence survived into the compact dialect on
+                                       // --connect alone, one verb paying full price for a fact the table
+                                       // states in a third of the bytes.
+
     "<!-- r:root=",                    // the map header's terse spelling of the same block
     "<!-- pr_iters=",                  // the PageRank convergence block on map-family roots
     "<!-- at= is the git commit",      // the churn/quality provenance block
@@ -196,6 +204,12 @@ inline constexpr CompactCompletenessTerm kCompactCompletenessTerms[] =
 {
     { "counts_floor",      "counts_floor=1: every count is a FLOOR, never a total" },
     { "graph_ambiguous",   "graph_ambiguous=/graph_unresolved=: resolver gauge" },
+    // Issue #66's third gauge, and it needs its OWN row rather than a widening of the one above: the pair is
+    // unconditional on a graph-floored root while this one is OMITTED AT ZERO, so folding it into the gauge
+    // sentence would define an attribute most documents do not carry. Present-only, like every term here —
+    // which is also what kept it invisible: the compact dialect stripped the full clause and had nothing to
+    // put back, on every verb, for the whole of v0.6.0.
+    { "graph_unindexed",   "graph_unindexed=N: N files no grammar could read (the map header's unindexed=); their calls raise neither gauge" },
     { "hits_capped",       "hits_capped=1: hits= is a floor" },
     { "est_tokens",        "est_tokens=: price as emitted (an upper bound under compact)" },
     { "over_ceiling",      "over_ceiling=1: budget not met" },

--- a/src/graphlegend.h
+++ b/src/graphlegend.h
@@ -127,11 +127,22 @@ inline constexpr const char* kGraphUnindexedLegend =
 inline const char* graphUnindexedLegend( bool on ) noexcept { return on ? kGraphUnindexedLegend : ""; }
 
 // The same sentence as its OWN XML comment, for the legends that are one closed <!-- ... --> literal rather
-// than a %s inside one (--connect). Wrapped, never re-spelled: a second copy of this sentence is the drift
+// than a %s inside one. Wrapped, never re-spelled: a second copy of this sentence is the drift
 // this header exists to stop, and splicing the bare clause after a closing "-->" is not a wording bug but a
 // WELL-FORMEDNESS one (test/floormarkcheck.sh arm (9) caught exactly that during this change).
 // legendcoveragecheck reads the whole LEADING RUN of comments as the legend, so an adjacent comment IS the
 // legend -- the rule kRootRelPathsLegend already relies on.
+//
+// FOUR USERS, and the fourth-to-first of them is why this paragraph is here. #66 landed the clause into the
+// three SHARED legend builders below (graphCountDisclosure, graphCountFloorBrief, graphUnindexedTextClause)
+// plus --connect through this wrapper -- but the ATTRIBUTE rides a different code path entirely
+// (graph.h graphCountFloorAttrXml/Json, whose only condition is g.unindexedFiles > 0). So every verb whose
+// legend is a hand-spelled closed literal rather than a call into a builder got the attribute and no clause:
+// --lego (kLegoLegend below, CLI and MCP), --verify (verify.h kVerifyLegend) and --nonlocal-state
+// (nonlocalstate.h kNonLocalStateLegend) shipped that way in v0.6.0. They now take this wrapper, which is
+// what it was written for. `on` is always the emitter's own g.unindexedFiles > 0, never a re-derivation.
+// Gate: test/blindspotcheck.sh arm (F) (attribute => clause, every surface, both dialects) and (G) (the
+// mirror: neither, on a corpus with nothing unindexed).
 inline std::string graphUnindexedLegendComment( bool on )
 {
     return on ? std::string( "<!-- " ) + kGraphUnindexedLegend + "-->" : std::string();

--- a/src/mcpverbs.h
+++ b/src/mcpverbs.h
@@ -1962,7 +1962,9 @@ inline std::string legoText( const std::string& root, const std::string& type, R
 
     return captureXml( [ & ]( std::FILE* mem )
     {
-        rw::emitTo( mem, "<ctx>{}", kLegoLegend );   // H5: the same legend the CLI --lego prints (graphlegend.h)
+        // H5: the same legend the CLI --lego prints, and (issue #66) the same adjacent clause defining the
+        // graph_unindexed= the root below carries — CLI and MCP are one wording by construction.
+        rw::emitTo( mem, "<ctx>{}{}", kLegoLegend, graphUnindexedLegendComment( ix.g.unindexedFiles > 0 ).c_str() );
         packLego( mem, ing, ix.g.implementors, flat, 1, redact, &impure, focus, /*withPaths=*/true,
                   ing.realPaths.empty() ? std::string_view( root ) : std::string_view(),    // R-R: root-relative <iface p=>
                   graphCountFloorAttrXml( ix.g ) );                                           // M15: gauge + marker

--- a/src/nonlocalstate.h
+++ b/src/nonlocalstate.h
@@ -975,6 +975,10 @@ inline int writeNonLocalStateReport( const IngestResult& ing, const Graph& g, in
     };
 
     std::fputs( kNonLocalStateLegend, stdout );
+    // #66: the root below carries graph_unindexed= when the crawl could not read a file at all, and the legend
+    // above is one closed literal — so its definition rides as its own adjacent comment, emitted on exactly
+    // the emitter's own condition (graphlegend.h graphUnindexedLegendComment), never a re-derivation of it.
+    rw::emitTo( stdout, "{}", rw::graphUnindexedLegendComment( g.unindexedFiles > 0 ).c_str() );
     rw::emitTo( stdout, "<nonlocal_state cells=\"{}\" functions=\"{}\"{}{}", scan.cells.size(), total, rw::cstr( disclosure ),
                  rw::graphCountFloorAttrXml( g ).c_str()  );   // M15: gauge + marker
     if( !scan.unanalyzedLangs.empty() )

--- a/src/verbs_for.h
+++ b/src/verbs_for.h
@@ -2669,7 +2669,11 @@ std::optional<int> runTargetedViews( const MainDispatch& d )
         // R-E fix (2026-08-19): the document root DISCLOSES the root its p= are now relative to. The first
         // R-E landing made packLego's p= root-relative and left the root undisclosed, so a --lego bundle
         // carried relative paths against a root the reader could not name — the honesty rule this tool sells.
-        rw::emitTo( stdout, "{}{}", rw::ctxRootOpen( {}, {}, tvRootArg ).c_str(), rw::kLegoLegend );   // H5: --lego had no legend at all
+        // H5: --lego had no legend at all. The #66 clause rides as its own adjacent comment (graphlegend.h
+        // graphUnindexedLegendComment) because kLegoLegend is one closed literal: the attribute below is
+        // conditional on g.unindexedFiles, so its definition has to be too.
+        rw::emitTo( stdout, "{}{}{}", rw::ctxRootOpen( {}, {}, tvRootArg ).c_str(), rw::kLegoLegend,
+                     rw::graphUnindexedLegendComment( g.unindexedFiles > 0 ).c_str() );
         packLego( stdout, ing, g.implementors, flat, 1, d.redactPtr, &legoImpure, focus, /*withPaths=*/true, tvRootArg,
                   rw::graphCountFloorAttrXml( g ) );   // M15: gauge + marker on the targeted root
         rw::emitRaw( stdout, "</ctx>" );

--- a/src/verbs_navigate.h
+++ b/src/verbs_navigate.h
@@ -1396,7 +1396,11 @@ std::optional<int> runVerify( const MainDispatch& d )
     const auto openRoot = [ & ]( const char* verdict, const std::string& facts, const char* limit, const char* honesty, const char* pageTail )
     {
         VERIFY( std::size_t( claim.shape ) < std::size( verify::kShapeTags ) );   // the parser is the only producer, every value in range
-        rw::emitTo( stdout, "{}{}<verify claim=\"{}\" shape=\"{}\" verdict=\"{}\"{}{}", verify::kVerifyLegend,
+        // #66: vfFloor above can carry graph_unindexed=, and kVerifyLegend is one closed literal that cannot
+        // splice a conditional clause — so the clause rides as its own adjacent comment, emitted exactly when
+        // the attribute is (graphlegend.h graphUnindexedLegendComment), ahead of the root= block.
+        rw::emitTo( stdout, "{}{}{}<verify claim=\"{}\" shape=\"{}\" verdict=\"{}\"{}{}", verify::kVerifyLegend,
+                     rw::graphUnindexedLegendComment( g.unindexedFiles > 0 ).c_str(),
                      rw::rootRelPathsLegend( verSingleRoot ),
                      ex( cfg.verifyClaim ).c_str(), verify::kShapeTags[ std::size_t( claim.shape ) ], verdict, facts.c_str(),
                      verRootAttr.c_str() );

--- a/test/blindspotcheck.sh
+++ b/test/blindspotcheck.sh
@@ -36,9 +36,12 @@
 #       an attribute nothing defines is a number an agent has to guess at, which is the same
 #       reader-facing failure #66 itself reported one level up.
 #   (G) #66 CLAUSE PARITY, the negative half — on a corpus with nothing unindexed, neither the attribute
-#       NOR a clause defining it appears on any of those surfaces. The mirror-image false claim
-#       graphlegend.h's rootRelPathsLegend rule already names: a legend that defines an attribute the
-#       document did not emit.
+#       NOR a clause defining it appears on any of those surfaces, CLI and MCP alike. The mirror-image
+#       false claim graphlegend.h's rootRelPathsLegend rule already names: a legend that defines an
+#       attribute the document did not emit. (F) and (G) walk the SAME surface list and, for MCP, the same
+#       posture list through the same args builder — a half that probed fewer surfaces than its twin is a
+#       hole shaped exactly like the one #66 came through, and the MCP postures were that hole until
+#       2026-09-11.
 #
 # WHAT (F)/(G) DO NOT COVER, said here rather than discovered later. They read XML COMMENTS, so they judge
 # the XML dialects only. --situ's blast-radius report is prose, not XML, and carries the same fact through
@@ -122,6 +125,20 @@ try:    d=json.loads(sys.stdin.read() or "{}")
 except Exception as e: sys.stdout.write("__ERROR__ unparseable: %s"%e);  raise SystemExit
 if "error" in d: sys.stdout.write("__ERROR__ %s"%d["error"].get("message",""));  raise SystemExit
 sys.stdout.write(d.get("result",{}).get("content",[{}])[0].get("text",""))'; }
+
+# The MCP lego postures, and the one args builder, that arms (F) and (G) SHARE. One enumeration and one args
+# shape on purpose. (F) probed the MCP surface and (G) probed CLI surfaces only, so an MCP answer could have
+# carried graph_unindexed= — or a clause defining it — on the corpus with nothing unindexed and no arm would
+# have read it. Both halves now iterate this list with the same extraction and the same rejections; a posture
+# added here is probed on BOTH corpora or on neither, which is the drift the shared list exists to stop.
+# An unknown posture yields EMPTY args, so the round trip fails loudly rather than silently falling back to
+# `default` and reporting a posture it never probed.
+MCP_LEGO_POSTURES="default full"
+mcpLegoArgs(){ case "$2" in
+        default) printf '{"path":"%s","type":"CloudStorage"}' "$1" ;;
+        full)    printf '{"path":"%s","type":"CloudStorage","legend":"full"}' "$1" ;;
+        *)       printf '' ;;
+    esac; }
 
 # ── corpora ───────────────────────────────────────────────────────────────────────────────────────────
 # Built here, not committed: each is the reporter's own minimal repro, and a committed .astro/.h fixture
@@ -440,12 +457,8 @@ EOF
 
 # the MCP twin of the worst case: the CLI --lego legend and its MCP copy are one literal, and the MCP
 # surface defaults to the compact posture, so both dialects are probed there too.
-for posture in default full; do
-    case "$posture" in
-        default) ARGS="{\"path\":\"$TMP/cxx\",\"type\":\"CloudStorage\"}" ;;
-        full)    ARGS="{\"path\":\"$TMP/cxx\",\"type\":\"CloudStorage\",\"legend\":\"full\"}" ;;
-    esac
-    mcp_text lego "$ARGS" >"$TMP/f_mcp.xml"
+for posture in $MCP_LEGO_POSTURES; do
+    mcp_text lego "$( mcpLegoArgs "$TMP/cxx" "$posture" )" >"$TMP/f_mcp.xml"
     MT="$( cat "$TMP/f_mcp.xml" )"
     case "$MT" in
         __ERROR__*) no "(F) MCP lego [$posture]: the verb refused — $MT" ;;
@@ -487,6 +500,29 @@ while IFS= read -r spec; do
 done <<EOF
 $SURFACES
 EOF
+
+# The MCP half of the mirror. (F) probes the MCP lego verb in both legend postures and (G) probed CLI
+# surfaces only, so an MCP response was free to carry graph_unindexed= — or a clause defining it — on the
+# clean corpus with nothing reading it. Same posture list, same args builder, same extraction and the same
+# four rejections as (F)'s MCP loop (refusal, empty payload, the attribute, a clause defining it); the ONLY
+# difference between the two loops is the corpus, which is what makes them a matched pair rather than two
+# checks that happen to be nearby.
+for posture in $MCP_LEGO_POSTURES; do
+    mcp_text lego "$( mcpLegoArgs "$TMP/cxxclean" "$posture" )" >"$TMP/g_mcp.xml"
+    GT="$( cat "$TMP/g_mcp.xml" )"
+    case "$GT" in
+        __ERROR__*) no "(G) MCP lego [$posture]: the verb refused — $GT" ;;
+        "")         no "(G) MCP lego [$posture]: empty payload (the absence arms reading it would have been vacuous)" ;;
+        *)
+            if grep -q 'graph_unindexed="' "$TMP/g_mcp.xml"; then
+                no "(G) MCP lego [$posture]: graph_unindexed= present on a corpus with nothing unindexed"
+            elif clauseDefines "$TMP/g_mcp.xml"; then
+                no "(G) MCP lego [$posture]: a clause DEFINES graph_unindexed= on an answer that never emits it — the mirror-image false claim"
+            else
+                ok "(G) MCP lego [$posture]: attribute absent, and no clause claims it"
+            fi ;;
+    esac
+done
 
 echo
 [ "$fail" -eq 0 ] && { echo "blindspotcheck: ALL PASS"; exit 0; }

--- a/test/blindspotcheck.sh
+++ b/test/blindspotcheck.sh
@@ -27,6 +27,23 @@
 #       the live call to the same callee in the same file still is. Both halves, because an arm that only
 #       checks the dead one passes just as well on a build that returns nothing at all.
 #   (E) MUTATION — every assertion SHAPE above is shown to be able to fail, against hand-built inputs.
+#   (F) #66 CLAUSE PARITY — wherever graph_unindexed= is EMITTED, a legend clause DEFINING it is emitted
+#       too, on every XML surface that can carry the attribute and in BOTH legend dialects (the default
+#       full one and --legend=compact), CLI and MCP alike. Arms (A)/(B) gate the attribute and its value;
+#       they never read the legend, and that gap is how v0.6.0 shipped `graph_unindexed="1"` on --lego,
+#       --verify, --nonlocal-state and on every verb under --legend=compact with zero clauses defining
+#       it anywhere in the document. G4's contract is that a reader learns the schema FROM THE OUTPUT:
+#       an attribute nothing defines is a number an agent has to guess at, which is the same
+#       reader-facing failure #66 itself reported one level up.
+#   (G) #66 CLAUSE PARITY, the negative half — on a corpus with nothing unindexed, neither the attribute
+#       NOR a clause defining it appears on any of those surfaces. The mirror-image false claim
+#       graphlegend.h's rootRelPathsLegend rule already names: a legend that defines an attribute the
+#       document did not emit.
+#
+# WHAT (F)/(G) DO NOT COVER, said here rather than discovered later. They read XML COMMENTS, so they judge
+# the XML dialects only. --situ's blast-radius report is prose, not XML, and carries the same fact through
+# graphlegend.h graphUnindexedTextClause(); the --json dialect carries no legend of any kind by design
+# (--help: "keys mirror the XML attribute names one to one"), so there is no clause there to be missing.
 #
 # VACUITY — the failure mode this gate was written against. Three arms in this tree in the week of
 # 2026-09-08 turned out to be unable to fail: the sharpest compared two EMPTY files, because G4 minifies a
@@ -73,10 +90,43 @@ sys.stdout.write(m.group(1) if m else "")' "$1" "$2"; }
 # Assert a capture is non-empty BEFORE anything is concluded from it. Every arm routes through this.
 nonempty(){ [ -n "$2" ] && return 0; no "$1 (empty capture — the arm reading it would have been vacuous)"; return 1; }
 
+# Does this document DEFINE graph_unindexed=, in a legend the reader meets? Exit 0 = yes.
+#
+# Two decisions, both load-bearing. (1) It reads only XML COMMENTS, split as SPANS and with CDATA skipped
+# — the payload attribute `graph_unindexed="1"` is the thing being defined, never the definition, so a
+# whole-document grep would call every gap a pass. (Line-wise comment stripping is the VACUITY bug this
+# file's header records: G4 minifies a document to ONE line.) (2) The predicate is legendcoveragecheck's
+# own DEFINITIONAL shape — the attribute name immediately followed by `=` — not a bare word search, so a
+# legend that merely alludes to unindexed files does not count as defining the attribute.
+clauseDefines(){ python3 -c '
+import re,sys
+d=open(sys.argv[1],encoding="utf-8",errors="replace").read()
+comments=[]
+i,n=0,len(d)
+while i<n:
+    if d.startswith("<![CDATA[",i):
+        j=d.find("]]>",i);  i=n if j<0 else j+3
+    elif d.startswith("<!--",i):
+        j=d.find("-->",i);  e=n if j<0 else j+3;  comments.append(d[i:e]);  i=e
+    else:
+        j=d.find("<",i+1);  i=n if j<0 else j
+sys.exit(0 if any(re.search(r"(?<![\w:.-])graph_unindexed\s*=",c) for c in comments) else 1)' "$1"; }
+
+# One MCP tools/call round trip, answering with the verb's text payload (or __ERROR__… so an arm reading
+# it fails loudly rather than on an empty string).
+mcp_text(){ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
+                          "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":$2}}" \
+    | "$BIN" --mcp 2>/dev/null | tail -1 | python3 -c '
+import sys,json
+try:    d=json.loads(sys.stdin.read() or "{}")
+except Exception as e: sys.stdout.write("__ERROR__ unparseable: %s"%e);  raise SystemExit
+if "error" in d: sys.stdout.write("__ERROR__ %s"%d["error"].get("message",""));  raise SystemExit
+sys.stdout.write(d.get("result",{}).get("content",[{}])[0].get("text",""))'; }
+
 # ── corpora ───────────────────────────────────────────────────────────────────────────────────────────
 # Built here, not committed: each is the reporter's own minimal repro, and a committed .astro/.h fixture
 # would also join every OTHER gate's view of test/.
-mkdir -p "$TMP/unind/src" "$TMP/clean/src" "$TMP/hdr" "$TMP/if0"
+mkdir -p "$TMP/unind/src" "$TMP/clean/src" "$TMP/hdr" "$TMP/if0" "$TMP/cxx" "$TMP/cxxclean"
 
 # (A)/(B): #66 — the caller differs from the contrast arm ONLY in file extension.
 cat > "$TMP/unind/src/util.ts" <<'EOF'
@@ -143,6 +193,51 @@ int deadCaller(int x)
     return target(x);
 #endif
 }
+EOF
+
+# (F)/(G): the CLAUSE-PARITY pair. ONE C++ corpus that reaches every surface the attribute can ride —
+# an interface with an implementor (--lego), a call chain (--verify calls(), --path, --connect), a mutable
+# global a function writes (--nonlocal-state), an uncalled function (--dead-code, --safe-delete) — and its
+# TWIN, identical but for the one file no grammar in this build can read. C++ rather than the TypeScript
+# corpus above because --nonlocal-state analyses C/C++/ObjC/Python only and --lego is own-language.
+cat > "$TMP/cxx/iface.h" <<'EOF'
+#pragma once
+class CloudStorage
+{
+public:
+    virtual int putObject(const char* key) = 0;
+};
+class S3Storage : public CloudStorage
+{
+public:
+    int putObject(const char* key) override;
+};
+EOF
+cat > "$TMP/cxx/s3.cpp" <<'EOF'
+#include "iface.h"
+int gUploadCount = 0;
+int S3Storage::putObject(const char* key)
+{
+    gUploadCount = gUploadCount + 1;
+    return key ? 1 : 0;
+}
+int driveIt(S3Storage& s)
+{
+    return s.putObject("k");
+}
+int neverCalled(S3Storage& s)
+{
+    return driveIt(s);
+}
+EOF
+cp "$TMP/cxx/iface.h" "$TMP/cxxclean/iface.h"
+cp "$TMP/cxx/s3.cpp"  "$TMP/cxxclean/s3.cpp"
+# the ONE difference: a file with an extension the crawl walks and no grammar reads
+cat > "$TMP/cxx/page.astro" <<'EOF'
+---
+const x = 1;
+---
+<p>{x}</p>
 EOF
 
 echo
@@ -282,6 +377,116 @@ fi
 [ -z "$( rootEl "$TMP/m_d.xml" callers )" ] \
     && ok "(E) rootEl: returns empty for an element the document does not contain" \
     || no "(E) rootEl matched a <callers> element in a document that has none"
+# (F)/(G) shape: clauseDefines() must say NO on the exact document the defect produces — the attribute on
+# the root, a legend present and plausible, and no clause about it anywhere.
+printf '%s' '<ctx><!-- ripwire lego: ONE interface/base type. counts_floor="1": every graph-derived count here is a FLOOR, never a total. --><lego graph_ambiguous="0" graph_unindexed="1" counts_floor="1"/></ctx>' >"$TMP/m_f0.xml"
+clauseDefines "$TMP/m_f0.xml" \
+    && no "(E) clauseDefines() claims a clause on the v0.6.0 defect document itself — the (F) arm is inert" \
+    || ok "(E) F-shape: a legend that never mentions graph_unindexed IS seen as undefined"
+# and YES on the same document with the clause present — a predicate that only ever says NO fails (F) forever
+printf '%s' '<ctx><!-- ripwire lego: ONE interface/base type. --><!-- graph_unindexed=N is a third gauge. --><lego graph_unindexed="1"/></ctx>' >"$TMP/m_f1.xml"
+clauseDefines "$TMP/m_f1.xml" \
+    && ok "(E) F-shape: a clause spelling graph_unindexed= IS credited" \
+    || no "(E) clauseDefines() cannot see a clause that is present — the (F) arm could never go green"
+# the payload attribute is NOT a definition: a document with the attribute and no comment at all must be NO
+printf '%s' '<lego graph_unindexed="1" counts_floor="1"/>' >"$TMP/m_f2.xml"
+clauseDefines "$TMP/m_f2.xml" \
+    && no "(E) clauseDefines() read the PAYLOAD attribute as its own definition — every gap would pass" \
+    || ok "(E) F-shape: the payload attribute alone is not read as a definition"
+# and CDATA is not a legend: the same bytes inside a body must not count
+printf '%s' '<ctx><b><![CDATA[<!-- graph_unindexed=N is a third gauge. -->]]></b><lego graph_unindexed="1"/></ctx>' >"$TMP/m_f3.xml"
+clauseDefines "$TMP/m_f3.xml" \
+    && no "(E) clauseDefines() credited a comment that is CDATA body text, not a legend" \
+    || ok "(E) F-shape: a clause-shaped string inside CDATA is not credited"
+
+echo
+echo "=== (F) #66 — wherever graph_unindexed= is EMITTED, a legend clause DEFINES it ==="
+# One row per (surface, dialect). The premise — the attribute is actually on this answer — is asserted by
+# its own FAIL rather than a skip: a surface that stops emitting the attribute must be noticed, not
+# silently dropped from the conjunction.
+SURFACES="lego:--lego=CloudStorage
+verify:--verify=calls(driveIt,putObject)
+nonlocal-state:--nonlocal-state
+callers:--callers=putObject
+callees:--callees=driveIt
+uses:--uses=putObject
+impact:--impact=putObject
+path:--path=neverCalled,putObject
+connect:--connect=neverCalled,driveIt,putObject
+dead-code:--dead-code
+safe-delete:--safe-delete=driveIt
+communities:--communities
+seams:--seams"
+while IFS= read -r spec; do
+    [ -n "$spec" ] || continue
+    lbl="${spec%%:*}"; flag="${spec#*:}"
+    for dialect in full compact; do
+        if [ "$dialect" = compact ]; then
+            "$BIN" "$TMP/cxx" --no-cache "$flag" --legend=compact >"$TMP/f.xml" 2>/dev/null
+        else
+            "$BIN" "$TMP/cxx" --no-cache "$flag" >"$TMP/f.xml" 2>/dev/null
+        fi
+        if ! grep -q 'graph_unindexed="' "$TMP/f.xml"; then
+            no "(F) $lbl [$dialect]: premise broken — this answer carries NO graph_unindexed=, so the clause arm would be vacuous"
+        elif clauseDefines "$TMP/f.xml"; then
+            ok "(F) $lbl [$dialect]: graph_unindexed= emitted AND defined in the legend"
+        else
+            no "(F) $lbl [$dialect]: graph_unindexed= emitted with NO clause defining it — a number the output cannot teach (#66/G4)"
+        fi
+    done
+done <<EOF
+$SURFACES
+EOF
+
+# the MCP twin of the worst case: the CLI --lego legend and its MCP copy are one literal, and the MCP
+# surface defaults to the compact posture, so both dialects are probed there too.
+for posture in default full; do
+    case "$posture" in
+        default) ARGS="{\"path\":\"$TMP/cxx\",\"type\":\"CloudStorage\"}" ;;
+        full)    ARGS="{\"path\":\"$TMP/cxx\",\"type\":\"CloudStorage\",\"legend\":\"full\"}" ;;
+    esac
+    mcp_text lego "$ARGS" >"$TMP/f_mcp.xml"
+    MT="$( cat "$TMP/f_mcp.xml" )"
+    case "$MT" in
+        __ERROR__*) no "(F) MCP lego [$posture]: the verb refused — $MT" ;;
+        "")         no "(F) MCP lego [$posture]: empty payload (the arm reading it would have been vacuous)" ;;
+        *)
+            if ! grep -q 'graph_unindexed="' "$TMP/f_mcp.xml"; then
+                no "(F) MCP lego [$posture]: premise broken — no graph_unindexed= on the MCP answer"
+            elif clauseDefines "$TMP/f_mcp.xml"; then
+                ok "(F) MCP lego [$posture]: graph_unindexed= emitted AND defined in the legend"
+            else
+                no "(F) MCP lego [$posture]: graph_unindexed= emitted with NO clause defining it (#66/G4)"
+            fi ;;
+    esac
+done
+
+echo
+echo "=== (G) #66 — on a corpus with nothing unindexed, neither the attribute nor a clause appears ==="
+# The mirror-image false claim: a legend that defines an attribute the document did not emit. The corpus is
+# the (F) corpus MINUS the one unreadable file, so any difference found here is that file and nothing else.
+while IFS= read -r spec; do
+    [ -n "$spec" ] || continue
+    lbl="${spec%%:*}"; flag="${spec#*:}"
+    for dialect in full compact; do
+        if [ "$dialect" = compact ]; then
+            "$BIN" "$TMP/cxxclean" --no-cache "$flag" --legend=compact >"$TMP/g.xml" 2>/dev/null
+        else
+            "$BIN" "$TMP/cxxclean" --no-cache "$flag" >"$TMP/g.xml" 2>/dev/null
+        fi
+        if [ ! -s "$TMP/g.xml" ]; then
+            no "(G) $lbl [$dialect]: the clean corpus produced NO answer — the absence arms would be vacuous"
+        elif grep -q 'graph_unindexed="' "$TMP/g.xml"; then
+            no "(G) $lbl [$dialect]: graph_unindexed= present on a corpus with nothing unindexed"
+        elif clauseDefines "$TMP/g.xml"; then
+            no "(G) $lbl [$dialect]: a clause DEFINES graph_unindexed= on an answer that never emits it — the mirror-image false claim"
+        else
+            ok "(G) $lbl [$dialect]: attribute absent, and no clause claims it"
+        fi
+    done
+done <<EOF
+$SURFACES
+EOF
 
 echo
 [ "$fail" -eq 0 ] && { echo "blindspotcheck: ALL PASS"; exit 0; }

--- a/test/compactlegendcheck.sh
+++ b/test/compactlegendcheck.sh
@@ -360,7 +360,12 @@ while IFS="$( printf '\t' )" read -r flag kind example policy; do
         fi
     done
     for a in $( leg headattrs "$TMP/u.c" ); do
-        case "$a" in counts_floor|est_tokens|at|root|graph_ambiguous|graph_unresolved|hits_capped|limit|offset|over_ceiling|tier_partial) ;; *) continue ;; esac
+        # graph_unindexed joined this list with issue #66's clause-parity fix. It is INERT on this gate's
+        # corpus — the fixture copy carries no file a grammar cannot read, so the attribute never appears and
+        # this row never fires. Said out loud rather than left to be re-discovered: the arm that actually
+        # exercises the compact reading is test/blindspotcheck.sh (F), on a corpus built to carry one. The
+        # name is listed here anyway so the enumeration matches the term table, not the fixture.
+        case "$a" in counts_floor|est_tokens|at|root|graph_ambiguous|graph_unresolved|graph_unindexed|hits_capped|limit|offset|over_ceiling|tier_partial) ;; *) continue ;; esac
         case "$legtxt" in *"$a="*) ;; *) no "(U) $probe compact legend does not name $a= although the root carries it" ;; esac
     done
     if command -v xmllint >/dev/null 2>&1; then


### PR DESCRIPTION
`graph_unindexed=` — the #66 third gauge, the count of files no grammar in this build could read — shipped in
v0.6.0 on surfaces whose legend never defined it. An agent reading `graph_unindexed="3"` off a `--lego` root
had a number and no way to learn what it counted. Under this repo's honesty contract a legend defines what
it emits, so that is a defect in the output itself, not a documentation gap.

There were **two independent causes**, which is why the affected surfaces looked arbitrary.

**1. The attribute and the clause ride different code paths.** The attribute comes from
`graph.h::graphCountFloorAttrXml/Json`, whose only condition is `unindexedFiles > 0`. The #66 clause was
spliced into `graphlegend.h`'s shared legend *builders* plus `--connect`'s wrapper. Every verb whose legend
is a hand-spelled closed `<!-- … -->` literal rather than a builder call therefore got the number with no
reading: `kLegoLegend` (one literal, two emitters — CLI and MCP), `kVerifyLegend`, `kNonLocalStateLegend`.

**2. `--legend=compact` deleted the clause and had nothing to put back.** The compact layer strips every
`<!-- ripwire …` prose comment and rebuilds a bounded legend from `kCompactCompletenessTerms`, which carried
a `graph_ambiguous` row and no `graph_unindexed` row. So under compact the definition was missing on *every*
XML verb that can carry the attribute except `--connect` — which survived only by accident, its clause being
a standalone comment whose opener was not in `kCompactProsePrefixes`.

Adding that prefix also removes a double-count: without it `--connect` would now carry both the surviving
177 B full clause and the new compact term. Its compact legend drops ~570 B → 505 B, while every other verb
gains a 113 B reading it previously lacked entirely.

## Why no gate caught it

`blindspotcheck` arms (A)/(B) assert the attribute and its value-equality with the map header, and never read
the legend. `legendcoveragecheck` — the gate whose entire job is this class of defect — has no `lego`,
`verify` or `nonlocal-state` row in its roster.

New arm **(F)** closes the first gap: attribute ⇒ clause across 13 verbs × 2 dialects, plus MCP `lego` in both
postures. Arm **(G)** is the negative control on a corpus differing only by the one unreadable file. Arm (E)
gained four mutation probes, including one that says NO on the v0.6.0 defect document and YES on a fixed one.

- unmodified `main`: **20 FAIL**, exit 1
- after: **72 PASS, 0 FAIL**, exit 0, and clean under ASan

Arms (F)/(G) are scoped to the XML dialects on purpose, stated in the gate header: `--situ` is a text report
and was never broken — it carries the fact through `graphUnindexedTextClause`.

## Deliberately not in this PR

**The roster gap stays open.** Adding `lego`/`verify`/`nonlocal-state` to `legendcoveragecheck` would surface
those verbs' *other* undefined attributes, and that baseline may only be edited downward. Widening it is a
decision of its own, not a rider on a defect fix — it is queued as its own change.

## Verification

616 gates: 613 pass, 3 skip, 0 fail. (`strkerncheck` hit its 300 s budget once under three-session machine
contention — SIMD string kernels, no legend surface — and passes re-run alone.) ASan clean on all four verbs
× both dialects and on a repo self-run; `g1freshcheck` PASS; determinism ×3 byte-identical; `xmllint` clean;
`formatcheck` ALL PASS; `gatecount_build --check` and `limits_build --check` green. No budget pin moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
