### PR TITLE
fix(gates): a --listen server still warming up read as a transport difference, and a dead one as a catalog verdict

### DIFF
--- a/test/lib/gatehttp.sh
+++ b/test/lib/gatehttp.sh
@@ -12,8 +12,16 @@
 # timeout left the body empty, and the empty string went on to be judged: "transports DIFFER … http=" in
 # mcpframehonestycheck (CI 2026-09-12, release macos-14, shard 2/4, first frame only), a traceback that silenced every
 # later arm in mcpcontractcheck, "premise BROKEN" in mcptoolprunecheck. `post` reads the body to its Content-Length; a
-# timeout, a refused connect, a close without a response or a short body raises NoAnswer, whose sentence names which.
-# The sentence is context-free: each caller adds what the silence is NOT (a transport difference, a catalog verdict).
+# timeout, a refused connect, a close without a response, a short body or a garbled one raises NoAnswer, whose sentence
+# names which. The sentence is context-free: each caller adds what the silence is NOT (a transport difference, a catalog
+# verdict).
+#
+# ONE DEADLINE PER REQUEST. A timeout set on each recv bounds the silence BETWEEN bytes, not the request: a listener that
+# sends one byte more often than the timeout kept a request alive, and its buffer growing, for as long as it went on
+# sending (review of PR #188). `post` now gives the whole request, connect through the last body byte, one absolute
+# deadline, and every blocking call waits only for what is left of it; waitServing does the same against its serving
+# ceiling. Nothing is read past a declared Content-Length, and a read that already carried more is a garbled answer,
+# never a body cut to length. mcpframehonestycheck (I0) observes it live: a stand-in that trickles a body it never ends.
 #
 # READY MEANS ANSWERED. A port that ACCEPTS is not a server that answers: runMcpHttp (src/mcpserver.h) listen()s,
 # then warms the pinned index, and only then enters its accept loop, while the kernel completes handshakes into the
@@ -39,21 +47,40 @@ REQUEST_TIMEOUT_SEC = 5.0
 class NoAnswer( Exception ):
     """There is no response body to judge; str() is the sentence that says why."""
 
+def secondsLeft( deadline ):
+    """What is left of an ABSOLUTE deadline, as the next blocking call's timeout; socket.timeout once nothing is."""
+    left = deadline - time.monotonic()
+    if left <= 0:
+        raise socket.timeout( "timed out" )
+    return left
+
+def recvBefore( s, deadline, size ):
+    """One recv of at most `size` bytes that cannot outlive `deadline`, however often the peer sends."""
+    s.settimeout( secondsLeft( deadline ) )
+    return s.recv( size )
+
 def waitServing( port, isAlive, ceilingSec = SERVING_CEILING_SEC ):
     """'' once the listener on `port` ANSWERS an HTTP request, else the sentence naming why it never did."""
     deadline = time.monotonic() + ceilingSec
+    status   = b"HTTP/1."                              # any status line: 405 bare, 401 under a token
     while time.monotonic() < deadline:
         if not isAlive():
             return "the HTTP listener exited before it answered a request"
-        try:
-            s = socket.create_connection( ( "127.0.0.1", port ), 0.25 )
+        try:                                           # socket.timeout is an OSError: the ceiling passing lands here too
+            s = socket.create_connection( ( "127.0.0.1", port ), min( 0.25, secondsLeft( deadline ) ) )
         except OSError:
             time.sleep( 0.02 )
             continue
-        try:                                           # connected is not served: wait on THIS connection
-            s.settimeout( max( 0.05, deadline - time.monotonic() ) )
+        try:                                           # connected is not served: wait on THIS connection, to the ceiling
+            s.settimeout( secondsLeft( deadline ) )
             s.sendall( b"GET /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n" )
-            if s.recv( 16 ).startswith( b"HTTP/1." ):
+            got = b""
+            while len( got ) < len( status ):          # the status prefix and no further, however it is split
+                chunk = recvBefore( s, deadline, len( status ) - len( got ) )
+                if not chunk:
+                    break
+                got += chunk
+            if got == status:
                 return ""
         except OSError:
             pass
@@ -70,28 +97,39 @@ def contentLength( head ):
     return None
 
 def post( port, body, extraHeaders = b"", timeoutSec = REQUEST_TIMEOUT_SEC ):
-    """The body of one POST /mcp, read to its Content-Length. Raises NoAnswer when there is no body to judge."""
+    """The body of one POST /mcp, read to its Content-Length. Raises NoAnswer when there is no body to judge.
+
+    `timeoutSec` is ONE deadline for the whole request, connect through the last body byte: every blocking call waits
+    only for what is left of it, so a listener that keeps sending cannot keep the request alive."""
     req = ( b"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n" + extraHeaders
             + b"Accept: application/json, text/event-stream\r\nContent-Length: " + str( len( body ) ).encode()
             + b"\r\n\r\n" + body )
+    started  = time.monotonic()
+    deadline = started + timeoutSec
     try:
         s = socket.create_connection( ( "127.0.0.1", port ), timeoutSec )
     except OSError as e:
         raise NoAnswer( "could not connect to 127.0.0.1:%d (%s)" % ( port, e ) )
-    got = b""
+    got, tail, length = b"", b"", None
     try:
+        s.settimeout( secondsLeft( deadline ) )
         s.sendall( req )
         while True:
             head, sep, tail = got.partition( b"\r\n\r\n" )
             length = contentLength( head ) if sep else None
-            if length is not None and len( tail ) >= length:
-                return tail[ :length ].decode( "utf-8", "replace" )
-            chunk = s.recv( 65536 )
+            if length is not None and len( tail ) > length:
+                raise NoAnswer( "the server sent %d body bytes against a declared Content-Length of %d: a garbled answer, "
+                                "not a body to cut to length" % ( len( tail ), length ) )
+            if length is not None and len( tail ) == length:
+                return tail.decode( "utf-8", "replace" )
+            chunk = recvBefore( s, deadline, 65536 if length is None else min( 65536, length - len( tail ) ) )
             if not chunk:
                 break
             got += chunk
     except socket.timeout:
-        raise NoAnswer( "HTTP request timed out after %g s with %d response bytes" % ( timeoutSec, len( got ) ) )
+        raise NoAnswer( "HTTP request timed out after %g s with %d response bytes (%.2f s elapsed%s)"
+                        % ( timeoutSec, len( got ), time.monotonic() - started,
+                            "" if length is None else "; %d of the %d body bytes its Content-Length declares" % ( len( tail ), length ) ) )
     except OSError as e:
         raise NoAnswer( "HTTP request failed after %d response bytes (%s)" % ( len( got ), e ) )
     finally:

