### PR TITLE
fix(legend): compact answers carried declined_calls=, unproven_defs= and four more with no definition

### DIFF
--- a/src/compactlegend.h
+++ b/src/compactlegend.h
@@ -19,11 +19,12 @@
 // already carries schema= is left alone entirely — the layer never double-compacts.
 //
 // THE COMPLETENESS VOCABULARY is emitted present-only: a term rides the legend iff the payload carries the
-// attribute. The counts_floor reading keeps floormarkcheck's anchor ("is a FLOOR, never a total") verbatim —
-// one attribute, one reading, in both dialects (lane L4's law).
+// attribute (or, for a MapHeaderRead term, iff the kept map header carries the field). The counts_floor reading
+// keeps floormarkcheck's anchor ("is a FLOOR, never a total") verbatim — one attribute, one reading, in both
+// dialects (lane L4's law).
 //
 // CONSUMERS: main.cpp (CLI — stdout is captured for the run and rewritten once), mcp.h (the textResult
-// envelope, under the opt-in `legend:"compact"` argument). Gate: test/compactlegendcheck.sh (U)/(L)/(M).
+// envelope, under the opt-in `legend:"compact"` argument). Gate: test/compactlegendcheck.sh (U)/(L)/(M)/(D)/(S).
 
 #include <cctype>
 #include <cstddef>
@@ -193,15 +194,27 @@ inline bool isCompactProseComment( std::string_view comment ) noexcept
     return false;
 }
 
+// Where a term is read BESIDES the head: the map header. serialize.h buildStats writes the map's gauges as unquoted
+// `name=N` fields of one comment, `<!-- files=… -->`, which this layer keeps as DATA, while the `<!-- hdr:` clauses (and
+// the always-on legend's hdr: half) that define those fields are prose and go.
+enum class MapHeaderRead : std::uint8_t
+{
+    No,     // the head (and, with wholeDoc or onTag, the payload) only
+    Also,   // the head OR the header: est_tokens= rides the header alone under order=stable, over_ceiling= under max-tokens
+    Only,   // the header alone: extent_suspect_syms=, macro_blanked_files=, max_tokens=, external= are DIFFERENT quoted
+            // attributes on other verbs (a hotspots row, the skipped root, the for root, a uses row)
+};
+
 // The completeness vocabulary: attribute → terse reading. Emitted present-only, in this order. The counts_floor
 // reading carries floormarkcheck's BRIEF_ANCHOR verbatim ("is a FLOOR, never a total").
 struct CompactCompletenessTerm
 {
     std::string_view attr;
     std::string_view reading;
-    bool             wholeDoc = false;   // a ROW-level term (amb=, parse_degraded=, dangling=): read anywhere in the payload
-    std::string_view onTag    = {};      // read ONLY on this element and never on the head: label= on the multi-root <root>
-                                         // rows is not the label= --communities carries on its first child
+    bool             wholeDoc  = false;   // a ROW-level term (amb=, parse_degraded=, dangling=): read anywhere in the payload
+    std::string_view onTag     = {};      // read ONLY on this element and never on the head: label= on the multi-root <root>
+                                          // rows is not the label= --communities carries on its first child
+    MapHeaderRead    mapHeader = MapHeaderRead::No;
 };
 
 inline constexpr CompactCompletenessTerm kCompactCompletenessTerms[] =
@@ -229,8 +242,10 @@ inline constexpr CompactCompletenessTerm kCompactCompletenessTerms[] =
     // row attribute that exists only beside member=, so one head term defines the whole form.
     { "member",            "member=Owner.field: rows use that field; pinned=/amb_sites= rows with one owner/with owner_candidates=K; owners_of_name= fields so named" },
     { "hits_capped",       "hits_capped=1: hits= is a floor" },
-    { "est_tokens",        "est_tokens=: price as emitted (an upper bound under compact)" },
-    { "over_ceiling",      "over_ceiling=1: budget not met" },
+    // Both also ride the map header: est_tokens= alone there under order=stable (the root drops it), over_ceiling=1 there
+    // under max-tokens. Same number, same reading, so one row reads both places.
+    { "est_tokens",        "est_tokens=: price as emitted (an upper bound under compact)", false, {}, MapHeaderRead::Also },
+    { "over_ceiling",      "over_ceiling=1: budget not met", false, {}, MapHeaderRead::Also },
     // M1 (terminality round A, 2026-09-05): the ranked head's own floor — how many rank>0 candidates the
     // ceiling ladder cut. It rides the root on --for and (since M1) on --pack-task/explore too, so the
     // compact dialect has to define it wherever it appears, or the default answer names a number with no
@@ -242,6 +257,28 @@ inline constexpr CompactCompletenessTerm kCompactCompletenessTerms[] =
     // The multi-root roots table (serialize.h writeMultiRootTable): its `<!-- root rows:` clause is prose-stripped above
     // and nothing put the reading back. ELEMENT-qualified, because --communities carries a different label= on its rows.
     { "label",             "<root label= p=>: a workspace root; label= prefixes every p=/id=", true, "root" },
+    // THE MAP FAMILY AND --impact (2026-09-12), the same defect a second time. prconverge.h's clause rides as the map's
+    // `<!-- pr_iters=` comment and inside every other ranked verb's legend, prose either way, so pr_iters= reached every
+    // compact PageRank root undefined (--impact is an (L) loop verb, which is why its reading is this short).
+    // pr_converged="0" rides only a ranking that stopped at the iteration cap.
+    { "pr_iters",          "pr_iters=N: PageRank iterations" },
+    { "pr_converged",      "pr_converged=0: iteration cap hit before convergence" },
+    // Form-conditional map roots whose clauses (kRankByDisclosure, kChurnRankLegend, --around's seed block) are prose.
+    // window= and defs= are ELEMENT-qualified: --hotspots carries window= and --callers defs=, each meaning something else.
+    { "rank_by",           "rank_by=: the ranker behind k=" },
+    { "window",            "window=: the git span mined", true, "r" },
+    { "defs",              "defs=N: of= names N defs; the lowest-id one was walked", true, "r" },
+    // The map HEADER's absent-at-zero gauges: `<!-- files=` is kept as data while the `<!-- hdr:` clauses that define
+    // these fields go (kDeclinedMapLegend, kIgnoredLegend, kExtentSuspectHdrLegend, kMacroBlankedHdrLegend, the absent-if-0
+    // half of the always-on legend, kMaxTokensFitLegend). Header-ONLY: several are quoted attributes elsewhere.
+    { "declined",          "declined=K: K calls left unbound (several defs, none chosen)", false, {}, MapHeaderRead::Only },
+    { "external",          "external=K: K calls taken as outside the tree, no edge", false, {}, MapHeaderRead::Only },
+    { "locality_pinned",   "locality_pinned=K: K calls pinned by locality alone (a guess)", false, {}, MapHeaderRead::Only },
+    { "extent_suspect_syms", "extent_suspect_syms=K: K defs failed containment, corpus-wide", false, {}, MapHeaderRead::Only },
+    { "macro_blanked_files", "macro_blanked_files=K: K files indexed from a macro-blanked re-parse", false, {}, MapHeaderRead::Only },
+    { "ignored_files",     "ignored_files=K: K files git's ignore rules dropped", false, {}, MapHeaderRead::Only },
+    { "ignored_dirs",      "ignored_dirs=K: K subtrees git's ignore rules pruned, contents unknown", false, {}, MapHeaderRead::Only },
+    { "max_tokens",        "max_tokens=/fit_bytes=: tokens asked/the byte cap applied", false, {}, MapHeaderRead::Only },
     { "parse_degraded",    "parse_degraded=1: ERROR nodes in that parse", true },
     { "tier_partial",      "tier_partial=1: tier elected under a partial classification" },
     { "dangling",          "dangling=1: matches nothing indexed", true },
@@ -352,16 +389,23 @@ inline std::string_view compactDocHead( std::string_view doc, const CompactRootI
     return doc.substr( root.openBegin, end - root.openBegin );
 }
 
-// Does `head` carry ` <attr>="`? Matched at a tag boundary — a leading space and a trailing `="` — so `capped`
-// never matches `hits_capped`.
-inline bool headHasAttr( std::string_view head, std::string_view attr )
+// Does `span` carry ` <attr>=<tail>`? Matched after a leading space, so `capped` never matches `hits_capped` and `bytes`
+// never matches `fit_bytes`. The head reads a quoted attribute (tail `"`); the map header an unquoted field (no tail).
+inline bool spanHasAttr( std::string_view span, std::string_view attr, std::string_view tail )
 {
     std::string needle;
-    needle.reserve( attr.size() + 3 );
+    needle.reserve( attr.size() + tail.size() + 2 );
     needle += ' ';
     needle.append( attr );
-    needle += "=\"";
-    return head.find( needle ) != std::string_view::npos;
+    needle += '=';
+    needle.append( tail );
+    return span.find( needle ) != std::string_view::npos;
+}
+
+// Does `head` carry ` <attr>="`? Matched at a tag boundary — a leading space and a trailing `="`.
+inline bool headHasAttr( std::string_view head, std::string_view attr )
+{
+    return spanHasAttr( head, attr, "\"" );
 }
 
 // Any payload attribute ending in `_capped` (tests_capped=, importers_capped=, …) — their names, joined by '/'.
