### PR TITLE
fix(dispatchordercheck): the whereis precedence pair compared two reads of a ref namespace every session writes

### DIFF
--- a/test/dispatchordercheck.sh
+++ b/test/dispatchordercheck.sh
@@ -30,16 +30,51 @@
 # Adjacent pairs pin every seam in the chain; the two cross-handler cases pin the chain's endpoints
 # against its neighbours in main()'s handler sequence.
 #
-# Fixture: test/queryfix (shared with querycheck.sh / reachcheck.sh; d1 -> d2 -> d3 -> d4).
+# Fixture: test/queryfix (shared with querycheck.sh / reachcheck.sh; d1 -> d2 -> d3 -> d4), run from a COPY
+# committed into a repository this gate owns — see "the fixture owns its refs" below.
 
 set -u
 
 BIN="${1:-${RIPWIRE_BIN:-./build/ripwire}}"   # CA4: this gate ignored $1, so a caller passing a binary
-FIX="${FIX:-test/queryfix}"                    # positionally silently measured build/ripwire instead (trap #20)
+SRCFIX="${FIX:-test/queryfix}"                 # positionally silently measured build/ripwire instead (trap #20)
 fails=0
 
 pass() { echo "  PASS  $1"; }
 fail() { echo "  FAIL  $1"; fails=$((fails + 1)); }
+
+# ── the fixture owns its refs ─────────────────────────────────────────────────────────────────────────────
+#
+# The precedence arm below demands byte-identity between two runs, and one of its rows is --whereis=d2. That
+# verb's input is not the fixture's files: it is every refs/heads of the repository ENCLOSING the crawl root.
+# Run on test/queryfix in place, that is the checkout's .git, which every worktree of the clone and every
+# session working in it writes. Nothing in the suite holds it still, and pargates' tree tripwire cannot see a
+# ref write (it is not a `git status` line). One branch created between the solo run and the paired run (a
+# window of seconds: each run lists and reads every branch's tree) turned refs_scanned="317" into "318", moved
+# hits=/total=/<more hits=>, and shifted rows, and the arm reported "--whereis=d2 did NOT answer" about a verb
+# that answered correctly both times. Reproduced on a --shared clone by creating that branch between the two
+# runs; the same pair with the refs held still was byte-identical, cold cache or warm.
+#
+# So every arm runs on a copy committed into a private repository: `main` (HEAD, two commits) and `side`
+# (the first commit), so --whereis still scans one non-HEAD ref. TMPDIR is redirected into the same private
+# dir (the compactlegendcheck/shapingflagcheck idiom): the warm-by-default cache stays ON, so a cold first run
+# is still compared against warm ones, but no sibling gate's blob write can move it and no orphan blob keyed
+# by this per-run root is left in the shared cache dir. Not --no-cache: that would hide a cache-dependent
+# difference instead of ruling one out.
+[ -d "$SRCFIX/src" ] || { echo "dispatchordercheck: no fixture at $SRCFIX"; exit 2; }
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE    # inherited from a hook running the suite, these would aim every git
+                                              # and ripwire call below at the caller's repository instead
+GATETMP="$( mktemp -d )"; trap 'rm -rf "$GATETMP"' EXIT
+FIX="$GATETMP/queryfix"
+if ! ( fixgit(){ GIT_AUTHOR_DATE="$1" GIT_COMMITTER_DATE="$1" git -C "$FIX" -c user.name=ripwire -c user.email=ripwire@example.invalid \
+                     -c commit.gpgsign=false -c core.hooksPath=/dev/null "${@:2}"; }
+       mkdir -p "$FIX" "$GATETMP/tmp" && cp -R "$SRCFIX/." "$FIX/" \
+       && git -C "$FIX" init -q -b main && git -C "$FIX" add -A \
+       && fixgit "2026-01-01T00:00:00Z" commit -qm fixture \
+       && git -C "$FIX" branch side \
+       && fixgit "2026-01-02T00:00:00Z" commit -q --allow-empty -m head ) >/dev/null 2>&1; then
+    echo "dispatchordercheck: could not build the private fixture repository at $FIX"; exit 2
+fi
+export TMPDIR="$GATETMP/tmp"
 
 # assertWinner NAME EXPECTED_ROOT_TAG ARGS...
 #   runs BIN on the fixture with ARGS (two verb flags), and asserts the FIRST XML element emitted is
@@ -60,6 +95,28 @@ assertWinner()
 }
 
 echo "dispatchordercheck: BIN=$BIN"
