### PR TITLE
fix(connect): est_tokens stopped covering the document the moment a file went unindexed

### DIFF
--- a/skills/install.sh
+++ b/skills/install.sh
@@ -355,11 +355,17 @@ for d in "$src"/ripwire-*/; do
     count=$(( count + 1 ))
 done
 
-# Hermes loads the flat Agent-Skills-standard set AND Hermes-native skills (skills/hermes/*, e.g. the
-# ripwire-repo-map skill purpose-built for Hermes) side by side out of one directory — verified live:
+# Hermes loads the flat Agent-Skills-standard set AND Hermes-native skills (skills/hermes/ripwire-*, e.g.
+# the ripwire-repo-map skill purpose-built for Hermes) side by side out of one directory — verified live:
 # both formats index together, so --hermes deploys both and no prefer/fallback logic is needed.
+# The ripwire-* glob is the SAME name scope the flat install loop and the prune loop above use, and it is
+# load-bearing: this loop `ln -sfn`s each entry into the user's skill home under its own name, `ln -sfn`
+# unlinks an existing regular file first, and the prune loop only ever looks at ripwire-*. A hermes/ entry
+# without the prefix would therefore delete a same-named USER skill and then be impossible to prune. Only
+# ripwire-repo-map lives there today, so this is the asymmetry being closed, not a bug being observed.
+# Gate: test/hermesinstallcheck.sh arm 7.
 if [ "$mode" = "hermes" ]; then
-    for nd in "$src"/hermes/*/; do
+    for nd in "$src"/hermes/ripwire-*/; do
         [ -d "$nd" ] || continue                                  # skip the literal glob when nothing matches
         [ -f "$nd/SKILL.md" ] || continue                        # a Hermes-native skill is a dir with SKILL.md
         nname="$( basename "$nd" )"
@@ -385,7 +391,7 @@ manifestTmp="$( mktemp "$dst/.ripwire-manifest-v1.tmp.XXXXXX" )"
         wanted_skill "$d" && echo "skill=$( basename "$d" )"
     done
     if [ "$mode" = "hermes" ]; then
-        for nd in "$src"/hermes/*/; do
+        for nd in "$src"/hermes/ripwire-*/; do        # same name scope as the install loop above
             [ -d "$nd" ] || continue
             [ -f "$nd/SKILL.md" ] || continue
             nname="$( basename "$nd" )"