@@ -466,6 +510,46 @@ inline bool payloadHasAnyAttr( std::string_view doc, std::string_view attr, std:
     return false;
 }
 
+// The opener of the map header's data comment (serialize.h buildStats, its one emitter).
+inline constexpr std::string_view kCompactMapHeaderOpener = "<!-- files=";
+
+// The map header comment (before the root, or trailing under order=stable), or empty when the document has none: every
+// verb outside the map family and the bundles that embed it. A well-formed document spells `<!--` raw only in a comment
+// or a CDATA body, and a comment cannot hold `--`, so the first hit outside CDATA IS the header.
+inline std::string_view compactMapHeader( std::string_view doc ) noexcept
+{
+    for( std::size_t hit = doc.find( kCompactMapHeaderOpener ); hit != std::string_view::npos; hit = doc.find( kCompactMapHeaderOpener, hit + 1 ) )
+    {
+        const std::size_t cdataOpen = doc.rfind( "<![CDATA[", hit );
+        const bool        isInCdata = cdataOpen != std::string_view::npos && doc.find( "]]>", cdataOpen ) > hit;
+        if( !isInCdata )
+        {
+            const std::size_t close = doc.find( "-->", hit );
+            return doc.substr( hit, close == std::string_view::npos ? doc.size() - hit : close + 3 - hit );
+        }
+    }
+    return {};
+}
+
+// Does this document carry term `t`? An element-qualified term reads its element alone (the head can carry the same NAME
+// as a different attribute); a map-header term reads the kept header's unquoted field too (Also) or instead (Only).
+inline bool isCompletenessTermPresent( const CompactCompletenessTerm& t, std::string_view head, std::string_view doc, std::string_view mapHeader )
+{
+    if( t.mapHeader != MapHeaderRead::No && spanHasAttr( mapHeader, t.attr, {} ) )
+    {
+        return true;
+    }
+    if( t.mapHeader == MapHeaderRead::Only )
+    {
+        return false;
+    }
+    if( !t.onTag.empty() )
+    {
+        return payloadHasAnyAttr( doc, t.attr, t.onTag );
+    }
+    return headHasAttr( head, t.attr ) || ( t.wholeDoc && payloadHasAnyAttr( doc, t.attr ) );
+}
+
 // The ≤400 B compact legend for one document.
 inline std::string compactLegendText( const CompactLegendSpec& spec, std::string_view head, std::string_view doc )
 {
@@ -511,12 +595,10 @@ inline std::string compactLegendText( const CompactLegendSpec& spec, std::string
         out += subcaps;
         out += ": 1 = cut.";
     }
+    const std::string_view mapHeader = compactMapHeader( doc );
     for( const CompactCompletenessTerm& t : kCompactCompletenessTerms )
     {
-        // an element-qualified term reads its element alone: the head can carry the same NAME as a different attribute
-        const bool isPresent = t.onTag.empty() ? ( headHasAttr( head, t.attr ) || ( t.wholeDoc && payloadHasAnyAttr( doc, t.attr ) ) )
-                                               : payloadHasAnyAttr( doc, t.attr, t.onTag );
-        if( isPresent )
+        if( isCompletenessTermPresent( t, head, doc, mapHeader ) )
         {
             out += ' ';
             out.append( t.reading );

--- a/src/compactlegend.h
+++ b/src/compactlegend.h
@@ -159,7 +159,9 @@ inline constexpr std::string_view kCompactProsePrefixes[] =
     "<!-- max_tokens=",                // --max-tokens' fit_bytes block
     "<!-- with-profile: ",             // --with-profile's heat_* block
     "<!-- slice-",                     // slice's seed/flow/since FULL-dialect tiers (slice-seed:/slice-flow:/slice-since:)
-    "<!-- root rows: ",                // --stray-content's root-row block
+    "<!-- root rows: ",                // the multi-root roots table's reading (serialize.h kMultiRootTableLegend, the one
+                                       // emitter of this opener); the completeness table's element-qualified label= row
+                                       // restates it
     "<!-- multi-root workspace: ",     // the multi-root churn note
     "<!-- hdr:",                       // the map header's ignored_files definition
     "<!-- format=columnar: ",          // the columnar re-serialization block
@@ -198,6 +200,8 @@ struct CompactCompletenessTerm
     std::string_view attr;
     std::string_view reading;
     bool             wholeDoc = false;   // a ROW-level term (amb=, parse_degraded=, dangling=): read anywhere in the payload
+    std::string_view onTag    = {};      // read ONLY on this element and never on the head: label= on the multi-root <root>
+                                         // rows is not the label= --communities carries on its first child
 };
 
 inline constexpr CompactCompletenessTerm kCompactCompletenessTerms[] =
@@ -210,6 +214,20 @@ inline constexpr CompactCompletenessTerm kCompactCompletenessTerms[] =
     // which is also what kept it invisible: the compact dialect stripped the full clause and had nothing to
     // put back, on every verb, for the whole of v0.6.0.
     { "graph_unindexed",   "graph_unindexed=N: N files no grammar could read (the map header's unindexed=); their calls raise neither gauge" },
+    // THE COUNT QUALIFIERS the graph_unindexed row above did not bring along (2026-09-12). Each is absent at zero and
+    // its full clause rides only a document that carries it (graphlegend.h declinedCallsLegend( bool ),
+    // unprovenDefsLegend( bool ), the callees-only clause of callHierarchyLegendOpen( bool )), so the prose strip removed
+    // a definition this table never put back: --callers/--callees/--impact, their columnar forms and the MCP impact
+    // default all printed these numbers undefined. test/compactlegendcheck.sh (S) reads every conditional attribute the
+    // graphlegend.h family emits from source and fails the next one that lands without a row here.
+    // Written to the shortest honest form: a document carrying these is already near the 400 B ceiling, and the
+    // callees answer can carry the first two at once.
+    { "bodyless_defs",     "bodyless_defs=K: K of defs= have no body, so no callees to read" },
+    { "unproven_defs",     "unproven_defs=K: K same-named defs not tied to that file, in no count or row (bare name shows them)" },
+    { "declined_calls",    "declined_calls=K: K call sites left unbound (several defs, none chosen), in no count or row" },
+    // --uses=Owner.field's member form (fielduses.h appends kUsesFieldLegend to that answer alone). owner_candidates= is a
+    // row attribute that exists only beside member=, so one head term defines the whole form.
+    { "member",            "member=Owner.field: rows use that field; pinned=/amb_sites= rows with one owner/with owner_candidates=K; owners_of_name= fields so named" },
     { "hits_capped",       "hits_capped=1: hits= is a floor" },
     { "est_tokens",        "est_tokens=: price as emitted (an upper bound under compact)" },
     { "over_ceiling",      "over_ceiling=1: budget not met" },
@@ -221,6 +239,9 @@ inline constexpr CompactCompletenessTerm kCompactCompletenessTerms[] =
     { "withheld",          "withheld=: rows the budget cut" },
     { "at",                "at=: commit+dirty+shallow" },
     { "root",              "root=: p= relative to it" },
+    // The multi-root roots table (serialize.h writeMultiRootTable): its `<!-- root rows:` clause is prose-stripped above
+    // and nothing put the reading back. ELEMENT-qualified, because --communities carries a different label= on its rows.
+    { "label",             "<root label= p=>: a workspace root; label= prefixes every p=/id=", true, "root" },
     { "parse_degraded",    "parse_degraded=1: ERROR nodes in that parse", true },
     { "tier_partial",      "tier_partial=1: tier elected under a partial classification" },
     { "dangling",          "dangling=1: matches nothing indexed", true },
@@ -231,6 +252,11 @@ inline constexpr CompactCompletenessTerm kCompactCompletenessTerms[] =
     // always rides and can define hub="1" in the same clause — two terms did not fit the 400 B ceiling, and
     // the ceiling is the point of this dialect. The full legend carries the derivation.
     { "hub_floor",         "hub_floor=D: connects= >= D is hub=1, vacuous" },
+    // --lego's contract caveat (serialize.h, on the <iface> row): the attribute pair rides only a NAMED interface whose
+    // language's method contract is not read, and no purpose line names it. ELEMENT-qualified, not a head term: the head
+    // span holds the full legend comment between <ctx> and its first child, and kLegoLegend spells caveat="…" in it, so
+    // a head read fired on every --lego answer (compactlegendcheck (D7) caught it on --lego=Point).
+    { "caveat",            "methods=0 caveat=not-extracted-for-lang: no <m> contract read for this language", true, "iface" },
     { "next",              "next=: the one pasteable follow-up", true },
     { "scrubbed",          "scrubbed=1: this CDATA is not the bytes (]]> split or C0 replaced)", true },
     { "preview",           "preview=1: an UNWRITTEN payload; <overwrite l= end= bytes=> = the span an apply replaces, CDATA as on disk (shown=/capped=1/elided_lines= when cut)" },
@@ -388,8 +414,23 @@ inline std::string payloadSubCapAttrs( std::string_view doc )
     return names;
 }
 
-// Row-level terms: does ANY tag outside comments/CDATA carry ` <attr>="`?
-inline bool payloadHasAnyAttr( std::string_view doc, std::string_view attr )
+// Is `tag` (one `<…>` span) an element named `name`? An empty name matches every element.
+inline bool isElementNamed( std::string_view tag, std::string_view name ) noexcept
+{
+    if( name.empty() )
+    {
+        return true;
+    }
+    if( tag.size() < name.size() + 2 || tag[ 0 ] != '<' || tag.substr( 1, name.size() ) != name )
+    {
+        return false;
+    }
+    const char next = tag[ name.size() + 1 ];
+    return next == ' ' || next == '/' || next == '>';
+}
+
+// Row-level terms: does ANY tag outside comments/CDATA carry ` <attr>="`? With `onTag`, only a `<onTag …>` element counts.
+inline bool payloadHasAnyAttr( std::string_view doc, std::string_view attr, std::string_view onTag = {} )
 {
     std::string needle;
     needle.reserve( attr.size() + 3 );
@@ -413,7 +454,7 @@ inline bool payloadHasAnyAttr( std::string_view doc, std::string_view attr )
         {
             const std::size_t j = doc.find( '>', i );
             const std::string_view tag = doc.substr( i, j == std::string_view::npos ? doc.size() - i : j + 1 - i );
-            if( tag.find( needle ) != std::string_view::npos ) { return true; }
+            if( tag.find( needle ) != std::string_view::npos && isElementNamed( tag, onTag ) ) { return true; }
             i = j == std::string_view::npos ? doc.size() : j + 1;
         }
         else
@@ -472,7 +513,10 @@ inline std::string compactLegendText( const CompactLegendSpec& spec, std::string
     }
     for( const CompactCompletenessTerm& t : kCompactCompletenessTerms )
     {
-        if( headHasAttr( head, t.attr ) || ( t.wholeDoc && payloadHasAnyAttr( doc, t.attr ) ) )
+        // an element-qualified term reads its element alone: the head can carry the same NAME as a different attribute
+        const bool isPresent = t.onTag.empty() ? ( headHasAttr( head, t.attr ) || ( t.wholeDoc && payloadHasAnyAttr( doc, t.attr ) ) )
+                                               : payloadHasAnyAttr( doc, t.attr, t.onTag );
+        if( isPresent )
         {
             out += ' ';
             out.append( t.reading );

--- a/test/compactlegendcheck.sh
+++ b/test/compactlegendcheck.sh
@@ -26,9 +26,11 @@
 # everything else must refuse it. LOOP arm (L): the ten-verb loop's compact legend bill ≤ 4,100 B (was 29,824
 # on the ripwire tree). MCP arm (M): edit_check with legend:"compact" answers in ≤ 900 B on a clean tree.
 # CONDITIONAL arm (D): an absent-at-zero or form-conditional attribute (declined_calls=, unproven_defs=, bodyless_defs=,
-# the member form, the multi-root <root label=> rows, --lego's caveat=) is DEFINED by the compact legend of a document
-# that carries it, and by none that does not. STRUCTURAL arm (S): every conditional attribute the graphlegend.h helper
-# family emits, read from source, has a compact reading — so the next one cannot land undefined.
+# the member form, the multi-root <root label=> rows, --lego's caveat=; on the map family and --impact: pr_iters=,
+# pr_converged=, the map header's gauges, --around's defs=, --rank-by's rank_by=/window=) is DEFINED by the compact legend
+# of a document that carries it, and by none that does not. STRUCTURAL arm (S): every conditional attribute the
+# graphlegend.h helper family emits, the PageRank disclosure, and every conditional hdr: field of the map header, read
+# from source, has a compact reading — so the next one cannot land undefined.
 #
 # Usage:  RIPWIRE_BIN=build/ripwire bash test/compactlegendcheck.sh
 
@@ -573,21 +575,28 @@ cat > "$TMP/condattr.py" <<'PY'
 import re, sys
 op, path, spec = sys.argv[1], sys.argv[2], sys.argv[3]
 buf = open( path, encoding = "utf-8", errors = "replace" ).read()
-legend, tags = [], []
+legend, tags, header = [], [], []
 i = 0; n = len( buf )
 while i < n:
     if buf.startswith( "<![CDATA[", i ):
         j = buf.find( "]]>", i ); i = n if j < 0 else j + 3
     elif buf.startswith( "<!--", i ):
-        j = buf.find( "-->", i ); j = n if j < 0 else j + 3; legend.append( buf[ i:j ] ); i = j
+        # the map header (serialize.h buildStats, the one `<!-- files=` emitter) is DATA: a `#name` spec reads its fields,
+        # and it is never a definition — else every header row would be "defined" by the very number it asks about
+        j = buf.find( "-->", i ); j = n if j < 0 else j + 3
+        ( header if buf.startswith( "<!-- files=", i ) else legend ).append( buf[ i:j ] ); i = j
     elif buf[ i ] == "<":
         j = buf.find( ">", i ); j = n if j < 0 else j + 1; tags.append( buf[ i:j ] ); i = j
     else:
         j = buf.find( "<", i ); i = n if j < 0 else j
-tag, _, attr = spec.rpartition( ":" )
+isHdr = spec.startswith( "#" )   # `#name`: an UNQUOTED field of the map header, not an element attribute
+tag, _, attr = ( "", "", spec[ 1: ] ) if isHdr else spec.rpartition( ":" )
 def on( t ):   # a tag-qualified spec reads only that element: <root label=> is not <community label=>
     return not tag or re.match( r"<" + re.escape( tag ) + r"[\s/>]", t ) is not None
-vals = [ m.group( 1 ) for t in tags if on( t ) for m in [ re.search( r"\s" + re.escape( attr ) + r"=\"([^\"]*)\"", t ) ] if m ]
+if isHdr:
+    vals = [ m.group( 1 ) for h in header for m in [ re.search( r"\s" + re.escape( attr ) + r"=([^\s\"]+)", h ) ] if m ]
+else:
+    vals = [ m.group( 1 ) for t in tags if on( t ) for m in [ re.search( r"\s" + re.escape( attr ) + r"=\"([^\"]*)\"", t ) ] if m ]
 leg = " ".join( legend )
 if op == "carries":    print( 1 if vals else 0 )
 elif op == "value":    print( vals[ 0 ] if vals else "" )
@@ -601,7 +610,7 @@ condArm()
     local id="$1" label="$2" full="$3" comp="$4" spec attr bad=0 got=""
     shift 4
     for spec in "$@"; do
-        attr="${spec#*:}"
+        attr="${spec#*:}"; attr="${attr#\#}"
         if [ "$( ca carries "$full" "$spec" )" != 1 ] || [ "$( ca carries "$comp" "$spec" )" != 1 ]; then
             no "($id) $label: control broken — the answer does not carry $attr= in both postures, so its definition row would be vacuous: $( head -c 160 "$comp" )"
             bad=1; continue
@@ -652,6 +661,82 @@ condPair D4 "--uses=Counter.count (the member form)" "$FIELDS" "--uses=Counter.c
 condArm D5 "two roots, --callers=distance (the <root label= p=> table)" "$TMP/d.full" "$TMP/d.comp" root:label
 condPair D6 "--lego=Shape (Java: no method contract read)" "$LEGOJ" "--lego=Shape" iface:caveat iface:methods
 
+# ── THE MAP FAMILY AND --impact (2026-09-12, the second sweep of the class) ──────────────────────────────────────────
+# (D1)..(D6) closed the navigation verbs. The ranked documents carried the same defect in three more shapes, each
+# established by running 34a97f66 (carried, compact legend silent — the red rows are in the landing commit):
+#   • THE PAGERANK DISCLOSURE (prconverge.h). Its clause rides as the map's own `<!-- pr_iters=` comment and inside the
+#     verb legend of --impact and the ranked reports, prose either way — so pr_iters= reached every compact PageRank root
+#     undefined (--impact is an (L) loop verb), and pr_converged="0" with it on the one document whose order is an
+#     unfinished computation. That exit is unreachable by any INPUT at the shipped ceiling (test/prconvergecheck.sh
+#     derives the bound), so (D9) arms it the way that gate does: RIPWIRE_TEST_PR_MAXITERS lowers the ceiling in every
+#     build flavour, and --no-cache keeps the truncated ranking out of this gate's warm blob.
+#   • THE MAP HEADER. `<!-- files=… -->` is DATA and compact keeps it, while the `<!-- hdr:` clauses (and the absent-if-0
+#     half of `<!-- ripwire v1`) that define its gauges are prose and go — declined=17 or over_ceiling=1 stayed on the
+#     page with no reading. A `#name` spec reads such a field; the data comment is never counted as its definition.
+#   • FORM-CONDITIONAL MAP ROOTS: --around's defs= (only when the seed name has >1 def), --rank-by's rank_by=, churn's
+#     window=. Each name is a DIFFERENT quoted attribute on other verbs (defs= on --callers, window= on --hotspots), so the
+#     `r:` spec reads the map root alone, as the reading must.
+IGN="$TMP/ignored"; mkdir -p "$IGN/gen"; cp -R "$FIX"/. "$IGN"/
+printf 'def hidden():\n    return 1\n' >"$IGN/hidden.py"; printf 'def g():\n    return 1\n' >"$IGN/gen/g.py"; printf 'hidden.py\ngen/\n' >"$IGN/.gitignore"
+( cd "$IGN" && git init -q && git config user.email "t@example.com" && git config user.name "t" && git add -A && git commit -q -m one ) >/dev/null 2>&1 \
+    || no "(D10) the .gitignore fixture's git setup failed — its ignored_files=/ignored_dirs= row would be vacuous"
+MHOT="$TMP/maphot"; MLEAK="$TMP/mapleak"; LPIN="$ROOT/test/lpinfix"; mkdir -p "$MHOT" "$MLEAK"
+cp "$ROOT"/test/extentfix/{leak.cpp,head.c,orphan.cpp,plain.cpp} "$MHOT/" 2>/dev/null || no "(D10) fixture missing: test/extentfix"
+cp "$ROOT"/test/macroreparsefix/{leak_anon.cpp,leak_plain.cpp,leak_lambda.cpp,leak_c.c,leak_objc.m,leak_cuda.cu,leak_partial.cpp} "$MLEAK/" 2>/dev/null \
+    || no "(D10) fixture missing: test/macroreparsefix"
+[ -d "$LPIN" ] || no "(D10) fixture missing: $LPIN — its locality_pinned= row would be vacuous"
+
+condPair D8 "the flagless map" "$FIX" "" pr_iters
+condPair D8 "--impact=distance (an (L) loop verb)" "$FIX" "--impact=distance" pr_iters
+condPair D8 "--communities (a ranked report root)" "$FIX" "--communities" pr_iters
+mcp_text impact "{\"path\":\"$FIX\",\"symbol\":\"distance\",\"legend\":\"full\"}" >"$TMP/d.full"
+mcp_text impact "{\"path\":\"$FIX\",\"symbol\":\"distance\"}" >"$TMP/d.comp"
+condArm D8 "MCP impact at its DEFAULT posture (compact) vs legend:\"full\"" "$TMP/d.full" "$TMP/d.comp" pr_iters
+export RIPWIRE_TEST_PR_MAXITERS=2
+condPair D9 "the flagless map under a lowered PageRank ceiling" "$FIX" "--no-cache" pr_converged pr_iters
+condPair D9 "--impact=distance under a lowered PageRank ceiling" "$FIX" "--impact=distance --no-cache" pr_converged pr_iters
+unset RIPWIRE_TEST_PR_MAXITERS
+condPair D10 "the map over test/declinefix" "$DECL" "" "#declined" "#external"
+condPair D10 "the map over test/lpinfix" "$LPIN" "" "#locality_pinned"
+condPair D10 "the map over test/extentfix" "$MHOT" "" "#extent_suspect_syms"
+condPair D10 "the map over test/macroreparsefix" "$MLEAK" "" "#macro_blanked_files"
+condPair D10 "the map over a git tree whose .gitignore cuts a file and a subtree" "$IGN" "" "#ignored_files" "#ignored_dirs"
+condPair D10 "--max-tokens=50 (the fit_bytes form)" "$FIX" "--max-tokens=50" "#max_tokens" "#fit_bytes" "#over_ceiling"
+condPair D10 "--order=stable (est_tokens= rides the trailing header alone)" "$FIX" "--order=stable" "#est_tokens"
+condPair D11 "--around=distance (the seed name has two defs)" "$FIX" "--around=distance" r:defs
+condPair D11 "--rank-by=hub (a HITS order)" "$FIX" "--rank-by=hub" r:rank_by
+condPair D11 "--rank-by=churn (a git-weighted PageRank)" "$REPO" "--rank-by=churn" r:rank_by r:window pr_iters
+
+# (D12) THE MIRROR for those readings — present-only, on documents chosen for what they LACK, and each lack is asserted
+# before it is relied on: --query=distance is a lexical order (no pr_iters=), --rank-by=hub a HITS order (rank_by= with no
+# pr_iters= or window=), --around=total_area a seed with one def (no defs=), --impact=distance the loop verb with no map
+# header at all, and the flagless map none of the header gauges this fixture never produces. Green on 34a97f66 by
+# construction, like (D7); its failing state is shown in the landing commit on a legend with a reading spliced in.
+[ "$( rrun --query=distance --legend=compact | grep -c ' pr_iters="' )" = 0 ] \
+    || no "(D12) control: --query=distance now carries pr_iters=, so it no longer proves the pr_iters= reading is present-only"
+rrun --rank-by=hub --legend=compact >"$TMP/d12.hub"
+[ "$( ca carries "$TMP/d12.hub" r:rank_by )" = 1 ] && [ "$( ca carries "$TMP/d12.hub" r:window )" != 1 ] \
+    || no "(D12) control: --rank-by=hub no longer carries rank_by= without window=, so its mirror row proves nothing"
+[ "$( rrun --around=total_area --legend=compact | grep -c '<r [^>]* defs="' )" = 0 ] \
+    || no "(D12) control: --around=total_area now carries defs=, so it no longer proves the defs= reading is present-only"
+d12bad=0; d12n=0
+for v in "" "--query=distance" "--rank-by=hub" "--around=total_area" "--impact=distance"; do
+    rrun $v --legend=compact >"$TMP/d12.c"
+    if [ ! -s "$TMP/d12.c" ]; then
+        no "(D12) ${v:-the flagless map} --legend=compact answered nothing — its mirror row would be vacuous"; d12bad=1; continue
+    fi
+    d12n=$(( d12n + 1 ))
+    for spec in pr_iters pr_converged "#declined" "#external" "#locality_pinned" "#extent_suspect_syms" "#macro_blanked_files" \
+                "#ignored_files" "#ignored_dirs" "#max_tokens" "#fit_bytes" "#over_ceiling" r:defs r:rank_by r:window; do
+        attr="${spec#*:}"; attr="${attr#\#}"
+        if [ "$( ca defines "$TMP/d12.c" "$attr" )" = 1 ] && [ "$( ca carries "$TMP/d12.c" "$spec" )" != 1 ]; then
+            no "(D12) ${v:-the flagless map}: the compact legend defines $attr= but the document carries no $spec — a reading of a field that is not there"
+            d12bad=1
+        fi
+    done
+done
+[ "$d12bad" -eq 0 ] && [ "$d12n" -eq 5 ] && ok "(D12) mirror: no map-family reading prints on $d12n answers that lack its field (lexical, HITS, one-def seed, --impact, the plain map)"
+
 # (D7) THE MIRROR — present-only. A reading printed on a document WITHOUT its attribute is the opposite false claim, and
 # these single-root answers are the (L) loop's own shapes. --communities is the row that proves the <root label=>
 # reading is ELEMENT-qualified: it carries label= on every <community> row, a different attribute under the same name.
@@ -665,7 +750,8 @@ for v in "--callers=distance" "--callees=distance" "--impact=distance" "--uses=d
         no "(D7) $v --legend=compact answered nothing — its mirror row would be vacuous"; d7bad=1; continue
     fi
     d7n=$(( d7n + 1 ))
-    for pair in "unproven_defs=|unproven_defs" "bodyless_defs=|bodyless_defs" "declined_calls=|declined_calls" "member=|member" "<root label=|root:label" "caveat=|caveat"; do
+    for pair in "unproven_defs=|unproven_defs" "bodyless_defs=|bodyless_defs" "declined_calls=|declined_calls" "member=|member" "<root label=|root:label" "caveat=|caveat" \
+                "pr_converged=|pr_converged"; do
         needle="${pair%%|*}"; spec="${pair#*|}"
         if [ "$( ca mentions "$TMP/d7.c" "$needle" )" = 1 ] && [ "$( ca carries "$TMP/d7.c" "$spec" )" != 1 ]; then
             no "(D7) $v: the compact legend spells '$needle' but the document carries no ${spec#*:}= — a definition of an attribute that is not there"
@@ -676,22 +762,35 @@ done
 [ "$d7bad" -eq 0 ] && [ "$d7n" -eq 6 ] && ok "(D7) mirror: no conditional reading prints on $d7n single-root answers that lack its attribute (incl. --communities' <community label=>)"
 
 echo
-echo "=== (S) STRUCTURAL: every conditional attribute the graphlegend.h helper family emits has a compact reading ==="
+echo "=== (S) STRUCTURAL: every conditional attribute the graphlegend.h family, the PageRank disclosure and the map header emit has a compact reading ==="
 # The (D) rows prove today's members; this row keeps the NEXT one from landing undefined. The population is READ FROM
-# SOURCE, never listed here, from the two places the family spells a conditional attribute:
+# SOURCE, never listed here, from the places a conditional attribute is spelled:
 #   1. every `countAttrXmlOrEmpty( "NAME"` call, tree-wide — the one absent-at-zero spelling graphlegend.h mandates;
 #   2. every legend constant graphlegend.h selects CONDITIONALLY — named in exactly one arm of a `?:` (a clause against
 #      "", or the callees-only half of callHierarchyLegendOpen) — reduced to the attribute its text opens with, the
-#      house form ("declined_calls=K (absent when 0) …", "callees-only: bodyless_defs= …").
-# Each must have a kCompactCompletenessTerms row, a paging-window name, or the *_capped rule (all read from
+#      house form ("declined_calls=K (absent when 0) …", "callees-only: bodyless_defs= …");
+#   3. (2026-09-12) the PageRank disclosure's XML spelling in src/prconverge.h, and every map-HEADER field src/serialize.h
+#      defines as `hdr:NAME=` in a clause charged only to a map that carries it, or marked absent-if-0 inside the
+#      always-on `<!-- ripwire v1` legend. pr_iters=/pr_converged= need a row that reads the head; a header field needs a
+#      row that reads the kept `<!-- files=` comment (MapHeaderRead::Only/Also), because a head-only row never sees an
+#      unquoted field — and a header-ONLY row is not coverage for a (1)/(2) name, which is a quoted attribute.
+# Each (1)/(2) name must have a kCompactCompletenessTerms row, a paging-window name, or the *_capped rule (all read from
 # src/compactlegend.h). The one other way to be defined is a full clause the compact layer KEEPS because it is not
 # prose-prefixed — --skipped's `<!-- why=…` health comments — and that is never taken on trust: each such name is run
 # live here and must be carried AND defined by the compact document, or the row fails.
 # WHAT IT DOES NOT SEE, said so the arm is not read as wider than it is (CONTRIBUTING §2 shape 7): a clause made
 # conditional at its CALL SITE rather than inside graphlegend.h (fielduses.h's member form, serialize.h's multi-root
-# table, --lego's caveat=) — rows (D4)/(D5)/(D6) are what guard those.
+# table, --lego's caveat=) — rows (D4)/(D5)/(D6) are what guard those; nor a map-family clause not spelled `hdr:`
+# (kMaxTokensFitLegend's max_tokens=/fit_bytes=/over_ceiling=, est_tokens= under order=stable, --around's defs=,
+# --rank-by's rank_by=/window=) — (D10)/(D11) guard those. And BY CONSTRUCTION not the always-on header field unresolved=
+# (no absent-if-0 marker), which the reader prints as INFO on every run because it is STILL undefined under compact: its
+# shortest reading, "unresolved=: resolver gauge", costs 29 B on every map and puts two (U) probes over the 400 B ceiling
+# (--max-tokens=3 379 -> 408, --rank-by=churn 376 -> 405 over their measured legends). No ceiling is raised for it.
 # RED on origin/main 28ee1df3: bodyless_defs=, declined_calls= and unproven_defs= FAILed. Shown able to fail on the fix
 # too: with the declined_calls row deleted from kCompactCompletenessTerms this arm went red on that name (landing commit).
+# RED on 34a97f66 for population 3: pr_iters=, pr_converged= and all seven hdr: fields FAILed. Shown able to fail on the
+# fix: deleting the declined row, making pr_iters header-only, or dropping ignored_dirs' header read each went red on
+# exactly that name, and on nothing else (landing commit).
 cat > "$TMP/struct.py" <<'PY'
 import os, re, sys
 root = sys.argv[1]
@@ -766,6 +865,12 @@ def table( name ):
     return m.group( 1 ) if m else ""
 terms  = set( clits[ int( k ) ] for k in re.findall( r"\{\s*\"S(\d+)\"\s*,", table( "kCompactCompletenessTerms" ) ) )
 paging = set( clits[ int( k ) ] for t in ( "kCompactPagingAttrs", "kCompactPagingHeadAttrs" ) for k in re.findall( r"\"S(\d+)\"", table( t ) ) )
+# A row that reads the map header ALONE (MapHeaderRead::Only) defines an unquoted header field, never a quoted attribute:
+# extent_suspect_syms= and macro_blanked_files= are --skipped attributes too, and their live check below must still run.
+rows      = table( "kCompactCompletenessTerms" )
+hdrTerms  = set( clits[ int( k ) ] for k in re.findall( r"\{\s*\"S(\d+)\"\s*,(?:[^{}]|\{\})*?MapHeaderRead::(?:Only|Also)", rows ) )
+onlyHdr   = set( clits[ int( k ) ] for k in re.findall( r"\{\s*\"S(\d+)\"\s*,(?:[^{}]|\{\})*?MapHeaderRead::Only", rows ) )
+headTerms = terms - onlyHdr
 # presence guards: a reader that broke returns an empty set, and an empty population agrees with any table
 if not { "counts_floor", "graph_unindexed", "root" } <= terms or not { "shown", "limit" } <= paging:
     print( "FAIL|the term/paging tables read from src/compactlegend.h are incomplete (terms=%d paging=%d) — the reader broke, so no row here means anything" % ( len( terms ), len( paging ) ) )
@@ -775,11 +880,46 @@ if not { "graph_unindexed", "declined_calls", "unproven_defs", "bodyless_defs", 
     sys.exit( 0 )
 covered = []
 for attr in sorted( pop ):
-    if attr in terms or attr in paging or attr.endswith( "_capped" ):
+    if attr in headTerms or attr in paging or attr.endswith( "_capped" ):
         covered.append( attr + "=" )
     else:
         print( "LIVE|%s|%s" % ( attr, pop[ attr ] ) )
 print( "PASS|%d of %d helper-family conditional attributes have a compact reading in the term table: %s" % ( len( covered ), len( pop ), " ".join( covered ) ) )
+
+# 3. THE MAP FAMILY (2026-09-12). Two more places a ranked document spells a field whose clause compact strips, both read
+#    from source: the PageRank disclosure's XML spelling in src/prconverge.h (` pr_iters="`, ` pr_converged="0"`, on every
+#    PageRank-ordered root), and every map-HEADER field src/serialize.h defines as `hdr:NAME=` CONDITIONALLY — in a clause
+#    charged only to a map that carries it, or marked absent-if-0 inside the always-on `<!-- ripwire v1` legend. A header
+#    field needs a row that READS the map header (MapHeaderRead::Only/Also); a row that reads only the head never sees
+#    an unquoted field of a comment, and one that reads the header alone does not cover a quoted root attribute above.
+pcode, plits = lex( open( os.path.join( root, "src", "prconverge.h" ), encoding = "utf-8" ).read() )
+prs = sorted( set( m.group( 1 ) for s in plits for m in [ re.match( r' ([a-z][a-z0-9_]*)=\\"', s ) ] if m ) )
+scode, slits = lex( open( os.path.join( root, "src", "serialize.h" ), encoding = "utf-8" ).read() )
+hdr, always = {}, set()
+for s in slits:
+    for m in re.finditer( r"hdr:([a-z][a-z0-9_]*)=", s ):
+        clause = re.split( r" (?:hdr|r):| -->", s[ m.end(): ] )[ 0 ]
+        if s.startswith( "<!-- ripwire v1" ) and "absent-if-0" not in clause:
+            always.add( m.group( 1 ) )
+        else:
+            hdr.setdefault( m.group( 1 ), "serialize.h defines hdr:%s= conditionally" % m.group( 1 ) )
+if not { "pr_iters", "pr_converged" } <= set( prs ) or not { "declined", "ignored_files", "extent_suspect_syms" } <= set( hdr ) or "unresolved" not in always:
+    print( "FAIL|the map-family population read from src/prconverge.h and src/serialize.h lacks a known member (pr: %s; hdr: %s; always-on: %s) — the reader broke" % ( " ".join( prs ), " ".join( sorted( hdr ) ), " ".join( sorted( always ) ) ) )
+    sys.exit( 0 )
+mapCovered = []
+for attr in prs:
+    if attr in headTerms:
+        mapCovered.append( attr + "=" )
+    else:
+        print( "FAIL|%s= (prconverge.h spells it on every PageRank-ordered root) has NO kCompactCompletenessTerms row that reads the head — every compact ranked answer carries it undefined" % attr )
+for attr in sorted( hdr ):
+    if attr in hdrTerms:
+        mapCovered.append( "hdr:" + attr + "=" )
+    else:
+        print( "FAIL|%s= (%s) has no kCompactCompletenessTerms row that reads the map header — a compact map keeps the field and drops its clause" % ( attr, hdr[ attr ] ) )
+if len( mapCovered ) == len( prs ) + len( hdr ):
+    print( "PASS|map family: %d of %d PageRank attributes and conditional map-header fields have a compact reading: %s" % ( len( mapCovered ), len( prs ) + len( hdr ), " ".join( mapCovered ) ) )
+print( "INFO|outside that population by construction (unconditional on every map, no absent-if-0 marker): %s — still undefined under compact, see the arm's comment" % " ".join( a + "=" for a in sorted( always ) ) )
 PY
 python3 "$TMP/struct.py" "$ROOT" >"$TMP/s.rows" 2>"$TMP/s.err" || no "(S) the source reader crashed: $( head -c 300 "$TMP/s.err" )"
 [ -s "$TMP/s.rows" ] || no "(S) the source reader printed no rows — the structural arm would be vacuous"
@@ -795,6 +935,7 @@ while IFS='|' read -r kind name where <&3; do
     case "$kind" in
         PASS) ok "(S) $name" ;;
         FAIL) no "(S) $name" ;;
+        INFO) printf '  INFO  (S) %s\n' "$name" ;;
         LIVE)
             doc="$( liveDoc "$name" )"
             if [ -z "$doc" ]; then

--- a/test/compactlegendcheck.sh
+++ b/test/compactlegendcheck.sh
@@ -25,6 +25,10 @@
 # defaults on a tmp git fixture; whatever answers with an XML root is an XML verb and must honor compact,
 # everything else must refuse it. LOOP arm (L): the ten-verb loop's compact legend bill ≤ 4,100 B (was 29,824
 # on the ripwire tree). MCP arm (M): edit_check with legend:"compact" answers in ≤ 900 B on a clean tree.
+# CONDITIONAL arm (D): an absent-at-zero or form-conditional attribute (declined_calls=, unproven_defs=, bodyless_defs=,
+# the member form, the multi-root <root label=> rows, --lego's caveat=) is DEFINED by the compact legend of a document
+# that carries it, and by none that does not. STRUCTURAL arm (S): every conditional attribute the graphlegend.h helper
+# family emits, read from source, has a compact reading — so the next one cannot land undefined.
 #
 # Usage:  RIPWIRE_BIN=build/ripwire bash test/compactlegendcheck.sh
 
@@ -547,6 +551,262 @@ for verb in $LEGEND_VERBS; do
 done
 [ "$nVerbs" -ge 17 ] && ok "(N) the family was read from source: $nVerbs verbs declare legend" \
                      || no "(N) only $nVerbs verbs were extracted from kMcpVerbFields — the family read is broken, so every PASS above means nothing"
+
+echo
+echo "=== (D) CONDITIONAL attributes: a document that CARRIES one defines it under compact too (CLI, columnar, MCP default) ==="
+# THE DEFECT CLASS (2026-09-12). Each attribute here is absent at zero or form-conditional, and its full-dialect clause
+# rides ONLY a document that carries it: graphlegend.h declinedCallsLegend( bool ) / unprovenDefsLegend( bool ) and the
+# callees-only bodyless_defs= clause inside callHierarchyLegendOpen( bool ), fielduses.h's kUsesFieldLegend (the member
+# form), serialize.h multiRootTableLegend( bool ) (the <root label=> rows), and --lego's caveat= sentence. The compact
+# layer strips that clause as prose and rebuilds definitions from kCompactCompletenessTerms, which had a row for NONE of
+# them — so each reached a compact reader, and every MCP caller (whose default posture IS compact), as a number the
+# document never defined. PR #169 fixed graph_unindexed= alone; #173's unproven_defs= repeated the miss, because nothing
+# tied the helper family to the term table. Arm (S) below is that tie; these rows are the behaviour it stands for.
+#
+# EACH ROW, CONTROL FIRST: the attribute is CARRIED by both postures' payloads and DEFINED by the full legend. Without
+# that a green compact assertion could be an answer that never carried the attribute, or a demand for a definition the
+# tool never had. Then the compact legend must define it, read LEFT-ANCHORED (`defs=` is a suffix of unproven_defs= and
+# bodyless_defs=, the trap test/decltodefcheck.sh records). A tag-qualified spec (root:label) reads only that element.
+# RED on origin/main 28ee1df3: every (D1)..(D6) row FAILed (the red output is in the landing commit); (D7) is the mirror
+# the fix must KEEP, so it is green on both binaries by construction and is written as its own row for that reason.
+cat > "$TMP/condattr.py" <<'PY'
+import re, sys
+op, path, spec = sys.argv[1], sys.argv[2], sys.argv[3]
+buf = open( path, encoding = "utf-8", errors = "replace" ).read()
+legend, tags = [], []
+i = 0; n = len( buf )
+while i < n:
+    if buf.startswith( "<![CDATA[", i ):
+        j = buf.find( "]]>", i ); i = n if j < 0 else j + 3
+    elif buf.startswith( "<!--", i ):
+        j = buf.find( "-->", i ); j = n if j < 0 else j + 3; legend.append( buf[ i:j ] ); i = j
+    elif buf[ i ] == "<":
+        j = buf.find( ">", i ); j = n if j < 0 else j + 1; tags.append( buf[ i:j ] ); i = j
+    else:
+        j = buf.find( "<", i ); i = n if j < 0 else j
+tag, _, attr = spec.rpartition( ":" )
+def on( t ):   # a tag-qualified spec reads only that element: <root label=> is not <community label=>
+    return not tag or re.match( r"<" + re.escape( tag ) + r"[\s/>]", t ) is not None
+vals = [ m.group( 1 ) for t in tags if on( t ) for m in [ re.search( r"\s" + re.escape( attr ) + r"=\"([^\"]*)\"", t ) ] if m ]
+leg = " ".join( legend )
+if op == "carries":    print( 1 if vals else 0 )
+elif op == "value":    print( vals[ 0 ] if vals else "" )
+elif op == "defines":  print( 1 if re.search( r"(?<![A-Za-z0-9_])" + re.escape( attr ) + "=", leg ) else 0 )
+elif op == "mentions": print( 1 if spec in leg else 0 )   # a literal needle anywhere in the legend
+PY
+ca(){ python3 "$TMP/condattr.py" "$@"; }
+# condArm ID LABEL FULL COMPACT SPEC… — the control, then the compact definition, one verdict row per document
+condArm()
+{
+    local id="$1" label="$2" full="$3" comp="$4" spec attr bad=0 got=""
+    shift 4
+    for spec in "$@"; do
+        attr="${spec#*:}"
+        if [ "$( ca carries "$full" "$spec" )" != 1 ] || [ "$( ca carries "$comp" "$spec" )" != 1 ]; then
+            no "($id) $label: control broken — the answer does not carry $attr= in both postures, so its definition row would be vacuous: $( head -c 160 "$comp" )"
+            bad=1; continue
+        fi
+        if [ "$( ca defines "$full" "$attr" )" != 1 ]; then
+            no "($id) $label: control broken — the FULL legend does not define $attr= either, so this row asserts nothing compact-specific"
+            bad=1; continue
+        fi
+        if [ "$( ca defines "$comp" "$attr" )" != 1 ]; then
+            no "($id) $label: $attr=\"$( ca value "$comp" "$spec" )\" is carried but the compact legend never defines it: $( leg legend "$comp" | head -c 260 )"
+            bad=1; continue
+        fi
+        got="$got $attr="
+    done
+    [ "$bad" -eq 0 ] && ok "($id) $label: carried, and defined by the compact legend:$got"
+    return 0
+}
+cdRun(){ local out="$1" dir="$2"; shift 2; ( cd "$dir" && "$BIN" . "$@" >"$out" 2>"$TMP/derr" </dev/null ); }
+# condPair ID LABEL DIR "ARGS" SPEC… — one answer in both postures (ARGS word-split on purpose: no spaces in any of them)
+condPair(){ local id="$1" label="$2" dir="$3" args="$4"; shift 4; cdRun "$TMP/d.full" "$dir" $args; cdRun "$TMP/d.comp" "$dir" $args --legend=compact; condArm "$id" "$label" "$TMP/d.full" "$TMP/d.comp" "$@"; }
+
+# H1's own corpus (test/decltodefcheck.sh arm A): a/Store.h declares a putObject whose one same-named body is b::Store's,
+# in a file that never includes a/Store.h — so a/Store.h:putObject is a bodyless declaration with one unproven candidate.
+H1="$TMP/h1"; mkdir -p "$H1/a" "$H1/b"
+printf '#pragma once\nnamespace a {\nclass Store {\npublic:\n    int putObject(int x);\n};\n}\n' >"$H1/a/Store.h"
+printf '#pragma once\nnamespace b {\nclass Store {\npublic:\n    int putObject(int x);\n};\n}\n' >"$H1/b/Store.h"
+printf '#include "Store.h"\nnamespace b {\nint Store::putObject(int x)\n{\n    return x + 1;\n}\n}\nint callB(int x)\n{\n    b::Store s;\n    return s.putObject(x);\n}\n' >"$H1/b/Store.cpp"
+# --lego's caveat= rides a NAMED interface in a language whose method contract is not read (only C++/ObjC are).
+LEGOJ="$TMP/legojava"; mkdir -p "$LEGOJ"
+printf 'interface Shape {\n    double area();\n}\n' >"$LEGOJ/Shape.java"
+printf 'class Circle implements Shape {\n    public double area() { return 3.0; }\n}\n' >"$LEGOJ/Circle.java"
+DECL="$ROOT/test/declinefix"; FIELDS="$ROOT/test/fieldusesfix"
+for d in "$DECL" "$FIELDS"; do [ -d "$d" ] || no "(D) fixture missing: $d — every row reading it would be vacuous"; done
+
+condPair D1 "--callers=a/Store.h:putObject" "$H1" "--callers=a/Store.h:putObject" unproven_defs
+condPair D2 "--callees=a/Store.h:putObject" "$H1" "--callees=a/Store.h:putObject" bodyless_defs unproven_defs
+condPair D2 "--callees=a/Store.h:putObject --format=columnar" "$H1" "--callees=a/Store.h:putObject --format=columnar" bodyless_defs unproven_defs
+condPair D3 "--callers=java/alpha/Alpha.java:jbody" "$DECL" "--callers=java/alpha/Alpha.java:jbody" declined_calls
+condPair D3 "--callees=javaDeclined" "$DECL" "--callees=javaDeclined" declined_calls
+condPair D3 "--impact=java/alpha/Alpha.java:jbody" "$DECL" "--impact=java/alpha/Alpha.java:jbody" declined_calls
+condPair D3 "--impact=java/alpha/Alpha.java:jbody --format=columnar" "$DECL" "--impact=java/alpha/Alpha.java:jbody --format=columnar" declined_calls
+mcp_text impact "{\"path\":\"$DECL\",\"symbol\":\"java/alpha/Alpha.java:jbody\",\"legend\":\"full\"}" >"$TMP/d.full"
+mcp_text impact "{\"path\":\"$DECL\",\"symbol\":\"java/alpha/Alpha.java:jbody\"}" >"$TMP/d.comp"
+condArm D3 "MCP impact at its DEFAULT posture (compact) vs legend:\"full\"" "$TMP/d.full" "$TMP/d.comp" declined_calls
+condPair D4 "--uses=Counter.count (the member form)" "$FIELDS" "--uses=Counter.count" member pinned amb_sites owners_of_name u:owner_candidates
+"$BIN" "$FIX" "$H1" --callers=distance >"$TMP/d.full" 2>/dev/null </dev/null
+"$BIN" "$FIX" "$H1" --callers=distance --legend=compact >"$TMP/d.comp" 2>/dev/null </dev/null
+condArm D5 "two roots, --callers=distance (the <root label= p=> table)" "$TMP/d.full" "$TMP/d.comp" root:label
+condPair D6 "--lego=Shape (Java: no method contract read)" "$LEGOJ" "--lego=Shape" iface:caveat iface:methods
+
+# (D7) THE MIRROR — present-only. A reading printed on a document WITHOUT its attribute is the opposite false claim, and
+# these single-root answers are the (L) loop's own shapes. --communities is the row that proves the <root label=>
+# reading is ELEMENT-qualified: it carries label= on every <community> row, a different attribute under the same name.
+rrun --communities --legend=compact >"$TMP/d7.comm"
+[ "$( ca carries "$TMP/d7.comm" community:label )" = 1 ] \
+    || no "(D7) control: --communities carries no <community label=> any more, so the element-qualification row proves nothing"
+d7bad=0; d7n=0
+for v in "--callers=distance" "--callees=distance" "--impact=distance" "--uses=distance" "--lego=Point" "--communities"; do
+    rrun "$v" --legend=compact >"$TMP/d7.c"
+    if [ ! -s "$TMP/d7.c" ]; then
+        no "(D7) $v --legend=compact answered nothing — its mirror row would be vacuous"; d7bad=1; continue
+    fi
+    d7n=$(( d7n + 1 ))
+    for pair in "unproven_defs=|unproven_defs" "bodyless_defs=|bodyless_defs" "declined_calls=|declined_calls" "member=|member" "<root label=|root:label" "caveat=|caveat"; do
+        needle="${pair%%|*}"; spec="${pair#*|}"
+        if [ "$( ca mentions "$TMP/d7.c" "$needle" )" = 1 ] && [ "$( ca carries "$TMP/d7.c" "$spec" )" != 1 ]; then
+            no "(D7) $v: the compact legend spells '$needle' but the document carries no ${spec#*:}= — a definition of an attribute that is not there"
+            d7bad=1
+        fi
+    done
+done
+[ "$d7bad" -eq 0 ] && [ "$d7n" -eq 6 ] && ok "(D7) mirror: no conditional reading prints on $d7n single-root answers that lack its attribute (incl. --communities' <community label=>)"
+
+echo
+echo "=== (S) STRUCTURAL: every conditional attribute the graphlegend.h helper family emits has a compact reading ==="
+# The (D) rows prove today's members; this row keeps the NEXT one from landing undefined. The population is READ FROM
+# SOURCE, never listed here, from the two places the family spells a conditional attribute:
+#   1. every `countAttrXmlOrEmpty( "NAME"` call, tree-wide — the one absent-at-zero spelling graphlegend.h mandates;
+#   2. every legend constant graphlegend.h selects CONDITIONALLY — named in exactly one arm of a `?:` (a clause against
+#      "", or the callees-only half of callHierarchyLegendOpen) — reduced to the attribute its text opens with, the
+#      house form ("declined_calls=K (absent when 0) …", "callees-only: bodyless_defs= …").
+# Each must have a kCompactCompletenessTerms row, a paging-window name, or the *_capped rule (all read from
+# src/compactlegend.h). The one other way to be defined is a full clause the compact layer KEEPS because it is not
+# prose-prefixed — --skipped's `<!-- why=…` health comments — and that is never taken on trust: each such name is run
+# live here and must be carried AND defined by the compact document, or the row fails.
+# WHAT IT DOES NOT SEE, said so the arm is not read as wider than it is (CONTRIBUTING §2 shape 7): a clause made
+# conditional at its CALL SITE rather than inside graphlegend.h (fielduses.h's member form, serialize.h's multi-root
+# table, --lego's caveat=) — rows (D4)/(D5)/(D6) are what guard those.
+# RED on origin/main 28ee1df3: bodyless_defs=, declined_calls= and unproven_defs= FAILed. Shown able to fail on the fix
+# too: with the declined_calls row deleted from kCompactCompletenessTerms this arm went red on that name (landing commit).
+cat > "$TMP/struct.py" <<'PY'
+import os, re, sys
+root = sys.argv[1]
+def lex( text ):
+    # comments dropped; every string/char literal replaced by a numbered placeholder whose body is kept in lits
+    out, lits = [], []
+    i = 0; n = len( text )
+    while i < n:
+        if text.startswith( "//", i ):
+            j = text.find( "\n", i ); i = n if j < 0 else j
+        elif text.startswith( "/*", i ):
+            j = text.find( "*/", i + 2 ); i = n if j < 0 else j + 2
+        elif text[ i ] in "\"'":
+            q = text[ i ]; j = i + 1
+            while j < n and text[ j ] != q:
+                j += 2 if text[ j ] == "\\" else 1
+            if q == '"':
+                out.append( '"S%d"' % len( lits ) ); lits.append( text[ i + 1:j ] )
+            else:
+                out.append( "'?'" )
+            i = j + 1
+        else:
+            out.append( text[ i ] ); i += 1
+    return "".join( out ), lits
+def arms( code, q ):
+    # the two arms of the ternary whose '?' is at q: up to the first depth-0 ':' that is not '::', then to its end
+    depth = 0; i = q + 1; n = len( code ); mid = -1
+    while i < n:
+        c = code[ i ]
+        if code.startswith( "::", i ):
+            i += 2; continue
+        if c in "([{":
+            depth += 1
+        elif c in ")]}":
+            if depth == 0:
+                break
+            depth -= 1
+        elif depth == 0 and ( c == ";" or ( c == "," and mid >= 0 ) ):
+            break
+        elif depth == 0 and c == ":" and mid < 0:
+            mid = i
+        i += 1
+    return ( code[ q + 1:mid ], code[ mid + 1:i ] ) if mid >= 0 else None
+def opens( body ):
+    m = re.search( r"(?<![A-Za-z0-9_])([a-z][a-z0-9_]*)=", body )
+    return m.group( 1 ) if m else None
+
+code, lits = lex( open( os.path.join( root, "src", "graphlegend.h" ), encoding = "utf-8" ).read() )
+consts = {}
+for m in re.finditer( r"\b(k[A-Z]\w*)\s*=\s*((?:\"S\d+\"\s*)+);", code ):
+    consts[ m.group( 1 ) ] = "".join( lits[ int( k ) ] for k in re.findall( r"\"S(\d+)\"", m.group( 2 ) ) )
+pop = {}
+for q in [ m.start() for m in re.finditer( r"\?", code ) ]:
+    both = arms( code, q )
+    if both is None:
+        continue
+    a, b = ( set( re.findall( r"\bk[A-Z]\w*", x ) ) for x in both )
+    for k in sorted( a ^ b ):
+        if k in consts and opens( consts[ k ] ):
+            pop.setdefault( opens( consts[ k ] ), "graphlegend.h selects %s conditionally" % k )
+for dirpath, dirnames, files in os.walk( os.path.join( root, "src" ) ):
+    dirnames.sort()
+    for f in sorted( files ):
+        if f.endswith( ( ".h", ".cpp" ) ):
+            p = os.path.join( dirpath, f )
+            for m in re.finditer( r"countAttrXmlOrEmpty\(\s*\"([a-z][a-z0-9_]*)\"", open( p, encoding = "utf-8", errors = "replace" ).read() ):
+                pop.setdefault( m.group( 1 ), "countAttrXmlOrEmpty in %s" % os.path.relpath( p, root ) )
+
+ccode, clits = lex( open( os.path.join( root, "src", "compactlegend.h" ), encoding = "utf-8" ).read() )
+def table( name ):
+    m = re.search( r"\b" + name + r"\s*\[\s*\]\s*=\s*\{(.*?)\};", ccode, re.S )
+    return m.group( 1 ) if m else ""
+terms  = set( clits[ int( k ) ] for k in re.findall( r"\{\s*\"S(\d+)\"\s*,", table( "kCompactCompletenessTerms" ) ) )
+paging = set( clits[ int( k ) ] for t in ( "kCompactPagingAttrs", "kCompactPagingHeadAttrs" ) for k in re.findall( r"\"S(\d+)\"", table( t ) ) )
+# presence guards: a reader that broke returns an empty set, and an empty population agrees with any table
+if not { "counts_floor", "graph_unindexed", "root" } <= terms or not { "shown", "limit" } <= paging:
+    print( "FAIL|the term/paging tables read from src/compactlegend.h are incomplete (terms=%d paging=%d) — the reader broke, so no row here means anything" % ( len( terms ), len( paging ) ) )
+    sys.exit( 0 )
+if not { "graph_unindexed", "declined_calls", "unproven_defs", "bodyless_defs", "extent_suspect_files" } <= set( pop ):
+    print( "FAIL|the helper-family population read from src/ lacks a known member (got: %s) — the reader broke" % " ".join( sorted( pop ) ) )
+    sys.exit( 0 )
+covered = []
+for attr in sorted( pop ):
+    if attr in terms or attr in paging or attr.endswith( "_capped" ):
+        covered.append( attr + "=" )
+    else:
+        print( "LIVE|%s|%s" % ( attr, pop[ attr ] ) )
+print( "PASS|%d of %d helper-family conditional attributes have a compact reading in the term table: %s" % ( len( covered ), len( pop ), " ".join( covered ) ) )
+PY
+python3 "$TMP/struct.py" "$ROOT" >"$TMP/s.rows" 2>"$TMP/s.err" || no "(S) the source reader crashed: $( head -c 300 "$TMP/s.err" )"
+[ -s "$TMP/s.rows" ] || no "(S) the source reader printed no rows — the structural arm would be vacuous"
+XHOT="$TMP/xhot"; XLEAK="$TMP/xleak"; mkdir -p "$XHOT" "$XLEAK"
+for f in leak.cpp head.c orphan.cpp plain.cpp; do cp "$ROOT/test/extentfix/$f" "$XHOT/" 2>/dev/null || no "(S) fixture missing: test/extentfix/$f"; done
+for f in leak_anon.cpp leak_plain.cpp leak_lambda.cpp leak_c.c leak_objc.m leak_cuda.cu leak_partial.cpp; do
+    cp "$ROOT/test/macroreparsefix/$f" "$XLEAK/" 2>/dev/null || no "(S) fixture missing: test/macroreparsefix/$f"
+done
+"$BIN" "$XHOT"  --skipped --legend=compact >"$TMP/s.hot"  2>/dev/null </dev/null
+"$BIN" "$XLEAK" --skipped --legend=compact >"$TMP/s.leak" 2>/dev/null </dev/null
+liveDoc(){ case "$1" in extent_suspect_files|extent_suspect_syms) printf '%s' "$TMP/s.hot" ;; macro_blanked_files|macro_blanked) printf '%s' "$TMP/s.leak" ;; *) printf '' ;; esac; }
+while IFS='|' read -r kind name where <&3; do
+    case "$kind" in
+        PASS) ok "(S) $name" ;;
+        FAIL) no "(S) $name" ;;
+        LIVE)
+            doc="$( liveDoc "$name" )"
+            if [ -z "$doc" ]; then
+                no "(S) $name= ($where) has NO kCompactCompletenessTerms row — under --legend=compact it reaches the reader undefined"
+            elif [ "$( ca carries "$doc" "$name" )" = 1 ] && [ "$( ca defines "$doc" "$name" )" = 1 ]; then
+                ok "(S) $name= ($where) needs no term: its --skipped clause is a comment compact KEEPS, verified live (carried and defined)"
+            else
+                no "(S) $name= ($where) has no term, and its live --skipped compact document does not carry and define it (carried=$( ca carries "$doc" "$name" ) defined=$( ca defines "$doc" "$name" ))"
+            fi ;;
+        *) no "(S) unreadable row from the source reader: $kind|$name|$where" ;;
+    esac
+done 3<"$TMP/s.rows"
 
 [ "$fail" -eq 0 ] && echo 'ALL PASS' || echo 'FAILURES ABOVE'
 exit "$fail"


