### PR TITLE
fix(mcp): a client that dropped a large reply killed the --listen server with SIGPIPE

### DIFF
--- a/src/mcpserver.h
+++ b/src/mcpserver.h
@@ -112,12 +112,22 @@ inline std::string_view trim( std::string_view s ) noexcept
 }
 
 // send an entire buffer, tolerating short writes; false if the peer went away mid-write (we just drop it).
+// A peer that closed or reset its socket fails the write with EPIPE/ECONNRESET — an ordinary client disconnect, which
+// must never raise SIGPIPE: its default action ends the process, so ONE client that stopped reading took the listener
+// down for every client after it. The suppression is per socket, never process-wide, so the CLI's stdout keeps its
+// ordinary closed-pipe behaviour: MSG_NOSIGNAL on each send where the platform defines it (Linux), SO_NOSIGPIPE on each
+// accepted socket where that exists (macOS; see the accept loop). A platform with both gets both.
 inline bool sendAll( int fd, const std::string& data ) noexcept
 {
+#ifdef MSG_NOSIGNAL
+    const int sendFlags = MSG_NOSIGNAL;
+#else
+    const int sendFlags = 0;
+#endif
     std::size_t sent = 0;
     while( sent < data.size() )
     {
-        const ssize_t n = ::send( fd, data.data() + sent, data.size() - sent, 0 );
+        const ssize_t n = ::send( fd, data.data() + sent, data.size() - sent, sendFlags );
         if( n <= 0 )
         {
             return false;
@@ -586,6 +596,11 @@ inline int runMcpHttp( const McpHttpConfig& cfg )
         timeval tv{ kRecvTimeoutSec, 0 };
         ::setsockopt( fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof( tv ) );
         ::setsockopt( fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof( one ) );
+#ifdef SO_NOSIGPIPE
+        // a client that drops mid-response costs only its own connection: a send() to a peer that is gone fails with EPIPE
+        // instead of raising SIGPIPE (macOS's per-socket switch; sendAll passes MSG_NOSIGNAL where the platform has that).
+        ::setsockopt( fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof( one ) );
+#endif
 
         bool          tooManyHeaderBytes = false, tooLargeBody = false;
         const Request req = readRequest( fd, tooManyHeaderBytes, tooLargeBody );

--- a/test/mcpremotecheck.sh
+++ b/test/mcpremotecheck.sh
@@ -13,6 +13,8 @@
 #                           (RIPWIRE_MCP_TIMINGS rebuilt=0), and the omitted-path form defaults to the workspace.
 #   oversized body        — a > 8 MB body → 413; malformed HTTP → 400/405 and the server LIVES.
 #   2 sequential clients  — two back-to-back HTTP clients both get correct answers off the one warm index.
+#   client drops mid-reply — a client that closes or resets before/while reading a multi-MB response costs only
+#                           its own connection: the SAME listener stays alive and answers the next request.
 #   hostile-input parity  — the mcpaudit4hardencheck corpus (25-digit start_line, XML-comment-breaking task)
 #                           degrades IDENTICALLY over HTTP — the hardened parser is transport-agnostic.
 #
@@ -287,6 +289,73 @@ C2="$( curl -s -X POST "$URL" \
     || no "one of two sequential clients failed: C1=$( printf %s "$C1" | head -c 80 ) C2=$( printf %s "$C2" | head -c 80 )"
 
 stop_server
+
+# ═══════════════════════════════════════════════════════════════════════════
+echo
+echo "=== a client that drops mid-response costs only its own connection (no SIGPIPE) ==="
+# ═══════════════════════════════════════════════════════════════════════════
+# A peer that closes or resets its socket while the listener is still writing makes send() fail with EPIPE,
+# and unsuppressed that raises SIGPIPE, whose default action ends the process: ONE client that stopped
+# reading took the listener down for every client after it (2026-09-12, pre-fix binary on macOS: killed by
+# signal 13 on each of the three shapes below, the next client refused). A reply that fits in the socket
+# buffers is written in full before the peer's reset lands, so this arm first PROVES its reply is bigger than
+# any default buffer (4 MiB is Linux's tcp_wmem ceiling; macOS's sendspace is 131 KB). The `for` task is
+# echoed into the payload, which is what makes the reply large on a small fixture. A reply that shrinks below
+# the floor is a FAIL, so the arm cannot keep passing after it stops reaching a failing send().
+python3 -c 'import json,sys; sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":91,"method":"tools/call","params":{"name":"for","arguments":{"path":sys.argv[1],"task":"distance "*350000}}}))' "$WS" \
+    > "$TMP/bigreply.json"
+drop_client() { # $1 = read-all | close-before-read | reset-before-read | close-midway; prints "BYTES STATUSLINE"
+    python3 - "$PORT" "$1" "$TMP/bigreply.json" <<'PY'
+import socket, struct, sys, time
+port, mode, body = int(sys.argv[1]), sys.argv[2], open(sys.argv[3], "rb").read()
+head = ("POST /mcp HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nAccept: application/json, text/event-stream\r\n"
+        "Content-Type: application/json\r\nContent-Length: %d\r\n\r\n" % (port, len(body))).encode()
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+if mode == "close-midway":
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)   # before connect: the listener blocks in send()
+s.settimeout(120)
+s.connect(("127.0.0.1", port))
+s.sendall(head + body)
+data = b""
+if mode in ("read-all", "close-midway"):
+    want = 4096 if mode == "close-midway" else None
+    while want is None or len(data) < want:
+        chunk = s.recv(65536 if want is None else want - len(data))
+        if not chunk:
+            break
+        data += chunk
+elif mode == "reset-before-read":
+    time.sleep(0.3)                                             # an RST before the listener READ the request discards it
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))   # close() now sends RST, not FIN
+s.close()
+print(len(data), data.split(b"\r\n", 1)[0].decode("latin-1") or "-")
+PY
+}
+if start_server; then
+    read -r BIG_BYTES _ BIG_CODE _ <<<"$( drop_client read-all 2>/dev/null )"
+    if [ "${BIG_BYTES:-0}" -gt 4194304 ] 2>/dev/null && [ "${BIG_CODE:-}" = "200" ]; then
+        ok "the probe reply outgrows every default socket buffer ($BIG_BYTES bytes, 200, read in full)"
+    else
+        no "the probe reply is '${BIG_BYTES:-}' bytes (HTTP '${BIG_CODE:-}'), not a 200 over 4 MiB — the drop shapes below would not reach a failing send()"
+    fi
+    for shape in close-before-read reset-before-read close-midway; do
+        drop_client "$shape" >/dev/null 2>&1
+        # The next request queues behind the dropped one on the single-threaded loop, so no sleep is needed: it
+        # is answered only if the listener outlived the failed write.
+        NEXT="$( curl -s -o /dev/null -w '%{http_code}' -m 60 -X POST "$URL" -d '{"jsonrpc":"2.0","id":92,"method":"initialize"}' )"
+        if [ "$NEXT" = "200" ] && kill -0 "$SRV_PID" 2>/dev/null; then
+            ok "$shape: the same listener is alive and answers the next request (200)"
+        else
+            # status 141 = the listener died of SIGPIPE on its own; 143 = it was alive and this kill ended it.
+            kill "$SRV_PID" 2>/dev/null; wait "$SRV_PID" 2>/dev/null; RC=$?; SRV_PID=""
+            no "$shape: the listener did not outlive the dropped client (next request got $NEXT, listener status $RC; 141 = SIGPIPE)"
+            start_server || no "$shape: the listener could not be restarted for the remaining shapes"
+        fi
+    done
+    stop_server
+else
+    no "drop-mid-response listener failed to start"
+fi
 
 # ═══════════════════════════════════════════════════════════════════════════
 echo


