### PR TITLE
docs(readme): the call for help says what to run, in fewer words

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,24 @@ minified XML map, and a gate that demanded two runs be byte-identical. It shippe
 ---
 
 > **Want to help?** ripwire is twelve weeks old — first commit 2026-06-19, public since 2026-07-31 — and there is a
-> lot worth doing. Some of what we know needs doing is written up as a starter kit: the research is done, the file
-> and line pointers are in the prompt, and the prompt writes a plan and stops, so we can agree the approach before
-> you write any code.
+> lot worth doing. Twenty open problems are written up as starter kits: the research is done, the file and line
+> pointers are in the prompt, and **each prompt writes a plan and stops**, so we can agree the approach before you
+> write any code.
 >
-> Some of it is ordinary and useful — a language, a resolver bug, a fuzzer, better docs. One part we think has much
-> further to go is the quality lens: measuring what a change makes *worse* — duplication, dead code, nesting, a
-> helper quietly reinvented — and handing that back while the code is still being written. That is the most direct
-> lever we know on whether an agent writes code you would keep, and it is the part we would most like help thinking
-> about.
+> ```bash
+> git clone https://github.com/redhat-et/ripwire && cd ripwire
+> cmake -S . -B build && cmake --build build -j     # plain build, no build type
+> ls prompts/help-wanted/                           # twenty kits — pick one
+> claude "follow prompts/help-wanted/zig-language.md"     # or your agent of choice
+> ```
 >
-> Browse [help wanted](https://github.com/redhat-et/ripwire/labels/help%20wanted) — three are marked
-> [good first issue](https://github.com/redhat-et/ripwire/labels/good%20first%20issue). Languages, performance,
-> correctness, fuzzing, docs: pick what you enjoy.
+> Plenty of it is ordinary and useful — a language, a resolver bug, a fuzzer, better docs. The part we would most
+> like help thinking about is the quality lens: measuring what a change makes *worse* — duplication, dead code,
+> nesting, a helper quietly reinvented — and handing that back while the code is still being written.
+>
+> [help wanted](https://github.com/redhat-et/ripwire/labels/help%20wanted) ·
+> [good first issue](https://github.com/redhat-et/ripwire/labels/good%20first%20issue) (three) ·
+> [all twenty prompts](prompts/help-wanted/)
 
 ---
 


### PR DESCRIPTION
The help-wanted block described the starter kits at length and never showed anyone how to start one.

It now carries the four commands that get from a clone to a running prompt — clone, plain build, list the
kits, hand one to your agent — and the prose around them is shorter for it: two paragraphs instead of three,
and the three closing sentences collapse to a single line of links.

"Twenty" is the measured count of `prompts/help-wanted/*.md`, not a round number.

The example names `claude` with `# or your agent of choice` beside it, because a line you can paste is what
makes the block useful and the prompts are written for whatever agent you already have.

README.md is a corpus here, not just a page: twenty-seven gates parse it, and the recall gates rank passages
out of it, so prose edits can move their statistics. Verified green before pushing — `readmedriftcheck`,
`readmeexamplecheck`, `recalltotalcheck`, `recallevalcheck`, `recallrankdepthcheck`, `ripwirepubliccheck`,
`gatecountcheck` and `docdriftcommentcheck` all rc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