--- a/test/lib/gatehttp.sh
+++ b/test/lib/gatehttp.sh
@@ -1,0 +1,130 @@
+# gatehttp.sh — the ONE HTTP client shared by the gates that start `ripwire --listen`. SOURCED, not run.
+#
+# Sourced by mcpframehonestycheck.sh (arms I and K2), mcpcontractcheck.sh (arm E) and mcptoolprunecheck.sh. It lives
+# under test/lib/ because pargates.py and every gate-conformance sweep treat a top-level test/*.sh as a GATE.
+#
+#   gatehttp_install DIR  writes DIR/gatehttp.py and prints its path; returns 1 if it could not. That file is a module
+#                         (sys.path.insert( 0, DIR ); import gatehttp -> waitServing, post, NoAnswer) and a command:
+#                             python3 DIR/gatehttp.py wait PORT PID                -> exit 0 | exit 1 + the sentence
+#                             python3 DIR/gatehttp.py post PORT BODY [TIMEOUT_SEC] -> exit 0 + body | exit 3 + the sentence
+#
+# ONE CLIENT, because every hand-copied one turned a request that got NO ANSWER into an answer. An uncaught recv
+# timeout left the body empty, and the empty string went on to be judged: "transports DIFFER … http=" in
+# mcpframehonestycheck (CI 2026-09-12, release macos-14, shard 2/4, first frame only), a traceback that silenced every
+# later arm in mcpcontractcheck, "premise BROKEN" in mcptoolprunecheck. `post` reads the body to its Content-Length; a
+# timeout, a refused connect, a close without a response or a short body raises NoAnswer, whose sentence names which.
+# The sentence is context-free: each caller adds what the silence is NOT (a transport difference, a catalog verdict).
+#
+# READY MEANS ANSWERED. A port that ACCEPTS is not a server that answers: runMcpHttp (src/mcpserver.h) listen()s,
+# then warms the pinned index, and only then enters its accept loop, while the kernel completes handshakes into the
+# backlog. A fixed sleep (mcpcontractcheck's was 2 s) or an accept poll hands whatever warm-up remains to the first
+# request's timeout. waitServing polls until a GET /mcp is ANSWERED (any status line proves the accept loop runs:
+# 405 bare, 401 under a token) and gives up the moment the child dies.
+#
+# The two timeouts, measured 2026-09-12 (M-series, 18 cores, test/fixture, cold $TMPDIR, RIPWIRE_MCP_TIMINGS=1): the
+# port accepts 0.02–0.06 s after spawn and the first answer lands 0.09–0.11 s after that (0.11–0.19 s with 36 nice-10
+# busy loops starving a nice-19 server); every later request answers in < 1 ms, dispatch 0.005–0.06 ms. The 30 s
+# serving ceiling is ~150x the starved warm-up; the 5 s default request timeout bounds dispatch alone, and a caller
+# whose verbs do real work passes its own. Both are hang tripwires, not performance bars.
+
+gatehttp_install()
+{
+    local dest="$1/gatehttp.py"
+    cat >"$dest" <<'PY' || return 1
+import os, socket, sys, time
+
+SERVING_CEILING_SEC = 30.0
+REQUEST_TIMEOUT_SEC = 5.0
+
+class NoAnswer( Exception ):
+    """There is no response body to judge; str() is the sentence that says why."""
+
+def waitServing( port, isAlive, ceilingSec = SERVING_CEILING_SEC ):
+    """'' once the listener on `port` ANSWERS an HTTP request, else the sentence naming why it never did."""
+    deadline = time.monotonic() + ceilingSec
+    while time.monotonic() < deadline:
+        if not isAlive():
+            return "the HTTP listener exited before it answered a request"
+        try:
+            s = socket.create_connection( ( "127.0.0.1", port ), 0.25 )
+        except OSError:
+            time.sleep( 0.02 )
+            continue
+        try:                                           # connected is not served: wait on THIS connection
+            s.settimeout( max( 0.05, deadline - time.monotonic() ) )
+            s.sendall( b"GET /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n" )
+            if s.recv( 16 ).startswith( b"HTTP/1." ):
+                return ""
+        except OSError:
+            pass
+        finally:
+            s.close()
+        time.sleep( 0.02 )
+    return "the HTTP listener never ANSWERED a request on 127.0.0.1:%d within %g s" % ( port, ceilingSec )
+
+def contentLength( head ):
+    for line in head.split( b"\r\n" )[ 1: ]:
+        key, sep, value = line.partition( b":" )
+        if sep and key.strip().lower() == b"content-length" and value.strip().isdigit():
+            return int( value.strip() )
+    return None
+
+def post( port, body, extraHeaders = b"", timeoutSec = REQUEST_TIMEOUT_SEC ):
+    """The body of one POST /mcp, read to its Content-Length. Raises NoAnswer when there is no body to judge."""
+    req = ( b"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n" + extraHeaders
+            + b"Accept: application/json, text/event-stream\r\nContent-Length: " + str( len( body ) ).encode()
+            + b"\r\n\r\n" + body )
+    try:
+        s = socket.create_connection( ( "127.0.0.1", port ), timeoutSec )
+    except OSError as e:
+        raise NoAnswer( "could not connect to 127.0.0.1:%d (%s)" % ( port, e ) )
+    got = b""
+    try:
+        s.sendall( req )
+        while True:
+            head, sep, tail = got.partition( b"\r\n\r\n" )
+            length = contentLength( head ) if sep else None
+            if length is not None and len( tail ) >= length:
+                return tail[ :length ].decode( "utf-8", "replace" )
+            chunk = s.recv( 65536 )
+            if not chunk:
+                break
+            got += chunk
+    except socket.timeout:
+        raise NoAnswer( "HTTP request timed out after %g s with %d response bytes" % ( timeoutSec, len( got ) ) )
+    except OSError as e:
+        raise NoAnswer( "HTTP request failed after %d response bytes (%s)" % ( len( got ), e ) )
+    finally:
+        s.close()
+    head, sep, tail = got.partition( b"\r\n\r\n" )
+    if not sep:
+        raise NoAnswer( "the server closed the connection without an HTTP response (%d bytes)" % len( got ) )
+    if contentLength( head ) is not None:
+        raise NoAnswer( "the server closed after %d of %d body bytes" % ( len( tail ), contentLength( head ) ) )
+    return tail.decode( "utf-8", "replace" )
+
+if __name__ == "__main__":
+    verb, port = sys.argv[1], int( sys.argv[2] )
+    if verb == "wait":                                 # wait PORT PID -> exit 0 | exit 1 + the sentence
+        pid = int( sys.argv[3] )
+        def isAlive():
+            try:
+                os.kill( pid, 0 )
+                return True
+            except OSError:
+                return False
+        why = waitServing( port, isAlive )
+        sys.stdout.write( why )
+        sys.exit( 1 if why else 0 )
+    if verb == "post":                                 # post PORT BODY [TIMEOUT_SEC] -> exit 0 + body | exit 3 + the sentence
+        try:
+            sys.stdout.write( post( port, sys.argv[3].encode(),
+                                    timeoutSec = float( sys.argv[4] ) if len( sys.argv ) > 4 else REQUEST_TIMEOUT_SEC ) )
+        except NoAnswer as e:
+            sys.stdout.write( str( e ) )
+            sys.exit( 3 )
+        sys.exit( 0 )
+    sys.exit( 2 )
+PY
+    printf '%s' "$dest"
+}

--- a/test/mcpcontractcheck.sh
+++ b/test/mcpcontractcheck.sh
@@ -32,10 +32,17 @@ TMP="$( mktemp -d )"; trap 'rm -rf "$TMP"' EXIT
 [ -x "$BIN" ] || { echo "no ripwire binary at $BIN — build first (cmake --build build -j)"; exit 2; }
 echo "mcpcontractcheck: BIN=$BIN"
 
-python3 - "$BIN" "$ROOT" "$TMP" <<'PY'
-import hashlib, json, os, re, shutil, socket, subprocess, sys, time
+# Arm (E)'s HTTP client is the one the --listen gates share (test/lib/gatehttp.sh): it waits until the listener
+# ANSWERS, and a request that gets no answer is a FAIL of its own rather than a body to compare.
+. "$ROOT/test/lib/gatehttp.sh"
+GATEHTTP="$( gatehttp_install "$TMP" )" || { echo "could not write the shared HTTP client into $TMP"; exit 2; }
 
-BIN, ROOT, TMP = sys.argv[1], sys.argv[2], sys.argv[3]
+python3 - "$BIN" "$ROOT" "$TMP" "$GATEHTTP" <<'PY'
+import hashlib, json, os, re, shutil, subprocess, sys
+
+BIN, ROOT, TMP, GATEHTTP = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+sys.path.insert( 0, os.path.dirname( GATEHTTP ) )
+import gatehttp                    # waitServing / post / NoAnswer: see test/lib/gatehttp.sh
 fails = 0
 def check( cond, msg ):
     global fails
@@ -266,43 +273,48 @@ check( "result" in unknownVer,
 
 # ═══ (E) stdio == HTTP, byte for byte, on the arms this gate added ═════════════════════════════════════════
 # Wave 1 established that HTTP inherits the shared dispatchMcpLine. That is asserted here, not assumed.
+#
+# READY MEANS ANSWERED, and a request with no answer is not a body. This arm used to sleep a fixed 2 s and then post
+# through its own client, whose 5 s recv timeout nothing caught: a listener still warming its index handed the rest
+# of the warm-up to the first frame, and when that ran out Python died with "TimeoutError: timed out", taking every
+# arm after this one with it and failing the gate for a transport that was fine. gatehttp.waitServing polls until the
+# listener ANSWERS (30 s ceiling); gatehttp.post raises NoAnswer, which is reported per frame and never compared.
+FRAMES = ( '{"jsonrpc":"2.0","id":7,"method":"tools/list"}',
+           '{"jsonrpc":"2.0","id":7,"method":"ping"}',
+           '{"jsonrpc":"2.0","id":true,"method":"ping"}',
+           '{"jsonrpc":"2.0","id":7,"method":"initialize","params":{"protocolVersion":5}}',
+           '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"analyze","arguments":{"kind":"x"}}}' )
 port  = 24000 + ( os.getpid() % 6000 )
 token = "mc-%d" % os.getpid()
 http  = subprocess.Popen( [ BIN, rA, "--listen=127.0.0.1:%d" % port, "--mcp-token=" + token ],
                           stdout = subprocess.PIPE, stderr = subprocess.STDOUT )
-time.sleep( 2.0 )
-if http.poll() is not None:
-    check( False, "(E) the HTTP listener did not start: %s" % http.stdout.read()[ :180 ].decode( "utf-8", "replace" ) )
-else:
-    def post( line ):
-        body = line.encode()
-        req  = ( b"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n"
-                 b"Authorization: Bearer " + token.encode() +
-                 b"\r\nAccept: application/json, text/event-stream\r\nContent-Length: "
-                 + str( len( body ) ).encode() + b"\r\n\r\n" + body )
-        s = socket.create_connection( ( "127.0.0.1", port ), 5 ); s.sendall( req )
-        chunks = b""
-        while True:
-            c = s.recv( 65536 )
-            if not c: break
-            chunks += c
-            head, sep, tail = chunks.partition( b"\r\n\r\n" )
-            if sep and tail.strip().endswith( b"}" ): break
-        s.close()
-        return chunks.partition( b"\r\n\r\n" )[ 2 ].decode( "utf-8", "replace" ).strip()
-
-    stdio  = Stdio( rA )
-    differ = []
-    for line in ( '{"jsonrpc":"2.0","id":7,"method":"tools/list"}',
-                  '{"jsonrpc":"2.0","id":7,"method":"ping"}',
-                  '{"jsonrpc":"2.0","id":true,"method":"ping"}',
-                  '{"jsonrpc":"2.0","id":7,"method":"initialize","params":{"protocolVersion":5}}',
-                  '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"analyze","arguments":{"kind":"x"}}}' ):
-        s, h = stdio.raw( line ), post( line )
-        if s != h: differ.append( ( line[ :60 ], s[ :70 ], h[ :70 ] ) )
-    stdio.close()
-    for l, s, h in differ: print( "  FAIL  (E) %s\n           stdio=%s\n           http =%s" % ( l, s, h ) )
-    check( not differ, "(E) stdio == HTTP byte-for-byte on all 5 contract frames (asserted, not assumed)" )
+try:
+    whyNotServing = gatehttp.waitServing( port, lambda: http.poll() is None )
+    if http.poll() is not None:
+        check( False, "(E) the HTTP listener did not start: %s" % http.stdout.read()[ :180 ].decode( "utf-8", "replace" ) )
+    elif whyNotServing:
+        check( False, "(E) " + whyNotServing )
+    else:
+        auth   = b"Authorization: Bearer " + token.encode() + b"\r\n"
+        stdio  = Stdio( rA )
+        differ, noAnswer = [], []
+        try:
+            for line in FRAMES:
+                s = stdio.raw( line )
+                try:
+                    h = gatehttp.post( port, line.encode(), auth ).strip()
+                except gatehttp.NoAnswer as e:     # no body is not a DIFFERENT body: name it, never compare it
+                    noAnswer.append( ( line[ :60 ], str( e ) ) )
+                    continue
+                if s != h: differ.append( ( line[ :60 ], s[ :70 ], h[ :70 ] ) )
+        finally:
+            stdio.close()
+        for l, why in noAnswer: print( "  FAIL  (E) %s\n           no HTTP answer: %s — not a transport difference" % ( l, why ) )
+        for l, s, h in differ:  print( "  FAIL  (E) %s\n           stdio=%s\n           http =%s" % ( l, s, h ) )
+        check( not noAnswer, "(E) all %d contract frames got an HTTP answer (%d did not)" % ( len( FRAMES ), len( noAnswer ) ) )
+        check( not differ,   "(E) stdio == HTTP byte-for-byte on all %d answered contract frames (asserted, not assumed)"
+                             % ( len( FRAMES ) - len( noAnswer ) ) )
+finally:                                   # every path, an escaping exception included, stops the listener
     http.terminate()
     try:    http.wait( 10 )
     except Exception: http.kill()

--- a/test/mcpframehonestycheck.sh
+++ b/test/mcpframehonestycheck.sh
@@ -553,6 +553,61 @@ case "$CTRL" in
     *) no "(I0) control: a silent listener did not come back as a named no-answer (exit|stdout): $CTRL";;
 esac
 