### PR DESCRIPTION
`--legend=compact` strips the explanatory legend comments and rebuilds definitions from `kCompactCompletenessTerms`. Six attributes had no row there, so a compact answer printed them with no definition anywhere in the document. #169 fixed the same defect for `graph_unindexed=`.

| attribute | where it appears |
| --- | --- |
| `declined_calls=` | `--callers`, `--callees`, `--impact`, their columnar forms, and MCP `impact`, whose default dialect is compact |
| `unproven_defs=` | `--callers` / `--callees` on a `file:name` selector |
| `bodyless_defs=` | `--callees`, e.g. bare `--callees=distance` on `test/fixture` |
| `member=` and its row attributes | the `--uses=Owner.field` member form |
| `<root label= p=>` | the multi-root roots table |
| `methods="0" caveat=` | `--lego` on a language whose method contract is not read |

Each new term prints only when its attribute is present. `label=` and `caveat=` are element-qualified (`<root>`, `<iface>`) for two reasons: `--communities` carries a different `label=`, and the head span compact reads includes the full lego legend, which spells `caveat="…"`. MCP `find_symbol` and `find_referencing_symbols` answer JSON and take no `legend`, so this defect never reached them.

## Gate

`test/compactlegendcheck.sh` gains three kinds of arm:

- **(D1)–(D6):** one behavioural arm per attribute. Each runs a real selector that makes the attribute appear under `--legend=compact`. 18 of these rows failed on main.
- **(S):** a structural arm. It reads every conditional attribute the `graphlegend.h` helper family emits and fails when one has no compact term. On main it failed for `bodyless_defs`, `declined_calls` and `unproven_defs`. With the `declined_calls` term deleted from a scratch copy, it failed on exactly that name.
- **(D7):** checks the element qualifier. An intermediate build that left the qualifier unwired went red on `--communities` and `--lego=Point`.