+
+# --- the isolation above, asserted rather than assumed ------------------------------------------------------
+# Guard: --whereis=d2 must scan exactly the private repo's one non-HEAD ref. Pointed back at a shared checkout it
+# reads that clone's branch count instead (refs_scanned="317" where this was found, "0" on a CI checkout) and
+# reds. Control: a branch created in the private repo must CHANGE the bytes and deleting it must restore them,
+# so the copy is load-bearing — ref motion reaches the precedence pair, and only this gate can cause it.
+wh0="$( "$BIN" "$FIX" --whereis=d2 2>/dev/null )"
+if ! printf '%s' "$wh0" | grep -q '<whereis sym="d2" on-head="1" refs_scanned="1" '; then
+    fail "fixture refs: --whereis=d2 is not scanning only the private fixture's one side branch — the arms below would read a ref namespace this gate does not own (got: $( printf '%s' "$wh0" | grep -o '<whereis [^>]*>' | head -c 160 ))"
+else
+    git -C "$FIX" branch -q control side >/dev/null 2>&1
+    wh1="$( "$BIN" "$FIX" --whereis=d2 2>/dev/null )"
+    git -C "$FIX" branch -q -D control >/dev/null 2>&1
+    wh2="$( "$BIN" "$FIX" --whereis=d2 2>/dev/null )"
+    if [ "$wh1" = "$wh0" ]; then
+        fail "fixture refs (control): a branch created in the private fixture repo did not change --whereis=d2 — ref motion cannot reach the pair there, so this isolation proves nothing"
+    elif [ "$wh2" != "$wh0" ]; then
+        fail "fixture refs: deleting the control branch did not restore --whereis=d2 byte for byte"
+    else
+        pass "fixture refs: --whereis=d2 scans only this gate's private repo (refs_scanned=1); a branch created there changes the bytes, deleting it restores them"
+    fi
+fi
 
 # --- the tie INSIDE the first block ------------------------------------------------------------
 # --callers and --callees share one block; wantCallers = !cfg.callers.empty(), so --callers wins.
@@ -114,7 +171,7 @@ PREC_VERBS=(
   "--impact=d3" "--mentions=d2" "--handoff" "--flags" "--whereis=d2" "--field-affinity" "--doc-drift" "--notes"
   "--communities" "--zoom" "--seams" "--report" "--tree" "--grep=d2" "--lint" "--around=d2"
 )
-PRECTMP="$( mktemp -d )"; trap 'rm -rf "$PRECTMP"' EXIT
+PRECTMP="$( mktemp -d )"; trap 'rm -rf "$GATETMP" "$PRECTMP"' EXIT
 prec_pairs=0
 for (( pi = 0; pi + 1 < ${#PREC_VERBS[@]}; pi++ )); do
     A="${PREC_VERBS[$pi]}"; B="${PREC_VERBS[$((pi+1))]}"
@@ -245,7 +302,7 @@ assertCross "--handoff"            "--lint"
 # It runs before ingest (it IS the ingest-artifact generator), so it outranks even --for. That made it the
 # one row that can beat a query-family flag, and the reason X9(c) is now gated on the family actually
 # winning: a run where --index-out answered must not also claim "--for takes precedence".
-IOTMP="$( mktemp -d )"; trap 'rm -rf "$PRECTMP" "$IOTMP"' EXIT
+IOTMP="$( mktemp -d )"; trap 'rm -rf "$GATETMP" "$PRECTMP" "$IOTMP"' EXIT
 "$BIN" "$FIX" --index-out="$IOTMP/ix" --lint >"$IOTMP/o" 2>"$IOTMP/e"
 if [ -s "$IOTMP/o" ]; then
     fail "--index-out+--lint: stdout is non-empty — --lint answered instead of --index-out"


### PR DESCRIPTION
`dispatchordercheck`'s precedence arm runs each verb pair twice, the winner alone and then both flags, and requires byte-identical stdout. One of its pairs is `--whereis=d2 --field-affinity`.

`--whereis` does not read the fixture's files. It scans every branch of the repository enclosing the crawl root. When the gate runs on `test/queryfix` in place, that repository is the checkout's own `.git`, which every worktree and session in the clone writes to. A branch created between the two runs changed `refs_scanned=`, `hits=` and the rows. The gate then reported "--whereis=d2 did NOT answer" about a verb that answered correctly both times. The suite's tree tripwire cannot see a ref write.

## Ruled out first

- **The binary is not nondeterministic here.** With refs held still, 636 solo/paired pairs produced 0 differences. They covered cold, warm, racy-mtime and touched-between-runs caches, while querycheck and reachcheck looped on the same fixture.
- **No gate writes into `test/queryfix`.**

## Fix

The gate now copies the fixture into a private repository it creates:

- `main` has two commits and `side` points at the first.
- Commit dates are fixed.
- Inherited `GIT_DIR` and hooks are neutralised.
- `TMPDIR` points into the same private directory.

The warm-by-default cache stays on, so cold and warm runs are still compared, but nothing outside the gate can move the refs or the cache it reads. It deliberately does not use `--no-cache`, which would hide a cache-dependent difference instead of ruling one out.

Two new rows check the isolation:

- **Guard:** `--whereis=d2` must scan exactly one ref (`refs_scanned="1"`). If the gate is pointed back at a shared checkout, this row fails.
- **Control:** creating a branch in the private repository must change the bytes, and deleting it must restore them.

## Evidence

Run on a clone while a loop created a branch every 0.7 s:

- The stock gate exits 1, on exactly the `--whereis` pair.
- The fixed gate exits 0, with 79 PASS.
- With the fixture copy reverted, the guard fails.

## Verification

- 13 gates pass (`gates=13 pass=13 skip=0 fail=0`), including dispatchorder, query, reach, racymtime, gateexit, worktreeleak, manifest and binoverride.
- `limits_build --check` and `gatecount_build --check` both exit 0.
- Only the test file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