+# (I0) CONTROL, the listener that DOES send: a head declaring a Content-Length it never delivers, then one body byte
+# every 0.5 s. A timeout set on each recv never fires on that, because every byte restarts it, so the request lived as
+# long as the trickle did (review of PR #188). The 2 s deadline is the whole request's: the stand-in times its
+# connection from accept to the client's hang-up, so the bound is read off the wire rather than off the client's own
+# sentence, and a 10 s kill turns a client that no longer keeps its deadline into this row's FAIL instead of a hang.
+trickle_listener_post(){ python3 - "$GATEHTTP" <<'PY'
+import select, socket, subprocess, sys, threading, time
+TIMEOUT_SEC, MARGIN_SEC, KILL_SEC = 2.0, 1.0, 10.0
+stand = socket.socket(); stand.bind( ( "127.0.0.1", 0 ) ); stand.listen( 1 ); stand.settimeout( KILL_SEC )
+lived = []                                      # accept -> the client's hang-up, as the stand-in saw it
+def trickle():
+    try:
+        conn, _ = stand.accept()
+    except OSError:
+        return
+    accepted = time.monotonic()
+    try:
+        conn.sendall( b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1000000\r\n\r\n{" )
+        while time.monotonic() - accepted < KILL_SEC + 5:
+            if select.select( [ conn ], [], [], 0.5 )[ 0 ]:
+                if not conn.recv( 65536 ):      # EOF is the hang-up; the request's own bytes are drained unread
+                    break
+            else:
+                conn.sendall( b" " )
+    except OSError:                             # a reset or a broken pipe is the hang-up too
+        pass
+    lived.append( time.monotonic() - accepted )
+    conn.close()
+server = threading.Thread( target = trickle ); server.start()
+try:
+    r = subprocess.run( [ sys.executable, sys.argv[1], "post", str( stand.getsockname()[1] ), "{}", "%g" % TIMEOUT_SEC ],
+                        stdout = subprocess.PIPE, timeout = KILL_SEC )
+    rc, said = r.returncode, r.stdout.decode( "utf-8", "replace" )
+except subprocess.TimeoutExpired:
+    rc, said = None, ""
+server.join(); stand.close()
+if rc is None:
+    print( "FAIL|the client was still waiting when it was killed %g s in: the trickle kept a %g s request alive"
+           % ( KILL_SEC, TIMEOUT_SEC ) )
+elif rc != 3 or not said.startswith( "HTTP request timed out after %g s" % TIMEOUT_SEC ):
+    print( "FAIL|not a named timeout (exit %d): %s" % ( rc, said[ :200 ] ) )
+elif not lived or lived[ 0 ] > TIMEOUT_SEC + MARGIN_SEC:
+    print( "FAIL|a named timeout, but the connection lived %s against a %g s deadline + %g s margin: %s"
+           % ( "%.2f s" % lived[ 0 ] if lived else "an unmeasured time", TIMEOUT_SEC, MARGIN_SEC, said ) )
+else:
+    print( "PASS|the connection lived %.2f s against a %g s deadline (+ %g s margin): %s"
+           % ( lived[ 0 ], TIMEOUT_SEC, MARGIN_SEC, said ) )
+PY
+}
+TRICKLE="$( trickle_listener_post )"
+case "$TRICKLE" in
+    "PASS|"*) ok "(I0) control: a listener that trickles a body it never finishes is a NAMED no-answer at the request's deadline — ${TRICKLE#PASS|}";;
+    *) no "(I0) control: a trickling listener outlived the request's deadline, or was not a named no-answer — ${TRICKLE#FAIL|}";;
+esac
+
 PORT=$(( 21000 + ( $$ % 9000 ) ))
 "$BIN" "$FIX" --listen=127.0.0.1:"$PORT" >"$TMP/http.log" 2>&1 &
 HTTP_PID=$!
@@ -1002,10 +1057,11 @@ elif whyNotServing:
     http.terminate(); http.wait( 15 )
 else:
     auth   = b"Authorization: Bearer " + token.encode() + b"\r\n"
-    stdio  = StdioServer( ws )
-    before = identity( target )
+    stdio  = None
     differ, remoteApplied, noAnswer = [], [], []