## Bytes

- **The pinned loop:** the ten-verb loop (L) is 4,056 B before and after, so the 4,100 B pin did not move.
- **Unaffected answers:** 40 compact answers were compared between main and this branch. Only `--callees=distance` changed, because it really carries `bodyless_defs="1"`; its legend grew from 304 to 369 B.
- **Answers carrying these attributes:** they now exceed the dialect's nominal 400 B by 10–70 B. No gate pins those sizes, and main already reaches 430 B on `graph_unindexed=` answers. The alternative is a number with no definition.

## Verification

- 11 targeted gates pass (`gates=11 pass=11 skip=0 fail=0`): compactlegend, decltodef, decline, legendcoverage, graphlegendbudget, legendcost, estcharge, mcpattrparity, mcpclidiff, printffmtparity, xmlwellformed.
- `limits_build --check` and `gatecount_build --check` both exit 0.
- Two compact runs over the repo produce identical output, and it passes xmllint.

## Second commit (6ea3c0fc): the rest of the class

Each item below was verified by running the first commit's binary:

- **`pr_iters=`** is undefined under compact on every PageRank root: the map and its bundles, `--impact`, `--tree`/`--seams`/`--communities`/`--community`/`--zoom`, and MCP impact's default. The same holds for `pr_converged="0"`, which is reachable only under `RIPWIRE_TEST_PR_MAXITERS`.
- **Map header fields** survive compact as data while their `<!-- hdr:` definitions are stripped: `declined=`/`external=`, `extent_suspect_syms=`, `macro_blanked_files=`, `ignored_files=`/`ignored_dirs=`, `locality_pinned=`, `max_tokens=`/`fit_bytes=`/`over_ceiling=`, and `est_tokens=` under `--order=stable`.
- **`defs=` and `window=`:** `--around`'s `defs=`, plus `rank_by=`/`window=` on `--rank-by` maps.