--- a/src/mcpverbs.h
+++ b/src/mcpverbs.h
@@ -2855,7 +2855,18 @@ inline void packConnect( std::FILE* out, const IngestResult& ing, const Graph& g
     // this verb budgets, so they are charged to BOTH the trim-loop fit check and the printed est_tokens. Built
     // once here because connectEstTokens must be called with the same value in both places.
     const std::string  connectRootAttr = rootArg.empty() ? std::string() : ( " root=\"" + ex( rootArg ) + "\"" );
-    const std::size_t  connectExtraBytes = connectRootAttr.size() + std::strlen( rootRelPathsLegend( !rootArg.empty() ) );
+    // 0.6.1 M2 — the THIRD thing this verb emits ahead of its payload, and the one the estimator did not
+    // charge. PR #72 (issue #66, 382e66e6) added the graph_unindexed legend comment (185 B) beside the
+    // graph_unindexed= attribute and raised kConnectRootBytes 260 -> 285 for the ATTRIBUTE only. A corpus
+    // with one unindexed file therefore grew
+    // the delivered document by 205 B while est_tokens did not move a token: 2503 B / 1049 (conservative by
+    // 119 B) became 2708 B / 1049 — OPTIMISTIC by 86 B, the direction both constants above say this estimate
+    // may never take. Held in a NAMED string rather than charged from one call and emitted from another: the
+    // bytes counted here and the bytes written below are now the same object, so the two cannot drift again
+    // (same reason connectExtraBytes itself is built once). Gate: estchargecheck #17.
+    const std::string  connectUnindexedLegend = graphUnindexedLegendComment( g.unindexedFiles > 0 );
+    const std::size_t  connectExtraBytes = connectRootAttr.size() + std::strlen( rootRelPathsLegend( !rootArg.empty() ) )
+                                         + connectUnindexedLegend.size();
 
     // §2.4a: the derived hub threshold every Steiner row's connects= is read against, computed ONCE (it is a
     // property of the graph, not of a row) and named on the root so the label is never a bare assertion.
@@ -3066,7 +3077,7 @@ inline void packConnect( std::FILE* out, const IngestResult& ing, const Graph& g
     {
         estTokens = connectEstTokens( payload.size(), connectExtraBytes + std::strlen( connectOverAttr ) );
     }
-    rw::emitTo( out, "{}{}{}", rw::cstr( kConnectHeader ), graphUnindexedLegendComment( g.unindexedFiles > 0 ).c_str(), rootRelPathsLegend( !rootArg.empty() ) );
+    rw::emitTo( out, "{}{}{}", rw::cstr( kConnectHeader ), connectUnindexedLegend.c_str(), rootRelPathsLegend( !rootArg.empty() ) );
     rw::emitTo( out, "<connect terminals=\"{}\" nodes=\"{}\" edges=\"{}\" radius=\"{}\" groups=\"{}\" est_tokens=\"{}\" hub_floor=\"{}\"{}{}{}{}{}>",
                   res.terminals.size(), nodeTotal, edgeTotal, res.radius, connectedGroups, estTokens, hubFloor,
                   rw::cstr( connectCeiling ), connectOverAttr,

--- a/src/resolve.h
+++ b/src/resolve.h
@@ -1878,11 +1878,13 @@ inline std::vector<std::vector<std::uint32_t>> buildPreciseIncludeAdj( const Ing
     return buildPreciseIncludeAdjWithContext( ing, dedup, lazyPairsOut ).first;
 }
 
-// Transitive include-set per file: for each file f, the sorted, deduped set of fileIds reachable from
-// f by ≥1 include hop (f itself EXCLUDED). Cycle-safe via a `seen` bitset (a file already visited is
+// Transitive include-set per file: for each file f, the sorted, duplicate-free set of fileIds reachable
+// from f by ≥1 include hop (f itself EXCLUDED). Cycle-safe via a `seen` bitset (a file already visited is
 // not re-pushed), so mutually-including headers (a↔b) simply each reach the other — the exact
-// reachability walk shape as graph.h::dependencyHealth. Deterministic: `adj` is sorted, each result
-// set is re-sorted+deduped, so it is a pure function of the adjacency regardless of visit order.
+// reachability walk shape as graph.h::dependencyHealth. Deterministic: `adj` is sorted and each result set
+// is re-sorted, so it is a pure function of the adjacency regardless of visit order. Duplicate-free is a
+// property of the epoch stamp, NOT of a dedup pass — there is no longer one to describe; see the NO DEDUP
+// PASS note at the sort below, which is where the removed std::unique used to sit.
 inline std::vector<std::vector<NodeId>> transitiveIncludeSet( const std::vector<std::vector<std::uint32_t>>& adj )
 {
     PROFILE_SCOPE_DESCRIBE( "buildGraph/2b: transitive include closure (resolve.h)" );

--- a/src/situ.h
+++ b/src/situ.h
@@ -561,10 +561,13 @@ inline void writeSituation( std::FILE* out, const std::string& root, const Inges
     // F3: the decl/def partner FIRST — it is the answer to "what else has to change with this file" that the
     // dependent-symbol ranking below can never produce, because a header does not depend on its own source.
     writeSituDeclDefRows( out, declDefPartners( ing, changedFile ), situPathRel );
-    {   // H5/M15: the same floor + gauge the XML graph verbs mark, in this report's prose (one fold: graphGaugeAttrXml's)
-        std::size_t gaugeAmb = 0, gaugeUnresolved = 0;
-        for( std::uint32_t k : g.ambOut )        { gaugeAmb        += k; }
-        for( std::uint32_t k : g.unresolvedOut ) { gaugeUnresolved += k; }
+    {   // H5/M15: the same floor + gauge the XML graph verbs mark, in this report's prose — through the SAME
+        // fold, graphGaugeTotals, that graphGaugeAttrXml and graphGaugeAttrJson go through. PR #72 (382e66e6)
+        // introduced that fold in the same commit that widened the gauge to three, precisely to stop the two
+        // dialects being a clone pair — and this third copy was left hand-written three lines above the call
+        // that consumes it. A fold honoured in two places out of three is the shape #72 was fixing, not an
+        // exception to it.
+        const auto [gaugeAmb, gaugeUnresolved] = graphGaugeTotals( g.ambOut, g.unresolvedOut );
         rw::emitTo( out, kGraphCountFloorTextLine, gaugeAmb, gaugeUnresolved, graphUnindexedTextClause( g.unindexedFiles ).c_str() );
     }
     for( std::size_t i = blastPage.begin; i < blastPage.end; ++i )

--- a/test/estchargecheck.sh
+++ b/test/estchargecheck.sh
@@ -1125,5 +1125,89 @@ else
     fi
 fi
 
+# ── #17 (0.6.1, M2): --connect must charge its CONDITIONAL legend comment, and stay CONSERVATIVE ────────
+# packConnect emits THREE things ahead of its payload — kConnectHeader, the #66 graph_unindexed legend
+# comment (emitted exactly when graph_unindexed= rides the root), and the shared root-relative legend — and
+# connectExtraBytes charged only two of them. PR #72 (issue #66, 382e66e6) raised kConnectRootBytes 260 -> 285 for the
+# ATTRIBUTE and missed the 185 B COMMENT beside it, so on the two corpora below — identical but for one file
+# no grammar can read — the delivered document grew 205 B (185 B comment + the 20 B attribute) while
+# est_tokens did not move by a single token:
+#     0 unindexed files  2503 B   est_tokens=1049   modelled 2622 B   -119 B  (conservative)
+#     1 unindexed file   2708 B   est_tokens=1049   modelled 2622 B    +86 B  (OPTIMISTIC — the defect)
+# The printed est_tokens, the --max-tokens fit check and the over_ceiling="1" verdict then all measure a
+# smaller document than the caller receives, which is precisely what connectEstTokens' own header and
+# kConnectRootBytes' ("short is the ONE direction this constant may not be") say must never happen.
+#
+# WHY THIS IS NOT ALREADY COVERED by #1/#15's band arms: 2503/1049 = 2.38 B/tok and 2708/1049 = 2.58 B/tok
+# sit comfortably INSIDE the 2.00-3.20 markup band, so a band arm is green on both sides of the defect. The
+# separating property is the DIRECTION, not the magnitude — the delivered document must fit inside
+# est_tokens x kBytesPerTokenDefault (2.50) — and it must be asserted on a corpus that HAS an unindexed
+# file, because that is the only arm the uncharged comment reaches. Both corpora are asserted so the arm
+# cannot pass by measuring the side that was never broken.
+#
+# THE FIXTURE NAMES ARE THE SAME LENGTH ON PURPOSE, and that is not cosmetic. The first spelling of this
+# arm used "clean" and "unindexed": four extra path bytes land inside root="...", connectExtraBytes DOES
+# charge root=, and the estimate therefore moved 1047 -> 1048 across the mutation (observed, on the binary
+# this arm was written red against). The monotone arm (c)
+# passed on that ONE token while the defect it names was fully present — CONTRIBUTING §2 shape 5, a control
+# whose two arms differ in something other than the thing under test. Equal-length names make the legend
+# comment the only byte source that can move the estimate.
+C17="$TMP/c17"
+mkdir -p "$C17/unindexed_0/src" "$C17/unindexed_1/src"
+for d in unindexed_0 unindexed_1; do
+    printf 'export function greet( name: string ): string\n{\n    return `hello ${name}`;\n}\n'                        >"$C17/$d/src/util.ts"
+    printf 'import { greet } from "./util.ts";\nexport function render(): string\n{\n    return greet( "world" );\n}\n' >"$C17/$d/src/consumer.ts"
+done
+# THE ONE DIFFERENCE between the two corpora: a file no grammar in this build can read (real input, really
+# mutated — the identical extraction runs over both).
+printf -- '---\nconst x = 1;\n---\n<p>{x}</p>\n' >"$C17/unindexed_1/src/page.astro"
+for d in unindexed_0 unindexed_1; do
+    "$BIN" "$C17/$d" --connect=render,greet --no-cache >"$TMP/c17_$d.xml" 2>/dev/null
+done
+C17_LEGEND='graph_unindexed=N is a third gauge'
+# (a) presence guards — assert the mutation TOOK before trusting any number derived from it. Without these
+#     the arm is the "wrong population" shape: if .astro ever became indexable, or the legend moved, the two
+#     corpora would be identical and the comparison below would prove nothing while staying green.
+C17_CLEAN_U="$(  root_attr "$TMP/c17_unindexed_0.xml" connect graph_unindexed )"
+C17_UNIDX_U="$(  root_attr "$TMP/c17_unindexed_1.xml" connect graph_unindexed )"
+{ [ -z "$C17_CLEAN_U" ] && [ "$C17_UNIDX_U" = "1" ]; } \
+    && ok "#17 mutation took: the clean corpus carries no graph_unindexed= and the mutated one carries graph_unindexed=\"1\"" \
+    || no "#17 mutation did NOT take: graph_unindexed= is '${C17_CLEAN_U:-<absent>}' clean vs '${C17_UNIDX_U:-<absent>}' mutated — the arm is measuring two identical corpora"
+{ ! grep -q "$C17_LEGEND" "$TMP/c17_unindexed_0.xml" && grep -q "$C17_LEGEND" "$TMP/c17_unindexed_1.xml"; } \
+    && ok "#17 the #66 legend comment is emitted on the mutated corpus and absent on the clean one (the uncharged bytes are really there)" \
+    || no "#17 the #66 legend comment is not where this arm needs it — present on clean, or missing from the mutated corpus"
+C17_BC="$( bytes_of "$TMP/c17_unindexed_0.xml" )"; C17_EC="$( root_est "$TMP/c17_unindexed_0.xml" connect )"
+C17_BU="$( bytes_of "$TMP/c17_unindexed_1.xml" )"; C17_EU="$( root_est "$TMP/c17_unindexed_1.xml" connect )"
+{ [ -n "$C17_EC" ] && [ -n "$C17_EU" ] && [ "$C17_EC" -gt 0 ] && [ "$C17_EU" -gt 0 ]; } 2>/dev/null \
+    || no "#17 a <connect> root carries no positive est_tokens= (clean '$C17_EC', mutated '$C17_EU')"
+[ "$C17_BU" -gt "$C17_BC" ] 2>/dev/null \
+    && ok "#17 the mutated document is $(( C17_BU - C17_BC )) B larger than the clean one ($C17_BC -> $C17_BU B)" \
+    || no "#17 the mutated document did not grow ($C17_BC -> $C17_BU B) — there is nothing for est_tokens to have missed"
+# (b) THE PROPERTY, on both corpora: the WHOLE delivered document fits inside est_tokens x 2.50 B/tok.
+#     Integer math, no tolerance added: kConnectRootBytes deliberately OVER-covers the start tag, so a
+#     correctly charged document sits ~100 B clear of this line and only an uncharged section crosses it.
+#     The 2.50 is serialize.h's kBytesPerTokenDefault, the rate connectEstTokens divides by — if that
+#     constant ever moves, this arm's 25/10 moves with it, the same hand-pinned coupling #1's bands carry.
+for entry in "0 unindexed files:$C17_BC:$C17_EC" "1 unindexed file:$C17_BU:$C17_EU"; do
+    lab="${entry%%:*}"; rest="${entry#*:}"; b="${rest%%:*}"; e="${rest#*:}"
+    [ -n "$e" ] && [ "$e" -gt 0 ] 2>/dev/null || continue
+    m=$(( e * 25 / 10 ))
+    [ $(( b * 10 )) -le $(( e * 25 )) ] \
+        && ok "#17 --connect ($lab): $b B delivered against est_tokens=$e x 2.50 = $m B modelled — CONSERVATIVE by $(( m - b )) B" \
+        || no "#17 --connect ($lab): $b B delivered against est_tokens=$e x 2.50 = $m B modelled — OPTIMISTIC by $(( b - m )) B; a section of the document is not charged to est_tokens"
+done
+# (c) MONOTONE, the same property #2/#11 assert elsewhere: the two corpora share a payload byte for byte, so
+#     the ONLY thing that moved is the legend comment — and an estimate that does not move when the document
+#     does is the signature of the defect (est_tokens=1049 on both sides of a 205 B growth).
+{ [ -n "$C17_EU" ] && [ -n "$C17_EC" ] && [ "$C17_EU" -gt "$C17_EC" ]; } 2>/dev/null \
+    && ok "#17 --connect: est_tokens rose $C17_EC -> $C17_EU when the document grew (the conditional legend is charged)" \
+    || no "#17 --connect: est_tokens stayed at '$C17_EC' -> '$C17_EU' across a $(( C17_BU - C17_BC )) B growth — the conditional legend comment is uncharged"
+# (d) G4 — the two captures stay well-formed (this arm reads bytes, so it must not be reading a broken doc)
+if command -v xmllint >/dev/null 2>&1; then
+    for f in c17_unindexed_0 c17_unindexed_1; do
+        if xmllint --noout "$TMP/$f.xml" 2>/dev/null; then ok "#17 $f.xml is well-formed"; else no "#17 $f.xml FAILED xmllint"; fi
+    done
+fi
+
 [ "$fail" = 0 ] && echo "ALL PASS" || echo "FAILURES ABOVE"
 exit $fail

--- a/test/hermesinstallcheck.sh
+++ b/test/hermesinstallcheck.sh
@@ -27,7 +27,7 @@ export HERMES_HOME="$TMP/hermes-home"; rm -rf "$HERMES_HOME"; mkdir -p "$HERMES_
 # set under skills/hermes/ (both deploy via --hermes; a flat dir of the same name wins and the native
 # one is skipped, mirroring install.sh). $1 selects the set: user (activated by default) or contributor.
 skill_names() {
-    for d in "$SK"/ripwire-*/ "$SK"/hermes/*/; do
+    for d in "$SK"/ripwire-*/ "$SK"/hermes/ripwire-*/; do    # both globs are the installer's own (arm 7)
         [ -d "$d" ] || continue
         name="$( basename "$d" )"
         [ -f "$d/SKILL.md" ] || continue
@@ -144,5 +144,45 @@ else
             || no "wrap hermes prints a '--hermes --hook' install line, but the installer refuses it with exit 2"
     fi
 fi
+
+
+# ---- 7) the Hermes-native loops are constrained to ripwire-*, like every other loop in the installer ----
+# Three loops decide what --hermes links and unlinks. Two of them are name-scoped — the flat install loop
+# globs "$src"/ripwire-*/ and the prune loop globs "$dst"/ripwire-* — and the Hermes-native pair (install
+# and manifest) globbed "$src"/hermes/*/ instead. Today skills/hermes/ holds exactly one entry and it is
+# ripwire-repo-map, so nothing is broken; the asymmetry is what is broken. A future non-ripwire-prefixed
+# entry there would be `ln -sfn`'d into the user's skill home under ITS OWN name, and `ln -sfn` unlinks an
+# existing regular file before creating the link — so a user skill of the same name is DELETED, and the
+# prune loop, which only ever looks at ripwire-*, could never take the link back out again.
+#
+# Asserted as BEHAVIOUR, not as a grep for the glob: a decoy pair is planted in a COPY of skills/ (install.sh
+# derives $src from its own location, so a copy is a complete, isolated installer) and the installer is run
+# against a throwaway Hermes home. The live skills/ tree is never written to — other gates crawl it in
+# parallel under pargates, and a probe copy dropped into the measured tree is its own known trap.
+H7_SK="$TMP/skcopy"; rm -rf "$H7_SK"; cp -R "$SK" "$H7_SK"
+mkdir -p "$H7_SK/hermes/notes" "$H7_SK/hermes/ripwire-decoy-map"
+printf -- '---\nname: notes\ndescription: a user-authored skill that happens to share this name\n---\n'   >"$H7_SK/hermes/notes/SKILL.md"
+printf -- '---\nname: ripwire-decoy-map\ndescription: a Hermes-native ripwire skill\n---\n'                >"$H7_SK/hermes/ripwire-decoy-map/SKILL.md"
+H7_HOME="$TMP/hermes-home-7"; rm -rf "$H7_HOME"; mkdir -p "$H7_HOME/skills"
+# the user's OWN skill, a regular file (what `ln -sfn` silently removes), with a sentinel to read back.
+printf 'USER SKILL — must survive a ripwire install\n' >"$H7_HOME/skills/notes"
+HERMES_HOME="$H7_HOME" bash "$H7_SK/install.sh" --hermes >"$TMP/h7.out" 2>&1
+# (a) mutation took: the decoy loop really ran, and really links a ripwire-prefixed Hermes-native skill.
+#     Without this the arm is CONTRIBUTING §2 shape 1 — "nothing was installed" would read as a pass.
+{ [ -L "$H7_HOME/skills/ripwire-decoy-map" ] && [ -f "$H7_HOME/skills/ripwire-decoy-map/SKILL.md" ]; } \
+    && ok "the Hermes-native loop linked the planted ripwire-decoy-map (the arm's negative results are not an empty loop)" \
+    || no "the Hermes-native loop did not link the planted ripwire-decoy-map — this arm is measuring a loop that never ran"
+# (b) the property: a non-ripwire-* entry under skills/hermes/ is NOT linked, and the user's file survives.
+{ [ ! -L "$H7_HOME/skills/notes" ] && [ -f "$H7_HOME/skills/notes" ] \
+      && grep -q 'USER SKILL' "$H7_HOME/skills/notes"; } \
+    && ok "a non-ripwire-* entry under skills/hermes/ is skipped — the user's own 'notes' skill is untouched" \
+    || no "the Hermes-native loop linked 'notes' over the user's own file (ln -sfn removed it), and the ripwire-* prune loop can never take it back out"
+# (c) and it is not claimed in the manifest either — the manifest loop globs the same set as the install loop.
+{ ! grep -qx 'skill=notes' "$H7_HOME/skills/.ripwire-manifest-v1" 2>/dev/null; } \
+    && ok "the --hermes manifest does not claim the non-ripwire-* 'notes' entry" \
+    || no "the --hermes manifest claims 'skill=notes', a name this installer does not own"
+{ grep -qx 'skill=ripwire-decoy-map' "$H7_HOME/skills/.ripwire-manifest-v1" 2>/dev/null; } \
+    && ok "the --hermes manifest claims the ripwire-* Hermes-native skill it linked" \
+    || no "the --hermes manifest omits ripwire-decoy-map, which it linked"
 
 [ "$fail" -eq 0 ] && echo "hermesinstallcheck: ALL PASS" || { echo "hermesinstallcheck: FAILURES"; exit 1; }


### PR DESCRIPTION
Three fixes. The first is an honesty defect that shipped in v0.6.0.

## `--connect`'s `est_tokens` stopped covering the document the moment a file went unindexed

Commit `382e66e6` (issue #66) added the `graph_unindexed` attribute **and** a ~185 B legend comment to
`--connect`'s document, and raised `kConnectRootBytes` 260 → 285 for the *attribute only*. The comment was
never charged. So on any corpus with an unindexed file the printed `est_tokens=`, the `--max-tokens` fit
check and the `over_ceiling="1"` decision all measured a smaller document than was emitted.

Measured on the shipped v0.6.0 binary, and on a true matched pair of corpora — identical but for one
unreadable file:

| | document | `est_tokens` | modelled (×2.5) | actual − modelled |
| --- | --- | --- | --- | --- |
| v0.6.0, 0 unindexed | 2549 B | 1068 | 2670 | −121 (conservative) |
| v0.6.0, 1 unindexed | 2754 B | 1068 | 2670 | **+84 (optimistic)** |

The estimate was not merely wrong by 84 B — it was **frozen**, identical across a 205 B growth (185 B comment
+ 20 B attribute). `connectEstTokens`' own header names this exact failure class.

The fix is one term, but the shape matters: the legend is now held in a **named string that both the charge
and the write read**, so the counted bytes and the emitted bytes are the same object and cannot drift apart
again. After: est rises 1068 → 1142, conservative by 101 B; all four corpora tested are conservative
(−121, −101, −119, −100 B).

New `estchargecheck` arm #17 covers it. One note on how it is built: the first spelling used fixture
directories named `clean` and `unindexed`, and **the arm passed while the defect was fully present** — the
crawl root is echoed into `root="…"`, those bytes are themselves charged, and four characters of path
difference were enough to satisfy a monotone check. Equal-length fixture names (`unindexed_0` /
`unindexed_1`) are what make both arms go red on `main`.

## The Hermes install loop linked anything under `skills/hermes/`

`skills/install.sh` globbed `"$src"/hermes/*/` while the flat loop and the prune loop both used
`ripwire-*`. Today that directory holds only `ripwire-repo-map`, so nothing was at risk — but a future
non-`ripwire-`-prefixed entry would be `ln -sfn`'d over a same-named **user** skill (`ln -sfn` removes an
existing regular file first) and would never be pruned. Gate arm 7 plants a `notes` entry and observes it
destroy the user's same-named file and get claimed in the manifest.

`test/hermesinstallcheck.sh`'s own `skill_names()` helper carried the same `hermes/*/` glob — a second,
independent model of what is shipped. It is retargeted too; left alone it would have disagreed with the
installer the moment such a directory appeared, and arm 1 would have gone red for the wrong reason.

## Two comments describing code that is no longer there

`src/resolve.h` still advertised a "sorted, **deduped** set" and a "re-sorted+deduped" pass; the dedup is
gone, replaced by the epoch stamp. And `src/situ.h` still hand-folded `ambOut`/`unresolvedOut` a few lines
above the call that uses `graphGaugeTotals` — the shared fold introduced by the *same* commit as the defect
above, specifically to kill that clone pair. It now uses the fold, proved value-identical: byte-identical
`--situ` stdout and stderr on a corpus with non-trivial gauges (7594 / 4202 / 218), and cross-checked equal
to the XML dialect on the same corpus.

## Verification

616 gates: 613 pass, 3 skip, 0 fail. Determinism ×3 byte-identical, warm == cold, `xmllint` clean,
`gatecount_build --check` and `limits_build --check` green. **The gate count is unchanged at 602** — both
gates were extended rather than added, so this branch carries no landing conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
