### PR TITLE
docs(readme): the call for help asked before the reader had seen what they would help with

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,43 +56,6 @@ contributors named there; this release is largely theirs.
 
 ---
 
-> **Want to help?** Start anywhere on the spectrum. At the ready-made end, twenty open problems — languages,
-> resolver bugs, fuzzers, docs — are written up as starter kits: the research is done, the file and line pointers
-> are in the prompt, and **each prompt writes a plan and stops**, so we can agree the approach before you write any
-> code.
->
-> ```bash
-> git clone https://github.com/redhat-et/ripwire && cd ripwire
-> cmake -S . -B build && cmake --build build -j     # plain build, no build type
-> ls prompts/help-wanted/                           # twenty kits — pick one
-> claude "follow prompts/help-wanted/zig-language.md"     # or your agent of choice
-> ```
->
-> In the middle, a few prompts hand your agent the whole repository and a job to do:
->
-> - **[Full audit](prompts/full-audit.md)** — six independent lenses over the codebase; take one, or all six.
-> - **[Add a language](prompts/add-a-language.md)** — a vendored grammar, extraction and gates, start to finish.
-> - **[Use it for real, log every gap](prompts/dogfood-gaps.md)** — do an actual task with ripwire and write down
->   every place it let you down.
->
-> At the other end, bring your own:
->
-> - research an idea you have been turning over
-> - bring in a paper that deserves to be in a tool
-> - show how AI agents could read and write better code
-> - automate something decades of software engineering already know
-> - check software algorithmically — a smell nobody measures yet, a way to prove an answer is complete, a bug class
->   a tool could catch before a reviewer does
->
-> Open an issue; we want to hear it. The part we would most like help thinking about is the quality lens: measuring
-> what a change makes *worse*, and handing that back while the code is still being written.
->
-> [help wanted](https://github.com/redhat-et/ripwire/labels/help%20wanted) ·
-> [good first issue](https://github.com/redhat-et/ripwire/labels/good%20first%20issue) (three) ·
-> [all twenty prompts](prompts/help-wanted/)
-
----
-
 <p align="center"><img src="docs/assets/no-deps.svg"
   alt="No API key. No embeddings. No index server. No daemon." width="470"></p>
 
@@ -1166,6 +1129,43 @@ Full citation table, evidence tiers, and what got measured and *withdrawn* (a na
 flagged this repository's best-named functions, kept as the standing argument for measuring before
 shipping) → [`docs/LINEAGE.md`](docs/LINEAGE.md).
 </details>
+
+---
+
+> **Want to help?** Start anywhere on the spectrum. At the ready-made end, twenty open problems — languages,
+> resolver bugs, fuzzers, docs — are written up as starter kits: the research is done, the file and line pointers
+> are in the prompt, and **each prompt writes a plan and stops**, so we can agree the approach before you write any
+> code.
+>
+> ```bash
+> git clone https://github.com/redhat-et/ripwire && cd ripwire
+> cmake -S . -B build && cmake --build build -j     # plain build, no build type
+> ls prompts/help-wanted/                           # twenty kits — pick one
+> claude "follow prompts/help-wanted/zig-language.md"     # or your agent of choice
+> ```
+>
+> In the middle, a few prompts hand your agent the whole repository and a job to do:
+>
+> - **[Full audit](prompts/full-audit.md)** — six independent lenses over the codebase; take one, or all six.
+> - **[Add a language](prompts/add-a-language.md)** — a vendored grammar, extraction and gates, start to finish.
+> - **[Use it for real, log every gap](prompts/dogfood-gaps.md)** — do an actual task with ripwire and write down
+>   every place it let you down.
+>
+> At the other end, bring your own:
+>
+> - research an idea you have been turning over
+> - bring in a paper that deserves to be in a tool
+> - show how AI agents could read and write better code
+> - automate something decades of software engineering already know
+> - check software algorithmically — a smell nobody measures yet, a way to prove an answer is complete, a bug class
+>   a tool could catch before a reviewer does
+>
+> Open an issue; we want to hear it. The part we would most like help thinking about is the quality lens: measuring
+> what a change makes *worse*, and handing that back while the code is still being written.
+>
+> [help wanted](https://github.com/redhat-et/ripwire/labels/help%20wanted) ·
+> [good first issue](https://github.com/redhat-et/ripwire/labels/good%20first%20issue) (three) ·
+> [all twenty prompts](prompts/help-wanted/)
 
 ---
 


### PR DESCRIPTION
The "Want to help?" block sat directly under the release line. A first-time reader was asked to pick a starter kit before the page had shown what ripwire answers, how to run it, or the quality panel.

It now follows `## The quality panel`, just before `## Real runs`. By then the reader has seen the tool work, and the block's closing line, that the quality lens is the part we most want help thinking about, lands right after the section that shows it.

The change is a pure move: the same 34 lines, framed by the same `---` rules, with no wording changes. The README's line multiset is identical before and after.

Verification: the 27 gates that read `README.md` pass on this tree (`gates=27 pass=27 skip=0 fail=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