-    try:
+    try:                                            # the SETUP is inside too: StdioServer raises if its process will not
+        stdio  = StdioServer( ws )                  # start or initialize, identity() from os.stat or open, and either one
+        before = identity( target )                 # before this `try` skipped the terminate below and orphaned the listener
         for verb, field in WRITE_VERBS:
             for cp in inSet[ ::3 ]:
                 line = json.dumps( { "jsonrpc": "2.0", "id": 7, "method": "tools/call",
@@ -1019,9 +1075,12 @@ else:
                     continue
                 if s != h:                          differ.append( ( verb, cp, s[ :90 ], h[ :90 ] ) )
                 if '"error"' not in h:              remoteApplied.append( ( verb, cp ) )
-    finally:                                        # an escaping exception must not orphan a live listener
-        http.terminate(); http.wait( 15 )
-    stdio.close()
+    finally:                                        # a raise anywhere above, setup included, must not orphan the listener:
+        try:                                        # stdio is closed only if it was created, and the listener is
+            if stdio is not None:                   # terminated and reaped even when that close raises
+                stdio.close()
+        finally:
+            http.terminate(); http.wait( 15 )
     for verb, cp, why in noAnswer[ :5 ]:
         print( "  FAIL  (K2) %-20s U+%04X no HTTP answer: %s — not a transport difference" % ( verb, cp, why ) )
     for verb, cp, s, h in differ[ :5 ]:

--- a/test/mcpframehonestycheck.sh
+++ b/test/mcpframehonestycheck.sh
@@ -528,130 +528,19 @@ echo "=== (I) the HTTP transport returns BYTE-IDENTICAL bodies for the same byte
 # ═══════════════════════════════════════════════════════════════════════════════════════════════════════════
 # The framing gate lives in dispatchMcpLine, which both transports route through — so this arm asserts EQUALITY
 # with the stdio answers above rather than re-listing the expectations (a second list is a second thing to drift).
-# ONE HTTP CLIENT, written once below and shared with (K2). It used to be two hand-copied clients (already
-# drifting), and both turned a request that got NO ANSWER into an answer: an uncaught recv timeout left stdout
-# empty, and that empty string was compared with the stdio body and reported as "transports DIFFER … http=" —
-# which is how one slow CI runner read on 2026-09-12 (release macos-14, shard 2/4, first frame only). The client
-# now reads the body to its Content-Length; a timeout, a refused connect, a close without a response or a short
-# body exits 3 with the sentence that names it. A no-answer is its own FAIL, never a body to compare.
-#
-# WAIT ON THE CONDITION — the RIGHT one. A port that ACCEPTS is not a server that ANSWERS: runMcpHttp
-# (src/mcpserver.h) listen()s, then warms the pinned index (getIndex), and only then enters its accept loop, while
-# the kernel completes handshakes into the backlog. Polling for an accept handed that whole warm-up to the FIRST
-# frame's 5 s recv timeout — which is why only the first frame failed. waitServing polls until the listener
-# answers a real request (GET /mcp: any status line proves the accept loop runs — 405 here, 401 under a token),
-# abandoning the wait the moment the child dies. Exit 1 covers both give-up reasons, which the caller tells apart.
-#
-# The two timeouts, measured 2026-09-12 (M-series, 18 cores, test/fixture, cold $TMPDIR, RIPWIRE_MCP_TIMINGS=1):
-# the port accepts 0.02–0.06 s after spawn and the first answer lands 0.09–0.11 s after that (0.11–0.19 s with
-# 36 nice-10 busy loops starving a nice-19 server); every later request answers in < 1 ms, dispatch 0.005–0.06 ms.
-# The 30 s serving ceiling is ~150x the starved warm-up, and the 5 s per-request timeout now bounds dispatch
-# alone, >= 5,000x its measured round trip. Both are hang tripwires, not performance bars.
-MCPHTTP="$TMP/mcphttp.py"
-cat >"$MCPHTTP" <<'PY'
-import os, socket, sys, time
-
-SERVING_CEILING_SEC = 30.0
-REQUEST_TIMEOUT_SEC = 5.0
-
-class NoAnswer( Exception ):
-    """There is no response body to compare; str() is the sentence that says why."""
-
-def waitServing( port, isAlive, ceilingSec = SERVING_CEILING_SEC ):
-    """'' once the listener on `port` ANSWERS an HTTP request, else the sentence naming why it never did."""
-    deadline = time.monotonic() + ceilingSec
-    while time.monotonic() < deadline:
-        if not isAlive():
-            return "the HTTP listener exited before it answered a request"
-        try:
-            s = socket.create_connection( ( "127.0.0.1", port ), 0.25 )
-        except OSError:
-            time.sleep( 0.02 )
-            continue
-        try:                                           # connected is not served: wait on THIS connection
-            s.settimeout( max( 0.05, deadline - time.monotonic() ) )
-            s.sendall( b"GET /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n" )
-            if s.recv( 16 ).startswith( b"HTTP/1." ):
-                return ""
-        except OSError:
-            pass
-        finally:
-            s.close()
-        time.sleep( 0.02 )
-    return "the HTTP listener never ANSWERED a request on 127.0.0.1:%d within %g s" % ( port, ceilingSec )
-
-def contentLength( head ):
-    for line in head.split( b"\r\n" )[ 1: ]:
-        key, sep, value = line.partition( b":" )
-        if sep and key.strip().lower() == b"content-length" and value.strip().isdigit():
-            return int( value.strip() )
-    return None
-
-def post( port, body, extraHeaders = b"", timeoutSec = REQUEST_TIMEOUT_SEC ):
-    """The body of one POST /mcp, read to its Content-Length. Raises NoAnswer when there is no body to compare."""
-    req = ( b"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n" + extraHeaders
-            + b"Accept: application/json, text/event-stream\r\nContent-Length: " + str( len( body ) ).encode()
-            + b"\r\n\r\n" + body )
-    try:
-        s = socket.create_connection( ( "127.0.0.1", port ), timeoutSec )
-    except OSError as e:
-        raise NoAnswer( "could not connect to 127.0.0.1:%d (%s) — not a transport difference" % ( port, e ) )
-    got = b""
-    try:
-        s.sendall( req )
-        while True:
-            head, sep, tail = got.partition( b"\r\n\r\n" )
-            length = contentLength( head ) if sep else None
-            if length is not None and len( tail ) >= length:
-                return tail[ :length ].decode( "utf-8", "replace" )
-            chunk = s.recv( 65536 )
-            if not chunk:
-                break
-            got += chunk
-    except socket.timeout:
-        raise NoAnswer( "HTTP request timed out after %g s with %d response bytes — not a transport difference"
-                        % ( timeoutSec, len( got ) ) )
-    except OSError as e:
-        raise NoAnswer( "HTTP request failed after %d response bytes (%s) — not a transport difference" % ( len( got ), e ) )
-    finally:
-        s.close()
-    head, sep, tail = got.partition( b"\r\n\r\n" )
-    if not sep:
-        raise NoAnswer( "the server closed the connection without an HTTP response (%d bytes) — not a transport difference"
-                        % len( got ) )
-    if contentLength( head ) is not None:
-        raise NoAnswer( "the server closed after %d of %d body bytes — not a transport difference"
-                        % ( len( tail ), contentLength( head ) ) )
-    return tail.decode( "utf-8", "replace" )
-
-if __name__ == "__main__":
-    verb, port = sys.argv[1], int( sys.argv[2] )
-    if verb == "wait":                                 # wait PORT PID → exit 0 | exit 1 + the sentence
-        pid = int( sys.argv[3] )
-        def isAlive():
-            try:
-                os.kill( pid, 0 )
-                return True
-            except OSError:
-                return False
-        why = waitServing( port, isAlive )
-        sys.stdout.write( why )
-        sys.exit( 1 if why else 0 )
-    if verb == "post":                                 # post PORT BODY [TIMEOUT_SEC] → exit 0 + body | exit 3 + the sentence
-        try:
-            sys.stdout.write( post( port, sys.argv[3].encode(),
-                                    timeoutSec = float( sys.argv[4] ) if len( sys.argv ) > 4 else REQUEST_TIMEOUT_SEC ) )
-        except NoAnswer as e:
-            sys.stdout.write( str( e ) )
-            sys.exit( 3 )
-        sys.exit( 0 )
-    sys.exit( 2 )
-PY
+# ONE HTTP CLIENT, shared with (K2) below and with mcpcontractcheck (E) and mcptoolprunecheck: test/lib/gatehttp.sh
+# carries it and its reasons. READY MEANS ANSWERED: a port that accepts may still be warming its index, and polling
+# for an accept handed that warm-up to the FIRST frame's 5 s recv timeout, which is why only the first frame failed.
+# A request that gets NO ANSWER is its own FAIL with the sentence that names it, never a body to compare: an uncaught
+# timeout used to leave an empty string that was compared with the stdio body and reported as "transports DIFFER …
+# http=", which is how one slow CI runner read on 2026-09-12 (release macos-14, shard 2/4, first frame only).
+. "$ROOT/test/lib/gatehttp.sh"
+GATEHTTP="$( gatehttp_install "$TMP" )" || no "(I) could not write the shared HTTP client into $TMP"
 
 # (I0) CONTROL, so the no-answer path is observed live rather than asserted in prose: a socket that listen()s and
 # never accept()s — what a warming or starved listener looks like from outside — goes through the SAME `post`
 # command the loop below runs (a 0.5 s timeout keeps it cheap) and must come back as exit 3 + a named timeout.
-silent_listener_post(){ python3 - "$MCPHTTP" <<'PY'
+silent_listener_post(){ python3 - "$GATEHTTP" <<'PY'
 import socket, subprocess, sys
 silent = socket.socket(); silent.bind( ( "127.0.0.1", 0 ) ); silent.listen( 1 )
 r = subprocess.run( [ sys.executable, sys.argv[1], "post", str( silent.getsockname()[1] ), "{}", "0.5" ], stdout = subprocess.PIPE )
@@ -667,7 +556,7 @@ esac
 PORT=$(( 21000 + ( $$ % 9000 ) ))
 "$BIN" "$FIX" --listen=127.0.0.1:"$PORT" >"$TMP/http.log" 2>&1 &
 HTTP_PID=$!
-WHY="$( python3 "$MCPHTTP" wait "$PORT" "$HTTP_PID" )"; SERVING=$?
+WHY="$( python3 "$GATEHTTP" wait "$PORT" "$HTTP_PID" )"; SERVING=$?
 if ! kill -0 "$HTTP_PID" 2>/dev/null; then
     no "(I) the HTTP listener did not start: $( head -c 200 "$TMP/http.log" )"
 elif [ "$SERVING" != 0 ]; then
@@ -681,9 +570,9 @@ else
                  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":5}'; do
         label="$( printf '%s' "$frame" | cut -c1-46 )…"
         S="$( raw_one "$frame" )"
-        H="$( python3 "$MCPHTTP" post "$PORT" "$frame" 2>"$TMP/http_client.err" )"; HRC=$?
+        H="$( python3 "$GATEHTTP" post "$PORT" "$frame" 2>"$TMP/http_client.err" )"; HRC=$?
         if [ "$HRC" != 0 ]; then
-            no "(I) no HTTP answer for $label  $H$( [ -s "$TMP/http_client.err" ] && printf '  client stderr: %s' "$( tail -c 200 "$TMP/http_client.err" | tr '\n' ' ' )" )"
+            no "(I) no HTTP answer for $label  $H — not a transport difference$( [ -s "$TMP/http_client.err" ] && printf '  client stderr: %s' "$( tail -c 200 "$TMP/http_client.err" | tr '\n' ' ' )" )"
         elif [ "$S" = "$H" ]; then
             ok "(I) stdio == HTTP for $label"
         else
@@ -884,12 +773,12 @@ case $? in
     *) no "(K0) src/infra/blanktext.h kBlankRanges no longer matches test/derive_blankcodepoints.py: $( tail -4 "$TMP/derive.log" | tr '\n' ' ' )";;
 esac
 
-python3 - "$BIN" "$ROOT" "$MCPHTTP" <<'PY'
+python3 - "$BIN" "$ROOT" "$GATEHTTP" <<'PY'
 import hashlib, json, os, re, shutil, subprocess, sys, tempfile
 
-BIN, ROOT, MCPHTTP = sys.argv[1], sys.argv[2], sys.argv[3]
-sys.path.insert( 0, os.path.dirname( MCPHTTP ) )
-import mcphttp                     # arm (I)'s one HTTP client: a request with no answer raises NoAnswer, never compares
+BIN, ROOT, GATEHTTP = sys.argv[1], sys.argv[2], sys.argv[3]
+sys.path.insert( 0, os.path.dirname( GATEHTTP ) )
+import gatehttp                     # arm (I)'s one HTTP client: a request with no answer raises NoAnswer, never compares
 SRC = ( "// alpha adds one.\nint alpha( int x ) { return x + 1; }\n\n"
         "// beta doubles.\nint beta( int x ) { return x * 2; }\n" )
 SURROGATES  = range( 0xD800, 0xE000 )
@@ -1099,12 +988,12 @@ target = os.path.join( ws, "a.h" )
 http  = subprocess.Popen( [ BIN, ws, "--listen=127.0.0.1:%d" % port, "--allow-remote-edits",
                             "--mcp-token=" + token ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
 
-# WAIT ON THE CONDITION — the one arm (I)'s client comment names: mcphttp.waitServing polls until the listener
+# WAIT ON THE CONDITION — the one arm (I)'s client comment names: gatehttp.waitServing polls until the listener
 # ANSWERS a request (30 s ceiling), because a port that accepts may still be warming its index. A give-up FAILS the
 # arm rather than letting the remote sweep fall through against a listener that is not serving. `http.stdout` is
 # only read once the child has EXITED — reading a live child's pipe would block forever, which is the one thing a
 # timeout path must not do.
-whyNotServing = mcphttp.waitServing( port, lambda: http.poll() is None )
+whyNotServing = gatehttp.waitServing( port, lambda: http.poll() is None )
 if http.poll() is not None:
     check( False, "(K2) the --allow-remote-edits listener did not start: %s"
                   % http.stdout.read()[ :180 ].decode( "utf-8", "replace" ) )
@@ -1124,8 +1013,8 @@ else:
                                                  "arguments": { "symbol": "alpha", "file": "a.h", field: chr( cp ) } } } )
                 s = stdio.sendRaw( line )
                 try:
-                    h = mcphttp.post( port, line.encode(), auth ).strip()
-                except mcphttp.NoAnswer as e:       # no body is not a DIFFERENT body: name it, never compare it
+                    h = gatehttp.post( port, line.encode(), auth ).strip()
+                except gatehttp.NoAnswer as e:       # no body is not a DIFFERENT body: name it, never compare it
                     noAnswer.append( ( verb, cp, str( e ) ) )
                     continue
                 if s != h:                          differ.append( ( verb, cp, s[ :90 ], h[ :90 ] ) )
@@ -1134,7 +1023,7 @@ else:
         http.terminate(); http.wait( 15 )
     stdio.close()
     for verb, cp, why in noAnswer[ :5 ]:
-        print( "  FAIL  (K2) %-20s U+%04X no HTTP answer: %s" % ( verb, cp, why ) )
+        print( "  FAIL  (K2) %-20s U+%04X no HTTP answer: %s — not a transport difference" % ( verb, cp, why ) )
     for verb, cp, s, h in differ[ :5 ]:
         print( "  FAIL  (K2) %-20s U+%04X transports DIFFER  stdio=%s  http=%s" % ( verb, cp, s, h ) )
     for verb, cp in remoteApplied[ :5 ]:

--- a/test/mcpframehonestycheck.sh
+++ b/test/mcpframehonestycheck.sh
@@ -528,62 +528,167 @@ echo "=== (I) the HTTP transport returns BYTE-IDENTICAL bodies for the same byte
 # ═══════════════════════════════════════════════════════════════════════════════════════════════════════════
 # The framing gate lives in dispatchMcpLine, which both transports route through — so this arm asserts EQUALITY
 # with the stdio answers above rather than re-listing the expectations (a second list is a second thing to drift).
-# WAIT ON THE CONDITION, not on a guess: poll until the listener ACCEPTS a TCP connection on $PORT (20 ms
-# interval, 30 s ceiling), abandoning the wait the moment the child dies. Exit 1 covers both give-up reasons,
-# which the caller then tells apart — a dead child and a live-but-unreachable one are different faults and
-# get different sentences. Either way the arm FAILS loudly; it never probes a server that is not there.
-wait_listening(){ python3 - "$1" "$2" <<'PY'
+# ONE HTTP CLIENT, written once below and shared with (K2). It used to be two hand-copied clients (already
+# drifting), and both turned a request that got NO ANSWER into an answer: an uncaught recv timeout left stdout
+# empty, and that empty string was compared with the stdio body and reported as "transports DIFFER … http=" —
+# which is how one slow CI runner read on 2026-09-12 (release macos-14, shard 2/4, first frame only). The client
+# now reads the body to its Content-Length; a timeout, a refused connect, a close without a response or a short
+# body exits 3 with the sentence that names it. A no-answer is its own FAIL, never a body to compare.
+#
+# WAIT ON THE CONDITION — the RIGHT one. A port that ACCEPTS is not a server that ANSWERS: runMcpHttp
+# (src/mcpserver.h) listen()s, then warms the pinned index (getIndex), and only then enters its accept loop, while
+# the kernel completes handshakes into the backlog. Polling for an accept handed that whole warm-up to the FIRST
+# frame's 5 s recv timeout — which is why only the first frame failed. waitServing polls until the listener
+# answers a real request (GET /mcp: any status line proves the accept loop runs — 405 here, 401 under a token),
+# abandoning the wait the moment the child dies. Exit 1 covers both give-up reasons, which the caller tells apart.
+#
+# The two timeouts, measured 2026-09-12 (M-series, 18 cores, test/fixture, cold $TMPDIR, RIPWIRE_MCP_TIMINGS=1):
+# the port accepts 0.02–0.06 s after spawn and the first answer lands 0.09–0.11 s after that (0.11–0.19 s with
+# 36 nice-10 busy loops starving a nice-19 server); every later request answers in < 1 ms, dispatch 0.005–0.06 ms.
+# The 30 s serving ceiling is ~150x the starved warm-up, and the 5 s per-request timeout now bounds dispatch
+# alone, >= 5,000x its measured round trip. Both are hang tripwires, not performance bars.
+MCPHTTP="$TMP/mcphttp.py"
+cat >"$MCPHTTP" <<'PY'
 import os, socket, sys, time
-port, pid = int( sys.argv[1] ), int( sys.argv[2] )
-deadline = time.time() + 30.0
-while time.time() < deadline:
-    try:               os.kill( pid, 0 )              # the child is gone — stop waiting on a dead port
-    except OSError:    sys.exit( 1 )
+
+SERVING_CEILING_SEC = 30.0
+REQUEST_TIMEOUT_SEC = 5.0
+
+class NoAnswer( Exception ):
+    """There is no response body to compare; str() is the sentence that says why."""
+
+def waitServing( port, isAlive, ceilingSec = SERVING_CEILING_SEC ):
+    """'' once the listener on `port` ANSWERS an HTTP request, else the sentence naming why it never did."""
+    deadline = time.monotonic() + ceilingSec
+    while time.monotonic() < deadline:
+        if not isAlive():
+            return "the HTTP listener exited before it answered a request"
+        try:
+            s = socket.create_connection( ( "127.0.0.1", port ), 0.25 )
+        except OSError:
+            time.sleep( 0.02 )
+            continue
+        try:                                           # connected is not served: wait on THIS connection
+            s.settimeout( max( 0.05, deadline - time.monotonic() ) )
+            s.sendall( b"GET /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n" )
+            if s.recv( 16 ).startswith( b"HTTP/1." ):
+                return ""
+        except OSError:
+            pass
+        finally:
+            s.close()
+        time.sleep( 0.02 )
+    return "the HTTP listener never ANSWERED a request on 127.0.0.1:%d within %g s" % ( port, ceilingSec )
+
+def contentLength( head ):
+    for line in head.split( b"\r\n" )[ 1: ]:
+        key, sep, value = line.partition( b":" )
+        if sep and key.strip().lower() == b"content-length" and value.strip().isdigit():
+            return int( value.strip() )
+    return None
+
+def post( port, body, extraHeaders = b"", timeoutSec = REQUEST_TIMEOUT_SEC ):
+    """The body of one POST /mcp, read to its Content-Length. Raises NoAnswer when there is no body to compare."""
+    req = ( b"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n" + extraHeaders
+            + b"Accept: application/json, text/event-stream\r\nContent-Length: " + str( len( body ) ).encode()
+            + b"\r\n\r\n" + body )
     try:
-        socket.create_connection( ( "127.0.0.1", port ), 0.25 ).close()
+        s = socket.create_connection( ( "127.0.0.1", port ), timeoutSec )
+    except OSError as e:
+        raise NoAnswer( "could not connect to 127.0.0.1:%d (%s) — not a transport difference" % ( port, e ) )
+    got = b""
+    try:
+        s.sendall( req )
+        while True:
+            head, sep, tail = got.partition( b"\r\n\r\n" )
+            length = contentLength( head ) if sep else None
+            if length is not None and len( tail ) >= length:
+                return tail[ :length ].decode( "utf-8", "replace" )
+            chunk = s.recv( 65536 )
+            if not chunk:
+                break
+            got += chunk
+    except socket.timeout:
+        raise NoAnswer( "HTTP request timed out after %g s with %d response bytes — not a transport difference"
+                        % ( timeoutSec, len( got ) ) )
+    except OSError as e:
+        raise NoAnswer( "HTTP request failed after %d response bytes (%s) — not a transport difference" % ( len( got ), e ) )
+    finally:
+        s.close()
+    head, sep, tail = got.partition( b"\r\n\r\n" )
+    if not sep:
+        raise NoAnswer( "the server closed the connection without an HTTP response (%d bytes) — not a transport difference"
+                        % len( got ) )
+    if contentLength( head ) is not None:
+        raise NoAnswer( "the server closed after %d of %d body bytes — not a transport difference"
+                        % ( len( tail ), contentLength( head ) ) )
+    return tail.decode( "utf-8", "replace" )
+
+if __name__ == "__main__":
+    verb, port = sys.argv[1], int( sys.argv[2] )
+    if verb == "wait":                                 # wait PORT PID → exit 0 | exit 1 + the sentence
+        pid = int( sys.argv[3] )
+        def isAlive():
+            try:
+                os.kill( pid, 0 )
+                return True
+            except OSError:
+                return False
+        why = waitServing( port, isAlive )
+        sys.stdout.write( why )
+        sys.exit( 1 if why else 0 )
+    if verb == "post":                                 # post PORT BODY [TIMEOUT_SEC] → exit 0 + body | exit 3 + the sentence
+        try:
+            sys.stdout.write( post( port, sys.argv[3].encode(),
+                                    timeoutSec = float( sys.argv[4] ) if len( sys.argv ) > 4 else REQUEST_TIMEOUT_SEC ) )
+        except NoAnswer as e:
+            sys.stdout.write( str( e ) )
+            sys.exit( 3 )
         sys.exit( 0 )
-    except OSError:    time.sleep( 0.02 )
-sys.exit( 1 )
+    sys.exit( 2 )
+PY
+
+# (I0) CONTROL, so the no-answer path is observed live rather than asserted in prose: a socket that listen()s and
+# never accept()s — what a warming or starved listener looks like from outside — goes through the SAME `post`
+# command the loop below runs (a 0.5 s timeout keeps it cheap) and must come back as exit 3 + a named timeout.
+silent_listener_post(){ python3 - "$MCPHTTP" <<'PY'
+import socket, subprocess, sys
+silent = socket.socket(); silent.bind( ( "127.0.0.1", 0 ) ); silent.listen( 1 )
+r = subprocess.run( [ sys.executable, sys.argv[1], "post", str( silent.getsockname()[1] ), "{}", "0.5" ], stdout = subprocess.PIPE )
+sys.stdout.write( "%d|%s" % ( r.returncode, r.stdout.decode( "utf-8", "replace" ) ) )
 PY
 }
+CTRL="$( silent_listener_post )"
+case "$CTRL" in
+    "3|HTTP request timed out after 0.5 s"*) ok "(I0) control: a listener that accepts and never answers is a NAMED no-answer, not an empty body";;
+    *) no "(I0) control: a silent listener did not come back as a named no-answer (exit|stdout): $CTRL";;
+esac
+
 PORT=$(( 21000 + ( $$ % 9000 ) ))
 "$BIN" "$FIX" --listen=127.0.0.1:"$PORT" >"$TMP/http.log" 2>&1 &
 HTTP_PID=$!
-wait_listening "$PORT" "$HTTP_PID"; LISTENING=$?
+WHY="$( python3 "$MCPHTTP" wait "$PORT" "$HTTP_PID" )"; SERVING=$?
 if ! kill -0 "$HTTP_PID" 2>/dev/null; then
     no "(I) the HTTP listener did not start: $( head -c 200 "$TMP/http.log" )"
-elif [ "$LISTENING" != 0 ]; then
-    no "(I) the HTTP listener never ACCEPTED on 127.0.0.1:$PORT within 30 s: $( head -c 200 "$TMP/http.log" )"
+elif [ "$SERVING" != 0 ]; then
+    no "(I) $WHY: $( head -c 200 "$TMP/http.log" )"
     kill "$HTTP_PID" 2>/dev/null; wait "$HTTP_PID" 2>/dev/null
 else
-    http_body(){ python3 - "$PORT" "$1" <<'PY'
-import socket, sys
-port, body = int( sys.argv[1] ), sys.argv[2].encode()
-req = ( b"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n"
-        b"Accept: application/json, text/event-stream\r\nContent-Length: " + str( len( body ) ).encode()
-        + b"\r\n\r\n" + body )
-s = socket.create_connection( ( "127.0.0.1", port ), 5 ); s.sendall( req )
-chunks = b""
-while True:
-    c = s.recv( 65536 )
-    if not c: break
-    chunks += c
-    head, sep, tail = chunks.partition( b"\r\n\r\n" )
-    if sep and tail.endswith( b"}" ): break
-s.close()
-sys.stdout.write( chunks.partition( b"\r\n\r\n" )[2].decode( "utf-8", "replace" ) )
-PY
-    }
     for frame in '{"jsonrpc":"2.0","id":1,"method":"tools/list"' \
                  '[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]' \
                  '{"jsonrpc":"2.0","id":1,"method":"tools/list"}{"jsonrpc":"2.0","id":2,"method":"initialize"}' \
                  '{"jsonrpc":"2.0","id":1,"method":5}' \
                  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":5}'; do
+        label="$( printf '%s' "$frame" | cut -c1-46 )…"
         S="$( raw_one "$frame" )"
-        H="$( http_body "$frame" )"
-        [ "$S" = "$H" ] \
-            && ok "(I) stdio == HTTP for $( printf '%s' "$frame" | cut -c1-46 )…" \
-            || no "(I) transports DIFFER for $( printf '%s' "$frame" | cut -c1-46 )…  stdio=$( printf '%s' "$S" | cut -c1-90 )  http=$( printf '%s' "$H" | cut -c1-90 )"
+        H="$( python3 "$MCPHTTP" post "$PORT" "$frame" 2>"$TMP/http_client.err" )"; HRC=$?
+        if [ "$HRC" != 0 ]; then
+            no "(I) no HTTP answer for $label  $H$( [ -s "$TMP/http_client.err" ] && printf '  client stderr: %s' "$( tail -c 200 "$TMP/http_client.err" | tr '\n' ' ' )" )"
+        elif [ "$S" = "$H" ]; then
+            ok "(I) stdio == HTTP for $label"
+        else
+            no "(I) transports DIFFER for $label  stdio=$( printf '%s' "$S" | cut -c1-90 )  http=$( printf '%s' "$H" | cut -c1-90 )"
+        fi
     done
     kill "$HTTP_PID" 2>/dev/null
     wait "$HTTP_PID" 2>/dev/null
@@ -779,10 +884,12 @@ case $? in
     *) no "(K0) src/infra/blanktext.h kBlankRanges no longer matches test/derive_blankcodepoints.py: $( tail -4 "$TMP/derive.log" | tr '\n' ' ' )";;
 esac
 