The commit adds thirteen more present-only terms. Some of these names mean something else as a quoted attribute on other verbs, so they are read from the header only (`MapHeaderRead`). `window=` and `defs=` are qualified to the `<r>` map root.

**Gate:** new rows (D8)–(D11) and a (D12) mirror. (S) now also reads `prconverge.h` and the conditional `hdr:` fields in `serialize.h`. 33 rows were red on the first commit, and all 86 pass after this one.

**Bytes:** the (L) loop goes from 4,056 to 4,089 B, under its 4,100 pin. Every (U) probe stays at or under 400 B; the largest is `--impact` at 390. Four answers with no pin that carry these fields run 413–446 B.

## Still undefined under compact, deliberately left out of this PR

Both of these would break the dialect's byte pins, so fixing them is a decision rather than a bug fix:

- **`unresolved=`** appears on every map header. Its shortest honest term (29 B) puts two pinned probes over 400 B.
- **`--impact`'s unconditional counts** (`reaches=`, `importers=`, `shown_importers=`, `radius_tested=`, `radius_untested=`) need 151 B of terms against 11 B of (L) headroom.

Also noticed and left for a follow-up: `--tree files=`, `--communities drill=`/`isolated=`, the `--zoom` counts, and churn-decay's `<recent of=>`.

**Verification for the second commit:**
- 9 targeted gates pass (`gates=9 pass=9 skip=0 fail=0`).
- 7 more gates that exercise compact output pass (`gates=7 pass=7`).
- limits and gatecount `--check` both exit 0, determinism holds, and xmllint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