### PR DESCRIPTION
`sendAll` in `src/mcpserver.h` wrote each reply with `::send( fd, …, 0 )`, and nothing in `src/` handles SIGPIPE. Suppose a client closed its connection before reading a reply larger than the socket send buffer. The next `send()` raised SIGPIPE, whose default action terminates the process. The `--listen` server died, and every later client was refused.

Reproduced on main (547f6a14, macOS) with a 4.5 MB reply, from a `for` call over a copy of the repo:

| client | listener | next client |
| --- | --- | --- |
| closes before reading | killed by signal 13 | connection refused |
| resets (`SO_LINGER` 0) before reading | killed by signal 13 | connection refused |
| closes after reading 4 KB | killed by signal 13 | connection refused |
| resets after reading 4 KB | alive (ECONNRESET, no signal) | 200 |

## Fix

SIGPIPE is now suppressed per socket, so the CLI's ordinary stdout-pipe behaviour is unchanged:

- `sendAll` passes `MSG_NOSIGNAL` where the platform defines it (Linux).
- The accept loop sets `SO_NOSIGPIPE` on each accepted socket where the platform defines it (macOS).

A failed send already returned false and dropped that connection. Now the server keeps serving other clients after that.

## Gate

`test/mcpremotecheck.sh` gains an arm with two parts:

- It first proves its reply is a 200 larger than 4 MiB, above Linux's default send-buffer ceiling, so it cannot pass blind if the reply ever shrinks.
- It then drops a client in each of the three shapes that killed the listener, and asserts that the same listener is still alive and answers the next request.

It kills the listener on every path.

| binary | drop rows | whole gate |
| --- | --- | --- |
| before, plain | 3 FAIL (status 141 = SIGPIPE) | 42 PASS, 3 FAIL |
| before, ASan | 3 FAIL | 42 PASS, 3 FAIL |
| after, plain | 3 PASS | 45/45 |
| after, ASan | 3 PASS, no sanitizer reports | 45/45 |

The Linux `MSG_NOSIGNAL` path is exercised only by CI's Linux legs, not locally.

## Verification

- Targeted gates: `gates=5 pass=5 skip=0 fail=0` (mcprobust, mcpremote, mcpreadloop, mcpwatcher, mcphandle).
- `limits_build --check` and `gatecount_build --check` both exit 0.
- `--quality-delta` reports 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