-python3 - "$BIN" "$ROOT" <<'PY'
-import hashlib, json, os, re, shutil, socket, subprocess, sys, tempfile, time
+python3 - "$BIN" "$ROOT" "$MCPHTTP" <<'PY'
+import hashlib, json, os, re, shutil, subprocess, sys, tempfile
 
-BIN, ROOT = sys.argv[1], sys.argv[2]
+BIN, ROOT, MCPHTTP = sys.argv[1], sys.argv[2], sys.argv[3]
+sys.path.insert( 0, os.path.dirname( MCPHTTP ) )
+import mcphttp                     # arm (I)'s one HTTP client: a request with no answer raises NoAnswer, never compares
 SRC = ( "// alpha adds one.\nint alpha( int x ) { return x + 1; }\n\n"
         "// beta doubles.\nint beta( int x ) { return x * 2; }\n" )
 SURROGATES  = range( 0xD800, 0xE000 )
@@ -992,68 +1099,53 @@ target = os.path.join( ws, "a.h" )
 http  = subprocess.Popen( [ BIN, ws, "--listen=127.0.0.1:%d" % port, "--allow-remote-edits",
                             "--mcp-token=" + token ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
 
-# WAIT ON THE CONDITION: poll until the listener ACCEPTS on `port` (20 ms interval, 30 s ceiling), returning
-# early if the child dies. A timeout FAILS the arm here rather than letting a 96-probe sweep fall through
-# against a socket nobody is listening on. `http.stdout` is only read once the child has EXITED — reading a
-# live child's pipe would block forever, which is the one thing a timeout path must not do.
-def waitListening( port, proc, timeoutSec = 30.0 ):
-    deadline = time.time() + timeoutSec
-    while time.time() < deadline:
-        if proc.poll() is not None: return False
-        try:
-            socket.create_connection( ( "127.0.0.1", port ), 0.25 ).close()
-            return True
-        except OSError:
-            time.sleep( 0.02 )
-    return False
-
-listening = waitListening( port, http )
+# WAIT ON THE CONDITION — the one arm (I)'s client comment names: mcphttp.waitServing polls until the listener
+# ANSWERS a request (30 s ceiling), because a port that accepts may still be warming its index. A give-up FAILS the
+# arm rather than letting the remote sweep fall through against a listener that is not serving. `http.stdout` is
+# only read once the child has EXITED — reading a live child's pipe would block forever, which is the one thing a
+# timeout path must not do.
+whyNotServing = mcphttp.waitServing( port, lambda: http.poll() is None )
 if http.poll() is not None:
     check( False, "(K2) the --allow-remote-edits listener did not start: %s"
                   % http.stdout.read()[ :180 ].decode( "utf-8", "replace" ) )
-elif not listening:
-    check( False, "(K2) the --allow-remote-edits listener never ACCEPTED on 127.0.0.1:%d within 30 s" % port )
+elif whyNotServing:
+    check( False, "(K2) " + whyNotServing )
     http.terminate(); http.wait( 15 )
 else:
-    def post( line ):
-        body = line.encode()
-        req  = ( b"POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n"
-                 b"Authorization: Bearer " + token.encode() + b"\r\n"
-                 b"Accept: application/json, text/event-stream\r\nContent-Length: "
-                 + str( len( body ) ).encode() + b"\r\n\r\n" + body )
-        s = socket.create_connection( ( "127.0.0.1", port ), 5 ); s.sendall( req )
-        chunks = b""
-        while True:
-            c = s.recv( 65536 )
-            if not c: break
-            chunks += c
-            head, sep, tail = chunks.partition( b"\r\n\r\n" )
-            if sep and tail.strip().endswith( b"}" ): break
-        s.close()
-        return chunks.partition( b"\r\n\r\n" )[ 2 ].decode( "utf-8", "replace" ).strip()
-
+    auth   = b"Authorization: Bearer " + token.encode() + b"\r\n"
     stdio  = StdioServer( ws )
     before = identity( target )
-    differ, remoteApplied = [], []
-    for verb, field in WRITE_VERBS:
-        for cp in inSet[ ::3 ]:
-            line = json.dumps( { "jsonrpc": "2.0", "id": 7, "method": "tools/call",
-                                 "params": { "name": verb,
-                                             "arguments": { "symbol": "alpha", "file": "a.h", field: chr( cp ) } } } )
-            s, h = stdio.sendRaw( line ), post( line )
-            if s != h:                          differ.append( ( verb, cp, s[ :90 ], h[ :90 ] ) )
-            if '"error"' not in h:              remoteApplied.append( ( verb, cp ) )
+    differ, remoteApplied, noAnswer = [], [], []
+    try:
+        for verb, field in WRITE_VERBS:
+            for cp in inSet[ ::3 ]:
+                line = json.dumps( { "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                                     "params": { "name": verb,
+                                                 "arguments": { "symbol": "alpha", "file": "a.h", field: chr( cp ) } } } )
+                s = stdio.sendRaw( line )
+                try:
+                    h = mcphttp.post( port, line.encode(), auth ).strip()
+                except mcphttp.NoAnswer as e:       # no body is not a DIFFERENT body: name it, never compare it
+                    noAnswer.append( ( verb, cp, str( e ) ) )
+                    continue
+                if s != h:                          differ.append( ( verb, cp, s[ :90 ], h[ :90 ] ) )
+                if '"error"' not in h:              remoteApplied.append( ( verb, cp ) )
+    finally:                                        # an escaping exception must not orphan a live listener
+        http.terminate(); http.wait( 15 )
     stdio.close()
+    for verb, cp, why in noAnswer[ :5 ]:
+        print( "  FAIL  (K2) %-20s U+%04X no HTTP answer: %s" % ( verb, cp, why ) )
     for verb, cp, s, h in differ[ :5 ]:
         print( "  FAIL  (K2) %-20s U+%04X transports DIFFER  stdio=%s  http=%s" % ( verb, cp, s, h ) )
     for verb, cp in remoteApplied[ :5 ]:
         print( "  FAIL  (K2) %-20s U+%04X APPLIED over the remote transport" % ( verb, cp ) )
     probes = len( inSet[ ::3 ] ) * len( WRITE_VERBS )
-    check( not differ,        "(K2) %d probes byte-identical stdio vs HTTP (%d differed)" % ( probes, len( differ ) ) )
+    check( not noAnswer,      "(K2) all %d remote probes got an HTTP answer (%d did not)" % ( probes, len( noAnswer ) ) )
+    check( not differ,        "(K2) %d answered probes byte-identical stdio vs HTTP (%d differed)"
+                              % ( probes - len( noAnswer ), len( differ ) ) )
     check( not remoteApplied, "(K2) every remote probe REFUSED (%d applied)" % len( remoteApplied ) )
     check( identity( target ) == before,
            "(K2) the workspace file is byte-identical after %d remote blank-payload writes" % probes )
-    http.terminate(); http.wait( 15 )
 shutil.rmtree( ws, ignore_errors=True )
 
 print( "  INFO  (K) %d ranges x 4 boundaries, 3 write verbs, 2 transports" % len( ranges ) )

--- a/test/mcptoolprunecheck.sh
+++ b/test/mcptoolprunecheck.sh
@@ -58,9 +58,13 @@ SRV_PID=""
 cleanup(){ [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null; rm -rf "$TMP"; }
 
 [ -x "$BIN" ] || { echo "no ripwire binary at $BIN — build first (cmake --build build -j)"; exit 2; }
-command -v python3 >/dev/null 2>&1 || { echo "python3 required for JSON assertions"; exit 2; }
-command -v curl    >/dev/null 2>&1 || { echo "curl required (present on macOS/Linux)"; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 required for JSON assertions and the HTTP client"; exit 2; }
 command -v git     >/dev/null 2>&1 || { echo "git required (arm G pins a GIT workspace)"; exit 2; }
+
+# The HTTP client the --listen gates share (test/lib/gatehttp.sh), so a listener that never answers, or a request that
+# gets no answer, is reported as exactly that.
+. "$ROOT/test/lib/gatehttp.sh"
+GATEHTTP="$( gatehttp_install "$TMP" )" || { echo "could not write the shared HTTP client into $TMP"; exit 2; }
 
 echo "mcptoolprunecheck: BIN=$BIN"
 
@@ -114,23 +118,32 @@ git -C "$EMPTYGIT" rev-parse --show-toplevel >/dev/null 2>&1 \
     || { echo "the empty git workspace is not even inside a repo (git init failed?) — arm H is void"; exit 2; }
 
 PORT=$(( 21000 + ( $$ % 4000 ) ))
-ACCEPT='application/json, text/event-stream'
 
+# Ready means ANSWERED: `wait` polls until the listener answers a request (30 s ceiling) and stops the moment the
+# child dies; either give-up leaves its sentence in $TMP/srv.why for the caller's refusal line.
 start_pinned() { # $1 = workspace root
     "$BIN" "$1" --listen=127.0.0.1:"$PORT" >"$TMP/srv.out" 2>"$TMP/srv.err" &
     SRV_PID=$!
-    for _ in $( seq 1 60 ); do
-        curl -s -o /dev/null -m 1 -H "Accept: $ACCEPT" -H 'Content-Type: application/json' \
-             -X POST "http://127.0.0.1:$PORT/mcp" -d '{"jsonrpc":"2.0","id":0,"method":"initialize"}' 2>/dev/null && return 0
-        kill -0 "$SRV_PID" 2>/dev/null || return 1
-        sleep 0.1
-    done
-    return 1
+    python3 "$GATEHTTP" wait "$PORT" "$SRV_PID" >"$TMP/srv.why"
 }
 stop_pinned() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null; wait "$SRV_PID" 2>/dev/null; SRV_PID=""; }
-http_call() {
-    curl -s -H "Accept: $ACCEPT" -H 'Content-Type: application/json' \
-         -X POST "http://127.0.0.1:$PORT/mcp" -d "$1"
+# A request that gets NO ANSWER is its own FAIL, never a body to parse. The curl call this replaced had no timeout and
+# handed an empty reply to the parsers below, which read the silence as a verdict on the catalog ("advertises 0 verbs",
+# "premise BROKEN", "pruned on a REAL git repo"), beside a PASS for "(A) omitted" that nothing had answered. Every
+# later arm would only re-read that silence, so the gate stops at the first one. 30 s is a hang tripwire, not a
+# performance bar: the slowest request here measured 0.14 s (quality_baseline, rebuilt=1; 2026-09-12, M-series).
+REQUEST_TIMEOUT_SEC=30
+http_call() { # $1 = the JSON-RPC line, $2 = the file the response body goes to
+    local body rc
+    body="$( python3 "$GATEHTTP" post "$PORT" "$1" "$REQUEST_TIMEOUT_SEC" 2>"$TMP/client.err" )"; rc=$?
+    if [ "$rc" = 0 ]; then
+        printf '%s' "$body" >"$2"
+        return 0
+    fi
+    no "no HTTP answer for $( printf '%s' "$1" | cut -c1-72 )…: $body$( [ -s "$TMP/client.err" ] && printf '  client stderr: %s' "$( tail -c 200 "$TMP/client.err" | tr '\n' ' ' )" ) — there is no body to check, so the arms that read one cannot run"
+    stop_pinned
+    echo
+    echo "SOME CHECKS FAILED"; exit 1
 }
 stdio_call() { # $1 = workspace root (positional startup root), $2 = the JSON-RPC line
     printf '%s\n%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize"}' "$2" \
@@ -149,9 +162,9 @@ print(" ".join(t["name"] for t in r["result"]["tools"]))
 echo
 echo "=== (A) [red] NON-GIT pinned root: the three git-only verbs are omitted from tools/list ==="
 # ════════════════════════════════════════════════════════════════════════════════════════════════════
-start_pinned "$NOGIT" || { echo "listener on the non-git workspace failed to start: $( head -3 "$TMP/srv.err" )"; exit 1; }
-http_call '{"jsonrpc":"2.0","id":1,"method":"initialize"}' > "$TMP/nogit.init"
-http_call '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' > "$TMP/nogit.list"
+start_pinned "$NOGIT" || { echo "listener on the non-git workspace failed to start: $( cat "$TMP/srv.why" ): $( head -3 "$TMP/srv.err" )"; exit 1; }
+http_call '{"jsonrpc":"2.0","id":1,"method":"initialize"}' "$TMP/nogit.init"
+http_call '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' "$TMP/nogit.list"
 NOGIT_NAMES="$( python3 -c "$names_py" "$TMP/nogit.list" )"
 [ "$NOGIT_NAMES" = "__ERR__" ] && { no "(A) tools/list on the non-git pinned root returned an error"; NOGIT_NAMES=""; }
 
@@ -233,7 +246,7 @@ PY
 echo
 echo "=== (D) [red] an omitted verb still DISPATCHES — omission is discoverability, not removal ==="
 # ════════════════════════════════════════════════════════════════════════════════════════════════════
-http_call '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"owners","arguments":{}}}' > "$TMP/owners.res"
+http_call '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"owners","arguments":{}}}' "$TMP/owners.res"
 python3 - "$TMP/owners.res" <<'PY' > "$TMP/own.res" 2>&1
 import sys, json
 r = json.load(open(sys.argv[1]))
@@ -260,11 +273,11 @@ done
                   || no "(E) over-pruned — these answer without git but were omitted:$missing"
 
 # and PROVE the premise, so (E) is a measurement rather than a claim: each of the four answers here.
-http_call '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"cochange","arguments":{"file":"core/engine.cpp"}}}' > "$TMP/e.cochange"
-http_call '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"situational_awareness","arguments":{"files":"core/engine.cpp"}}}' > "$TMP/e.situ"
-http_call '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"edit_check","arguments":{"symbol":"engineStepA2"}}}' > "$TMP/e.editcheck"
-http_call '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"quality_baseline","arguments":{}}}' > /dev/null
-http_call '{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"quality_delta","arguments":{}}}' > "$TMP/e.qdelta"
+http_call '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"cochange","arguments":{"file":"core/engine.cpp"}}}' "$TMP/e.cochange"
+http_call '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"situational_awareness","arguments":{"files":"core/engine.cpp"}}}' "$TMP/e.situ"
+http_call '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"edit_check","arguments":{"symbol":"engineStepA2"}}}' "$TMP/e.editcheck"
+http_call '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"quality_baseline","arguments":{}}}' /dev/null
+http_call '{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"quality_delta","arguments":{}}}' "$TMP/e.qdelta"
 refused=""
 for f in cochange situ editcheck qdelta; do
     python3 -c '
@@ -303,9 +316,9 @@ grep -q QUIET "$TMP/fdisc" && ok "(F) stdio discloses no omission (nothing was o
 echo
 echo "=== (G) a GIT pinned root advertises all 31 and discloses nothing ==="
 # ════════════════════════════════════════════════════════════════════════════════════════════════════
-start_pinned "$GITWS" || { echo "listener on the git workspace failed to start: $( head -3 "$TMP/srv.err" )"; exit 1; }
-http_call '{"jsonrpc":"2.0","id":1,"method":"initialize"}' > "$TMP/git.init"
-http_call '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' > "$TMP/git.list"
+start_pinned "$GITWS" || { echo "listener on the git workspace failed to start: $( cat "$TMP/srv.why" ): $( head -3 "$TMP/srv.err" )"; exit 1; }
+http_call '{"jsonrpc":"2.0","id":1,"method":"initialize"}' "$TMP/git.init"
+http_call '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' "$TMP/git.list"
 GIT_NAMES="$( python3 -c "$names_py" "$TMP/git.list" )"
 GIT_COUNT="$( printf '%s' "$GIT_NAMES" | wc -w | tr -d ' ' )"
 [ "$GIT_COUNT" = "31" ] && ok "(G) git pinned root advertises all 31 verbs" \
@@ -334,9 +347,9 @@ echo "=== (H) [red] finding #7: an EMPTY git repo (git init, no commit) gets the
 # repository" — FALSE for this workspace, which IS a git repository, it just has no HEAD commit yet. Every
 # git-only verb's OWN per-request refusal already carries the honest qualifier ("not a git repository (or
 # no HEAD commit)"); the disclosure sentence must say the same thing, not a narrower false one.
-start_pinned "$EMPTYGIT" || { echo "listener on the empty-git workspace failed to start: $( head -3 "$TMP/srv.err" )"; exit 1; }
-http_call '{"jsonrpc":"2.0","id":1,"method":"initialize"}' > "$TMP/empty.init"
-http_call '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' > "$TMP/empty.list"
+start_pinned "$EMPTYGIT" || { echo "listener on the empty-git workspace failed to start: $( cat "$TMP/srv.why" ): $( head -3 "$TMP/srv.err" )"; exit 1; }
+http_call '{"jsonrpc":"2.0","id":1,"method":"initialize"}' "$TMP/empty.init"
+http_call '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' "$TMP/empty.list"
 stop_pinned
 
 EMPTY_NAMES="$( python3 -c "$names_py" "$TMP/empty.list" )"


### PR DESCRIPTION
Three gates start `ripwire --listen` and talk to it over HTTP. Each of them could turn "the server has not answered yet" into a verdict about the server.

## The mechanism

`runMcpHttp` calls `listen()` (`src/mcpserver.h` ~534) before it warms the index (~562) and starts accepting (~574). During warm-up the kernel still completes connections into the backlog, so "the port accepts" does not mean "the server is serving".

- **`mcpframehonestycheck` (I)** treated an accepted connection as ready. It then gave the first request a 5 s receive timeout that nothing caught. On a loaded macOS CI runner (shard 2/4, #186's first run), that first reply came back empty. The arm reported `transports DIFFER … http=`, an honesty failure against a server that answered every frame. A 7 s stall after accept reproduces it exactly, and the FAIL moves with the stall to whichever frame follows it.
- **`mcpcontractcheck` (E)** waited a fixed 2 s. A 9 s pause after accept made its Python client raise an uncaught `TimeoutError`, so arms (E), (G) and (F) never reported at all.
- **`mcptoolprunecheck`** polled correctly, but gave its requests no timeout and read an empty reply as a catalog. With the listener killed after its first answer, it printed a false `PASS (A) omitted`, plus `advertises 0 verbs` and `premise BROKEN`.

There is no server defect here. Every request was answered after every stall, and every reply carries a Content-Length and ends properly.

## The fix

One client, `test/lib/gatehttp.sh`, sits beside the existing sourced helpers, and all three gates use it.

- **Readiness is an answered `GET /mcp`**, within the existing 30 s ceiling. The per-request timeout now covers only the round trip. Locally, a cold first request took 0.09–0.19 s, and the slowest real request took 0.14 s.
- **A missing answer is its own FAIL.** A timeout, a refused connection, a close without a response, or a short body each produces a distinct sentence ("no HTTP answer … not a transport difference"). None of them is compared as a payload.
- **An (I0) control row** proves that a socket which accepts but never answers comes back as a named timeout.
- **`mcpframehonestycheck`'s second client** counts no-answers separately and always shuts its listener down.

## Red → green

A scratch wrapper around the real binary injected each listener fault.

| gate | fault | before | after |
| --- | --- | --- | --- |
| mcpframehonestycheck | 7 s stall after accept | `FAIL (I) transports DIFFER … http=` | 5 PASS |
| mcpframehonestycheck | stall after the first answer | `FAIL … DIFFER` | `FAIL (I) no HTTP answer … timed out after 5 s … not a transport difference` |
| mcpcontractcheck | 9 s pause after accept | `TimeoutError`; (E), (G), (F) never ran | 45 PASS |
| mcpcontractcheck | listener never answers | | `FAIL (E) … never ANSWERED … within 30 s`; the other 43 checks still run |
| mcptoolprunecheck | listener killed after its first answer | a false `PASS (A)`, three wrong verdicts, tracebacks | one FAIL: `no HTTP answer … Connection refused` |

## Not in this PR

`mcpremotecheck` has the same flaw: no request timeout, and an empty body reads as "HTTP payload differs from stdio". #187 edits that file, so it moves to the shared client after both PRs land.

## Verification

- `gates=14 pass=14 skip=0 fail=0`. That covers the five MCP gates, plus manifest, gateexit, worktreeleak, forrankorder, readmedrift, showcasecapture, docanchor, limitstable and gatecount, since the new tracked file brings in the live-tree gates.
- `limits_build --check` and `gatecount_build --check` both exit 0.
- The change is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
