### PR TITLE
fix(graph): --safe-delete, --impact and --path answered zero from a declaration and never mentioned the definitions they dropped

### DIFF
--- a/src/graphlegend.h
+++ b/src/graphlegend.h
@@ -540,8 +540,8 @@ inline std::string unprovenDefsVerbLegend( UnprovenDefsVerb verb, bool on )
         return {};
     }
     const char* const clause = verb == UnprovenDefsVerb::Impact ? kUnprovenDefsImpactLegend
-                             : verb == UnprovenDefsVerb::Path   ? kUnprovenDefsPathLegend
-                             :                                    kUnprovenDefsSafeDeleteLegend;
+                               : verb == UnprovenDefsVerb::Path ? kUnprovenDefsPathLegend
+                                                                : kUnprovenDefsSafeDeleteLegend;
     return std::string( clause ) + kUnprovenDefsProofTail;
 }
 

--- a/src/graphlegend.h
+++ b/src/graphlegend.h
@@ -498,6 +498,53 @@ inline std::string unprovenDefsKeyJson( std::size_t unprovenDefs )
     return unprovenDefs > 0 ? ",\"unproven_defs\":" + std::to_string( unprovenDefs ) : std::string();
 }
 
+// ── THE SAME RESIDUE ON THE VERBS THAT READ THE SAME RESOLVER — safe-delete, impact, path (decltodefcheck arm E2e) ──
+// resolveAllByNameQualified serves --safe-delete, --impact (and the MCP impact twin) and --path (and path_between)
+// exactly as it serves --callers, so a `file:name` selector whose definitions were dropped reached THOSE readers as
+// callers="0" risk="none-found", reaches="0" and reachable="0": the silent zero E2 closed on the callers form, on the
+// verb whose answer a reader acts on as "safe to delete". The attribute is the one the callers form carries —
+// unprovenDefsAttrXml / unprovenDefsKeyJson above, and compactlegend.h's existing unproven_defs row reads it off any
+// root — so the vocabulary does not grow. What differs per verb is what the dropped definitions are MISSING FROM, and
+// that is the clause: the callers sentence names defs= and rows, while --path has from_defs=/to_defs= and a yes/no,
+// and --safe-delete has a risk= value computed from counts that never walked them.
+//
+// One clause per verb, one shared proof-and-widen tail, emitted exactly when the attribute is (the caller passes its
+// own attribute-present condition, the unprovenDefsLegend( bool ) rule above). kUnprovenDefsLegend states the same
+// proof rule inline and is left byte-for-byte as it is: the callers/callees emitter that selects it is not this
+// change's, and its bytes are pinned there.
+//
+// G4: inside an XML comment, so no double hyphen anywhere. Each clause OPENS with `unproven_defs=` — the house form,
+// and the attribute test/compactlegendcheck.sh (S) reduces a conditionally-selected clause to.
+inline constexpr const char* kUnprovenDefsImpactLegend =
+    "unproven_defs=K (absent when 0) counts same-named DEFINITIONS this file:name selector found and could not tie to the file it named: they are NOT in defs=, the walk never started from them, and so none of their callers or importers is in reaches=, importers=, the radius partition or any row. ";
+inline constexpr const char* kUnprovenDefsPathLegend =
+    "unproven_defs=K (absent when 0) counts same-named DEFINITIONS a file:name endpoint found and could not tie to the file it named, summed over from= and to= (a bare NAME endpoint never adds to it): they are NOT in from_defs= or to_defs=, the search neither started nor ended at them, and so reachable= and hops= say nothing about a path through them. ";
+inline constexpr const char* kUnprovenDefsSafeDeleteLegend =
+    "unproven_defs=K (absent when 0) counts same-named DEFINITIONS this file:name selector found and could not tie to the file it named: they are NOT in defs=, and callers=, impact_reaches=, uses=, the tested partition and dead_code_candidate= were all read without them. So risk= describes defs= alone, and risk=none-found beside unproven_defs= is an INCOMPLETE read, never a sign that the name can go. ";
+inline constexpr const char* kUnprovenDefsProofTail =
+    "A declaration widens to the definitions it stands for only where the definition is IN the named file, or its own file includes the named file, resolved path-precisely; a same-named body anywhere else is not evidence and is never served. Widen the file:name spelling to the bare NAME, or to Scope::name, to include them. ";
+
+enum class UnprovenDefsVerb : std::uint8_t
+{
+    Impact,
+    Path,
+    SafeDelete,
+};
+
+// `on` is the emitter's own `unprovenDefs > 0`, never a re-derivation; "" otherwise, so an answer that dropped
+// nothing stays byte-identical on every one of these verbs.
+inline std::string unprovenDefsVerbLegend( UnprovenDefsVerb verb, bool on )
+{
+    if( !on )
+    {
+        return {};
+    }
+    const char* const clause = verb == UnprovenDefsVerb::Impact ? kUnprovenDefsImpactLegend
+                             : verb == UnprovenDefsVerb::Path   ? kUnprovenDefsPathLegend
+                             :                                    kUnprovenDefsSafeDeleteLegend;
+    return std::string( clause ) + kUnprovenDefsProofTail;
+}
+
 // M12's writeMultiRootTable/multiRootTableLegend (the multi-root roots-table disclosure --callers/--uses
 // reuse from the default map) live in serialize.h, not here: they need escapeXml, and serialize.h includes
 // THIS header (for rootRelPathsLegend) before its own escapeXml definition — putting them here would be

--- a/src/mcpverbs.h
+++ b/src/mcpverbs.h
@@ -2228,7 +2228,10 @@ inline std::string impactText( const std::string& root, const std::string& symbo
 
     // resolveAllByNameQualified — the SAME resolver the CLI --impact uses (byte-identical on a bare
     // name/canonical id), so this twin finally accepts file:name AND the @FILE:LINE line-seed too.
-    const std::vector<NodeId> seeds = resolveAllByNameQualified( ing, symbol );
+    // H1: the decl→def residue, the CLI --impact's unproven_defs= — same resolver, same helpers, so the two surfaces
+    // cannot disagree about the number.
+    std::size_t               unprovenDefs = 0;
+    const std::vector<NodeId> seeds        = resolveAllByNameQualified( ing, symbol, &unprovenDefs );
     if( seeds.empty() )
     {
         return {}; // symbol not found → caller reports not-found
@@ -2267,9 +2270,10 @@ inline std::string impactText( const std::string& root, const std::string& symbo
     // exactly the §B4 echo-site divergence the shared-constant rule exists to stop.
     // LB-H: the import tier's clause rides here too — the CLI legend and this one are byte-identical by
     // rule, and an attribute the MCP root now carries has to be defined where the caller meets it.
-    rw::emitTo( mem, "{}{}. {}{}{}{}{}{}{}-->", kImpactLegendOpen, kPageRaiseCapClause, kImpactImportTierLegend,
+    rw::emitTo( mem, "{}{}. {}{}{}{}{}{}{}{}-->", kImpactLegendOpen, kPageRaiseCapClause, kImpactImportTierLegend,
                   kTestedRowLegend, kImpactTestedPartitionLegend,   // A6
                   kTestedLensBlindSpotLegend,                       // F-02: rides with the partition, byte-identical to the CLI twin
+                  unprovenDefsVerbLegend( UnprovenDefsVerb::Impact, unprovenDefs > 0 ).c_str(),   // H1: exactly when the root carries unproven_defs=, as on the CLI
                   declinedCallsLegend( declinedCalls > 0 ),         // exactly when the root carries declined_calls=, as on the CLI
                   graphCountDisclosure( g.unindexedFiles > 0 ).c_str(), renderDisclosure( prD, DiscloseAs::LegendClause ).c_str() );
     // r27-emitters §P2.1: the listing is capped at 40 by rank. Without shown=/capped= a 40-row answer to
@@ -2289,8 +2293,8 @@ inline std::string impactText( const std::string& root, const std::string& symbo
     // LB-H: ONE derivation, shared with the CLI arm (graph.h::impactImportTier) — mcpclidiffcheck compares
     // the two surfaces' attribute sets, and an honesty marker that lands on one of them is the §B4 class.
     const ImportTier imports = impactImportTier( ing, seeds );
-    rw::emitTo( mem, "<impact of=\"{}\" defs=\"{}\" reaches=\"{}\"{} radius_tested=\"{}\" radius_untested=\"{}\"{}{}{}{}{}{}>",
-                  ex( symbol ).c_str(), seeds.size(), reach.size(),
+    rw::emitTo( mem, "<impact of=\"{}\" defs=\"{}\" reaches=\"{}\"{}{} radius_tested=\"{}\" radius_untested=\"{}\"{}{}{}{}{}{}>",
+                  ex( symbol ).c_str(), seeds.size(), reach.size(), unprovenDefsAttrXml( unprovenDefs ).c_str(),   // H1: where the CLI root carries it
                   imports.xmlAttrs.c_str(), radiusTested, radiusUntested, declinedCallsAttrXml( declinedCalls ).c_str(), imRootAttr.c_str(),
                   pageDisclosure( ipab, sizeof( ipab ), shownRows, show.size(), ipw.end, page.limit, page.offset, true ),
                   graphCountFloorAttrXml( g ).c_str(), renderDisclosure( prD, DiscloseAs::XmlAttrs ).c_str(),   // M15: gauge + marker
@@ -2578,8 +2582,12 @@ inline std::string pathText( const std::string& root, const std::string& from, c
     // r27-emitters §P2.10: resolve EVERY def of each endpoint and run ONE multi-source BFS (shortestPathAny),
     // exactly as the CLI --path now does. Binding `from` to the lowest-NodeId def reported reachable="0" for
     // paths that plainly exist, and the answer never said which def it had picked.
-    const std::vector<NodeId> srcDefs = resolveAllByNameQualified( ing, from );
-    const std::vector<NodeId> dstDefs = resolveAllByNameQualified( ing, to );
+    // H1: each endpoint's decl→def residue, summed onto the root exactly as the CLI --path sums it.
+    std::size_t               srcUnprovenDefs = 0;
+    std::size_t               dstUnprovenDefs = 0;
+    const std::vector<NodeId> srcDefs         = resolveAllByNameQualified( ing, from, &srcUnprovenDefs );
+    const std::vector<NodeId> dstDefs         = resolveAllByNameQualified( ing, to, &dstUnprovenDefs );
+    const std::size_t         unprovenDefs    = srcUnprovenDefs + dstUnprovenDefs;
     if( srcDefs.empty() || dstDefs.empty() )
     {
         return {}; // an endpoint not found → caller reports not-found
@@ -2612,10 +2620,11 @@ inline std::string pathText( const std::string& root, const std::string& from, c
     // verb has no legend of its own either, and the two dialects must not differ on what they explain.
     // H5: the same brief floor legend + marker the CLI --path prints (verbs_navigate.h) — one wording, two transports.
     rw::emitTo( mem, "<!-- ripwire path: one DIRECTED call path from= to to= (each <s> a hop); reachable= is 0 and hops= 0 when the "
-                       "graph holds none. {}-->{}", graphCountFloorBrief( g.unindexedFiles > 0 ).c_str(), rootRelPathsLegend( ptSingleRoot ) );
-    rw::emitTo( mem, "<path from=\"{}\" to=\"{}\" from_p=\"{}\" to_p=\"{}\" from_defs=\"{}\" to_defs=\"{}\" reachable=\"{}\" hops=\"{}\"{}{}",
+                       "graph holds none. {}{}-->{}", unprovenDefsVerbLegend( UnprovenDefsVerb::Path, unprovenDefs > 0 ).c_str(),
+                  graphCountFloorBrief( g.unindexedFiles > 0 ).c_str(), rootRelPathsLegend( ptSingleRoot ) );
+    rw::emitTo( mem, "<path from=\"{}\" to=\"{}\" from_p=\"{}\" to_p=\"{}\" from_defs=\"{}\" to_defs=\"{}\"{} reachable=\"{}\" hops=\"{}\"{}{}",
                   ex( from ).c_str(), ex( to ).c_str(), loc( srcUsed ).c_str(), loc( dstUsed ).c_str(),
-                  srcDefs.size(), dstDefs.size(),
+                  srcDefs.size(), dstDefs.size(), unprovenDefsAttrXml( unprovenDefs ).c_str(),   // H1: as the CLI root carries it
                   pth.empty() ? 0 : 1, pth.empty() ? std::size_t( 0 ) : pth.size() - 1, ptRootAttr.c_str(),
                   graphCountFloorAttrXml( g ).c_str()  );   // M15: gauge + marker
     if( pth.empty() )

--- a/src/verbs_navigate.h
+++ b/src/verbs_navigate.h
@@ -681,7 +681,11 @@ std::optional<int> runUses( const MainDispatch& d )
 // §G4: an XML comment may never contain the literal byte pair "--", so every sibling-verb mention below is
 // spelled WITHOUT its leading flag dashes (impact/uses/callers/dead-code) — the one departure from how this
 // file's prose comments spell them elsewhere.
-inline void emitSafeDeleteLegend( std::size_t defCount, std::size_t ambiguousCallers, std::string_view risk, bool singleRoot, bool hasUnindexed )
+//
+// H1's residue: `unprovenDefs` is the count resolveAllByNameQualified dropped for this selector. Its clause
+// (graphlegend.h kUnprovenDefsSafeDeleteLegend) follows the risk= sentence directly, because it is the sentence
+// that says what risk= did NOT read; emitted exactly when the root carries unproven_defs=, nothing otherwise.
+inline void emitSafeDeleteLegend( std::size_t defCount, std::size_t unprovenDefs, std::size_t ambiguousCallers, std::string_view risk, bool singleRoot, bool hasUnindexed )
 {
     rw::emitTo( stdout, "<!-- ripwire safe-delete: composes signals the tool already computes into one \"can I delete this?\" READ "
                 "— never a verdict. defs= is resolveAllByNameQualified's match count, exactly as the impact/uses/callers "
@@ -699,7 +703,7 @@ inline void emitSafeDeleteLegend( std::size_t defCount, std::size_t ambiguousCal
                 "hold here — run the dead-code verb for the full-corpus scan. ambiguous_callers= counts callers whose OWN "
                 "outgoing calls include at least one that resolved to more than one candidate definition (g.ambOut, the "
                 "same counter a ranked row's amb= reads). {}{}risk= NAMES what was found, never a go/no-go verdict, and "
-                "this run reports {}{}-->{}",
+                "this run reports {}{}{}-->{}",
                 // The union caveat, only when there is a union to caveat.
                 defCount > 1
                     ? "defs= is above 1 here, so EVERY count in this element UNIONS more than one physical definition "
@@ -719,6 +723,8 @@ inline void emitSafeDeleteLegend( std::size_t defCount, std::size_t ambiguousCal
                   : risk == "untested-radius"
                       ? "untested-radius: callers or uses exist, and NONE of the transitive blast radius is test-covered. "
                       : "uses-exist: callers or uses exist, and at least part of the radius is test-covered. ",
+                // H1: what risk= did not read, straight after the sentence for the value it qualifies.
+                rw::unprovenDefsVerbLegend( rw::UnprovenDefsVerb::SafeDelete, unprovenDefs > 0 ).c_str(),
                 rw::graphCountDisclosure( hasUnindexed ).c_str(), rw::rootRelPathsLegend( singleRoot ) );
 }
 
@@ -739,8 +745,12 @@ std::optional<int> runSafeDelete( const MainDispatch& d )
         return std::nullopt;
     }
 
-    // file:name disambiguates like --around/--lego/--edit-check/--impact/--uses/--callers.
-    const std::vector<NodeId> defs = resolveAllByNameQualified( ing, cfg.safeDeleteSym );
+    // file:name disambiguates like --around/--lego/--edit-check/--impact/--uses/--callers. H1: the out-param is the
+    // decl→def widening's RESIDUE — same-named definitions this selector found and could not tie to the file it
+    // named, so every count below is read without them. Unreported, a drop reached the reader as callers="0"
+    // risk="none-found": a "safe to delete" reading about definitions nobody walked.
+    std::size_t               sdUnprovenDefs = 0;
+    const std::vector<NodeId> defs           = resolveAllByNameQualified( ing, cfg.safeDeleteSym, &sdUnprovenDefs );
     if( defs.empty() )
     {
         // §B4.2: the shared did-you-mean refusal every SYM-taking verb speaks (selectorrefuse.h).
@@ -882,7 +892,7 @@ std::optional<int> runSafeDelete( const MainDispatch& d )
     // shared graphCountDisclosure() tail is untouched, byte for byte: test/floormarkcheck.sh pins it across
     // seven other verbs and a private shorter copy here would be exactly the dialect divergence it exists
     // to catch.
-    emitSafeDeleteLegend( defs.size(), ambiguousCallers, risk, sdSingleRoot, g.unindexedFiles > 0 );
+    emitSafeDeleteLegend( defs.size(), sdUnprovenDefs, ambiguousCallers, risk, sdSingleRoot, g.unindexedFiles > 0 );
 
     const Symbol&      lead = ing.symbols[ defs[0] ];   // resolveAllByNameQualified walks ascending id — defs[0] is the
                                                         // lowest, same convention --impact/--uses/--callers's of=/defs=
@@ -892,10 +902,11 @@ std::optional<int> runSafeDelete( const MainDispatch& d )
     const std::string  sdRootAttr = sdSingleRoot ? ( " root=\"" + ex( cfg.roots[0] ) + "\"" ) : std::string();
     rw::emitTo( stdout, "<safe-delete sym=\"{}\" t=\"{}\" p=\"{}:{}\" defs=\"{}\" callers=\"{}\" ambiguous_callers=\"{}\" "
                 "impact_reaches=\"{}\" uses=\"{}\" tested_self=\"{}\" radius_tested=\"{}\" radius_untested=\"{}\" "
-                "dead_code_candidate=\"{}\" risk=\"{}\"{}{}{}>",
+                "dead_code_candidate=\"{}\" risk=\"{}\"{}{}{}{}>",
                 ex( cfg.safeDeleteSym ).c_str(), symTag( lead.kind ), ex( sdPathRel( lead.fileId ) ).c_str(), lead.line,
                 defs.size(), callerIds.size(), ambiguousCallers, reach.size(), sites.size(), testedSelf ? 1 : 0,
                 radiusTested, radiusUntested, deadCodeCandidate ? 1 : 0, risk,
+                rw::unprovenDefsAttrXml( sdUnprovenDefs ).c_str(),   // H1: beside the verdict it qualifies; absent at zero
                 pageDisclosure( cab, sizeof( cab ), cw.end - cw.begin, callerIds.size(), cw.end, cfg.pageLimit, cfg.pageOffset, true ),
                 rw::graphCountFloorAttrXml( g ).c_str(), sdRootAttr.c_str() );
     for( std::size_t i = cw.begin; i < cw.end; ++i )
@@ -1858,8 +1869,16 @@ std::optional<int> runPath( const MainDispatch& d )
         // cost is unchanged (a single O(E) pass, not one BFS per def pair). `file:name` still disambiguates,
         // exactly as on --around/--lego/--callers, and the resolved endpoints are now echoed so the ambiguity
         // that remains is VISIBLE.
-        const std::vector<NodeId> srcDefs = resolveAllByNameQualified( ing, srcN );
-        const std::vector<NodeId> dstDefs = resolveAllByNameQualified( ing, dstN );
+        // H1: each out-param is that endpoint's decl→def residue — same-named definitions a file:name endpoint found
+        // and could not tie to the file it named, so the BFS below neither starts nor ends at them. Summed onto the
+        // root: the remedy is the same for either endpoint (widen its file:name spelling), a bare-name endpoint always
+        // adds 0, and the one existing attribute keeps the vocabulary where it is. Unreported, a drop reached the
+        // reader as a bare reachable="0".
+        std::size_t               srcUnprovenDefs = 0;
+        std::size_t               dstUnprovenDefs = 0;
+        const std::vector<NodeId> srcDefs         = resolveAllByNameQualified( ing, srcN, &srcUnprovenDefs );
+        const std::vector<NodeId> dstDefs         = resolveAllByNameQualified( ing, dstN, &dstUnprovenDefs );
+        const std::size_t         pthUnprovenDefs = srcUnprovenDefs + dstUnprovenDefs;
         if( srcDefs.empty() || dstDefs.empty() )
         {
             // §M7 (W3FIX): both endpoints resolve through resolveAllByNameQualified, i.e. the shared file:name
@@ -1891,10 +1910,11 @@ std::optional<int> runPath( const MainDispatch& d )
         // same question --verify=calls(A,B) answers `not-established` + counts_floor="1" for. Same marker,
         // same brief sentence, on both transports (mcpverbs.h path_between mirrors this line).
         rw::emitTo( stdout, "<!-- ripwire path: one DIRECTED call path from= to to= (each <s> a hop); reachable= is 0 and hops= 0 when the "
-                     "graph holds none. {}-->{}", rw::graphCountFloorBrief( g.unindexedFiles > 0 ).c_str(), rw::rootRelPathsLegend( pthSingleRoot ) );
-        rw::emitTo( stdout, "<path from=\"{}\" to=\"{}\" from_p=\"{}\" to_p=\"{}\" from_defs=\"{}\" to_defs=\"{}\" reachable=\"{}\" hops=\"{}\"{}{}",
+                     "graph holds none. {}{}-->{}", rw::unprovenDefsVerbLegend( rw::UnprovenDefsVerb::Path, pthUnprovenDefs > 0 ).c_str(),
+                     rw::graphCountFloorBrief( g.unindexedFiles > 0 ).c_str(), rw::rootRelPathsLegend( pthSingleRoot ) );
+        rw::emitTo( stdout, "<path from=\"{}\" to=\"{}\" from_p=\"{}\" to_p=\"{}\" from_defs=\"{}\" to_defs=\"{}\"{} reachable=\"{}\" hops=\"{}\"{}{}",
                      ex( srcN ).c_str(), ex( dstN ).c_str(), loc( srcUsed ).c_str(), loc( dstUsed ).c_str(),
-                     srcDefs.size(), dstDefs.size(),
+                     srcDefs.size(), dstDefs.size(), rw::unprovenDefsAttrXml( pthUnprovenDefs ).c_str(),   // H1: beside the defs counts it is not in
                      path.empty() ? 0 : 1, path.empty() ? std::size_t( 0 ) : path.size() - 1, pthRootAttr.c_str(),
                      rw::graphCountFloorAttrXml( g ).c_str() );
         // P2.10: a dead end is exactly the moment to name the next verb. --path is DIRECTED; --connect searches
@@ -2008,6 +2028,7 @@ struct ImpactView
     const rw::IngestResult&        ing;
     std::string_view               sym;
     std::size_t                    defs;
+    std::size_t                    unprovenDefs;    // H1: the decl→def residue — definitions the walk never started from
     std::size_t                    reaches;
     const std::vector<rw::NodeId>& show;
     rw::PageWindow                 page;
@@ -2045,6 +2066,7 @@ int emitImpactColumnar( const ImpactView& v )
     std::vector<NodeId>     rows( v.show.begin() + v.page.begin, v.show.begin() + v.page.end );
     const std::string       attr = "of=\"" + std::string( escapeXml( v.sym, esc ) ) + "\" defs=\"" + std::to_string( v.defs )
                                  + "\" reaches=\"" + std::to_string( v.reaches ) + "\""
+                                 + rw::unprovenDefsAttrXml( v.unprovenDefs )                      // H1: where the XML root carries it
                                  + " importers=\"" + std::to_string( v.imports.files.size() ) + "\""
                                  + " radius_tested=\"" + std::to_string( v.radiusTested )       // A6
                                  + "\" radius_untested=\"" + std::to_string( v.radiusUntested ) + "\""
@@ -2079,7 +2101,8 @@ int emitImpactJson( const ImpactView& v )
     using namespace rw;
     char ipab[ kPageDisclosureCap ];
     const std::size_t shownRows = v.page.end - v.page.begin;
-    rw::emitTo( stdout, "{{\"of\":\"{}\",\"defs\":{},\"reaches\":{}", jsonStr( v.sym ).c_str(), v.defs, v.reaches );
+    rw::emitTo( stdout, "{{\"of\":\"{}\",\"defs\":{},\"reaches\":{}{}", jsonStr( v.sym ).c_str(), v.defs, v.reaches,
+                 rw::unprovenDefsKeyJson( v.unprovenDefs ).c_str() );   // H1: absent at zero, like its XML twin
     rw::emitTo( stdout, ",\"importers\":{},\"shown_importers\":{},\"importers_capped\":{}",
                  v.imports.files.size(), v.imports.shown, v.imports.capped ? "true" : "false" );
     rw::emitTo( stdout, ",\"radius_tested\":{},\"radius_untested\":{}{}", v.radiusTested, v.radiusUntested,
@@ -2108,8 +2131,9 @@ int emitImpactXml( const ImpactView& v )
     const auto        ex        = [ & ]( std::string_view t ) -> std::string { return std::string( escapeXml( t, esc ) ); };
     char              ipab[ kPageDisclosureCap ];
     const std::size_t shownRows = v.page.end - v.page.begin;
-    rw::emitTo( stdout, "<impact of=\"{}\" defs=\"{}\" reaches=\"{}\"{} radius_tested=\"{}\" radius_untested=\"{}\"{}{}{}{}{}{}>",
-                 ex( v.sym ).c_str(), v.defs, v.reaches, v.imports.xmlAttrs.c_str(), v.radiusTested, v.radiusUntested,
+    rw::emitTo( stdout, "<impact of=\"{}\" defs=\"{}\" reaches=\"{}\"{}{} radius_tested=\"{}\" radius_untested=\"{}\"{}{}{}{}{}{}>",
+                 ex( v.sym ).c_str(), v.defs, v.reaches, rw::unprovenDefsAttrXml( v.unprovenDefs ).c_str(),   // H1: beside the reaches= it qualifies
+                 v.imports.xmlAttrs.c_str(), v.radiusTested, v.radiusUntested,
                  rw::declinedCallsAttrXml( v.declinedCalls ).c_str(),   // tier-3 declines into the radius
                  std::string( v.rootAttr ).c_str(),
                  pageDisclosure( ipab, sizeof( ipab ), shownRows, v.show.size(), v.page.end,
@@ -2145,8 +2169,11 @@ std::optional<int> runImpact( const MainDispatch& d )
     // --impact=SYM: transitive blast radius — every symbol that (transitively) reaches SYM via calls
     if( !cfg.impactSym.empty() )
     {
-        // X9(b): "file:name" disambiguates here too (same rule as --around/--lego/--edit-check).
-        const std::vector<NodeId> seeds = resolveAllByNameQualified( ing, cfg.impactSym );
+        // X9(b): "file:name" disambiguates here too (same rule as --around/--lego/--edit-check). H1: the out-param is the
+        // decl→def widening's residue — definitions the walk below never starts from, which reached the reader as a
+        // bare reaches="0". The MCP twin reads the same resolver through the same helpers.
+        std::size_t               imUnprovenDefs = 0;
+        const std::vector<NodeId> seeds          = resolveAllByNameQualified( ing, cfg.impactSym, &imUnprovenDefs );
         if( seeds.empty() )
         {
             rw::emitTo( stderr, "{}\n", selectorNotFoundMessage( ing, "ripwire: --impact symbol not found: ",
@@ -2187,10 +2214,11 @@ std::optional<int> runImpact( const MainDispatch& d )
             // twin cannot drift from this wording (the §B4 echo-site class).
             // LB-H: the import-tier clause is the columnar variant under --format=columnar, because that
             // form carries the count without the rows and a reader must be told which shape they hold.
-            rw::emitTo( stdout, "{}{}. {}{}{}{}{}{}{}-->", rw::kImpactLegendOpen, rw::kPageRaiseCapClause,
+            rw::emitTo( stdout, "{}{}. {}{}{}{}{}{}{}{}-->", rw::kImpactLegendOpen, rw::kPageRaiseCapClause,
                          cfg.columnar ? rw::kImpactImportTierColumnarLegend : rw::kImpactImportTierLegend,
                          rw::kTestedRowLegend, rw::kImpactTestedPartitionLegend,   // A6
                          rw::kTestedLensBlindSpotLegend,                           // F-02: rides with the partition
+                         rw::unprovenDefsVerbLegend( rw::UnprovenDefsVerb::Impact, imUnprovenDefs > 0 ).c_str(),   // H1: exactly when the root carries unproven_defs=
                          rw::declinedCallsLegend( imDeclinedCalls > 0 ),           // exactly when the root carries declined_calls=
                          rw::graphCountDisclosure( g.unindexedFiles > 0 ).c_str(), rw::renderDisclosure( prD, rw::DiscloseAs::LegendClause ).c_str() );
         }
@@ -2198,7 +2226,7 @@ std::optional<int> runImpact( const MainDispatch& d )
         // above runImpact; pageDisclosure emits the ` shown= capped=` bytes this verb used to hand-roll
         // (src/pageview.h, THE TRUNCATION VOCABULARY, rules 1-3). LB-G: the same NAMED constant
         // --callers/--callees use, so the family's default lives in one place instead of three literals.
-        const ImpactView view{ ing, cfg.impactSym, seeds.size(), reach.size(), show,
+        const ImpactView view{ ing, cfg.impactSym, seeds.size(), imUnprovenDefs, reach.size(), show,
                                pageWindow( show.size(), effectiveRowCap( cfg.pageLimit, rw::kCallHierarchyRowCap ), cfg.pageOffset ),
                                imports, importPage, importLazyPage, prD, imSingleRoot, imRootPrefix, imRootAttr,
                                imSingleRoot ? cfg.roots[0] : std::string_view(), cfg.pageLimit, cfg.pageOffset,

--- a/test/decltodefcheck.sh
+++ b/test/decltodefcheck.sh
@@ -46,6 +46,12 @@
 #       that defines it in the legend beside it; and BOTH are absent when nothing was dropped. The arm is
 #       there because a dropped candidate that the answer does not mention is a plain zero — which is the
 #       silence #63 exists to kill, so shipping (E) without (E2) would trade one honesty defect for another.
+#   (E2e..E2h) THE SAME RESIDUE ON THE VERBS THAT READ THE SAME RESOLVER. --safe-delete, --impact (XML, --json,
+#       --format=columnar, MCP impact) and --path (MCP path_between) resolve SYM through it too, and met the same
+#       drop as callers="0" risk="none-found", reaches="0" and reachable="0" with nothing saying so. Each now carries
+#       unproven_defs= with a clause worded for that verb (--path sums both endpoints, E2g), --safe-delete's clause
+#       addresses risk= itself so none-found does not stand as a safety reading (E2f), the existing compact row
+#       fires on all of them (E2h), and a fully-proven file:name or a bare name carries neither (E2e absent rows).
 #   (F) MUTATION — every assertion SHAPE above is shown able to fail, against hand-built inputs.
 #
 # WHAT (E) AND (E2) EACH COVER, since between them they close what was once a stated gap. (E) reads the
@@ -122,9 +128,45 @@ run(){ # run <corpus> <selector-flag>  → stdout to $2out
 run2(){ # run <corpus> <selector-flag> <dialect-flag> — the --json / --format=columnar spellings of the same answer
     "$BIN" "$1" --no-cache "$2" "$3" 2>/dev/null; }
 
+# The MCP twins: one JSON-RPC tools/call piped into `ripwire --mcp`, the TRANSCRIPT kept in a file so the reader that
+# decodes it can be shown able to fail on its own (arm F). <legend> is "full", or "" to leave the server's default.
+mcpTranscript(){ # mcpTranscript <out-file> <tool> <legend|""> <key=value>...
+    _out="$1" _tool="$2" _legend="$3"; shift 3
+    python3 - "$_tool" "$_legend" "$@" <<'PY' | "$BIN" --mcp >"$_out" 2>/dev/null
+import json, sys
+tool, legend = sys.argv[1], sys.argv[2]
+args = dict( kv.split( "=", 1 ) for kv in sys.argv[3:] )
+if legend:
+    args[ "legend" ] = legend
+print( json.dumps( { "jsonrpc": "2.0", "id": 1, "method": "initialize" } ) )
+print( json.dumps( { "jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": { "name": tool, "arguments": args } } ) )
+PY
+}
+
+# The payload text of a transcript's last response; an error response yields `__ERROR__:message`, never a payload.
+mcpPayload(){ python3 -c '
+import json,sys
+lines=[l for l in open(sys.argv[1]).read().splitlines() if l.strip()]
+try:
+    r=json.loads(lines[-1])
+except Exception:
+    sys.stdout.write("__ERROR__:no JSON-RPC response"); sys.exit(0)
+if "error" in r:
+    sys.stdout.write("__ERROR__:"+str(r["error"].get("message","")))
+else:
+    sys.stdout.write(r["result"]["content"][0]["text"])' "$1"; }
+
+# The unproven_defs= clause of a legend, as a span: from its `unproven_defs=K` opening to the floor tail every graph
+# verb's legend closes on (`counts_floor=`), or the comment's end. Lets (E2f) assert WHAT the clause addresses rather
+# than that a word occurs somewhere in a 3 KB legend.
+clauseOf(){ python3 -c '
+import re,sys
+m=re.search(r"unproven_defs=K\b.*?(?=counts_floor=|-->)",sys.argv[1],re.S)
+sys.stdout.write(m.group(0) if m else "")' "$1"; }
+
 # ── corpora, built here rather than committed: each is a minimal repro and a committed .h/.cpp fixture
 #    would also join every OTHER gate's view of test/. ────────────────────────────────────────────────
-mkdir -p "$TMP/ns/a" "$TMP/ns/b" "$TMP/free" "$TMP/hdr" "$TMP/split/include" "$TMP/split/src" "$TMP/same"
+mkdir -p "$TMP/ns/a" "$TMP/ns/b" "$TMP/free" "$TMP/hdr" "$TMP/split/include" "$TMP/split/src" "$TMP/same" "$TMP/two"
 
 # (A) two namespaces, one class name, one shared basename.
 cat > "$TMP/ns/a/Store.h" <<'EOF'
@@ -257,6 +299,41 @@ cat > "$TMP/same/use.cpp" <<'EOF'
 int driveWidget(Widget& w)
 {
     return w.go(2);
+}
+EOF
+
+# (E2g) TWO file:name endpoints, each dropping exactly one definition — (B)'s shape twice, under different names, so a
+#       --path between them tells a sum (2) from either endpoint alone (1).
+cat > "$TMP/two/a.h" <<'EOF'
+#pragma once
+int alpha(int a);
+EOF
+cat > "$TMP/two/b.h" <<'EOF'
+#pragma once
+int beta(int b);
+EOF
+cat > "$TMP/two/x.cpp" <<'EOF'
+namespace {
+int alpha(int a)
+{
+    return a + 1;
+}
+}
+int useAlpha(int a)
+{
+    return alpha(a);
+}
+EOF
+cat > "$TMP/two/y.cpp" <<'EOF'
+namespace {
+int beta(int b)
+{
+    return b + 2;
+}
+}
+int useBeta(int b)
+{
+    return beta(b);
 }
 EOF
 
@@ -524,6 +601,157 @@ if nonempty "(E2d) the disclosing answer has no leading legend comment" "$L_HAS"
     fi
 fi
 
+# ── (E2e..E2h) THE SAME RESIDUE ON THE VERBS THAT READ THE SAME RESOLVER ────────────────────────────────────────────
+# --safe-delete, --impact (and MCP impact) and --path (and MCP path_between) resolve SYM through the resolver the callers
+# form reads, so the repros here met the identical drop — and answered it with the zeros a reader acts on most:
+# --safe-delete=api.h:helper read callers="0" impact_reaches="0" uses="0" risk="none-found", --impact reaches="0" and
+# --path reachable="0", with nothing on the root or in the legend saying two definitions were never walked. Per verb:
+# the PREMISE (that zero really is on the root, or the arm is about nothing), PRESENT (the seam's number beside it, in
+# every dialect the verb has), DEFINED (a clause in the legend the reader meets first), and ABSENT (a fully-proven
+# file:name and a bare name carry neither, so an answer that dropped nothing is left as it was). --safe-delete has no
+# --json, --format=columnar or MCP twin; --path has no dialect but its MCP twin.
+
+# e2Present <label> <file> <root> <want> <premise-attr> <premise-value>
+e2Present(){
+    _lbl="$1" _f="$2" _el="$3" _want="$4" _pa="$5" _pv="$6"
+    _R="$( rootEl "$_f" "$_el" )"
+    nonempty "$_lbl: no <$_el> root" "$_R" || return 0
+    _P="$( attr "$_R" "$_pa" )"
+    if [ "$_P" != "$_pv" ]; then
+        no "$_lbl: premise broken — $_pa=\"$_P\", expected \"$_pv\"; the disclosure arm would be about a zero that is not there"
+        return 0
+    fi
+    _G="$( attr "$_R" unproven_defs )"
+    if [ "$_G" = "$_want" ]; then
+        ok "$_lbl: <$_el $_pa=\"$_P\"> carries unproven_defs=\"$_G\""
+    else
+        no "$_lbl: <$_el> unproven_defs=\"${_G:-<absent>}\", expected \"$_want\" — the dropped definitions reach the reader as a bare $_pa=\"$_P\""
+    fi
+    case "$( legendOf "$_f" )" in
+        *'unproven_defs='*) ok "$_lbl: the leading legend defines unproven_defs=" ;;
+        *)                  no "$_lbl: no clause defining unproven_defs= in the legend the reader meets first" ;;
+    esac
+}
+
+# e2Absent <label> <file> <root> <control-attr> <control-value>
+e2Absent(){
+    _lbl="$1" _f="$2" _el="$3" _ca="$4" _cv="$5"
+    _R="$( rootEl "$_f" "$_el" )"
+    nonempty "$_lbl: no <$_el> root" "$_R" || return 0
+    _C="$( attr "$_R" "$_ca" )"
+    if [ "$_C" != "$_cv" ]; then
+        no "$_lbl: control broken — $_ca=\"$_C\", expected \"$_cv\"; an answer that found nothing carries no attribute either, vacuously"
+    elif [ -n "$( attr "$_R" unproven_defs )" ]; then
+        no "$_lbl: carries unproven_defs=\"$( attr "$_R" unproven_defs )\" — nothing was dropped, so there is no residue to disclose"
+    else
+        case "$( legendOf "$_f" )" in
+            *'unproven_defs='*) no "$_lbl: nothing dropped, yet the legend defines unproven_defs= — a clause for an attribute the document did not emit" ;;
+            *)                  ok "$_lbl: $_ca=\"$_C\", and neither unproven_defs= nor its clause is present" ;;
+        esac
+    fi
+}
+
+echo
+echo "=== (E2e) --safe-delete, --impact and --path, and the MCP twins, carry the residue beside their zero ==="
+run  "$TMP/free" --safe-delete=api.h:helper                 >"$TMP/e2_sd.xml"
+run  "$TMP/free" --impact=api.h:helper                      >"$TMP/e2_imp.xml"
+run2 "$TMP/free" --impact=api.h:helper --json               >"$TMP/e2_imp.json"
+run2 "$TMP/free" --impact=api.h:helper --format=columnar    >"$TMP/e2_imp_col.xml"
+run  "$TMP/free" --path=unrelatedCaller,api.h:helper        >"$TMP/e2_pth.xml"
+run  "$TMP/hdr"  --safe-delete=Store.h:putObject            >"$TMP/e2_sd_clean.xml"
+run  "$TMP/free" --safe-delete=helper                       >"$TMP/e2_sd_bare.xml"
+run  "$TMP/hdr"  --impact=Store.h:putObject                 >"$TMP/e2_imp_clean.xml"
+run  "$TMP/free" --impact=helper                            >"$TMP/e2_imp_bare.xml"
+run  "$TMP/hdr"  --path=driveTheStore,Store.h:putObject     >"$TMP/e2_pth_clean.xml"
+run  "$TMP/free" --path=unrelatedCaller,helper              >"$TMP/e2_pth_bare.xml"
+# The MCP twins read COPIES: the server keeps an index of its own, and nothing it writes may land in a corpus the CLI
+# arms read.
+cp -R "$TMP/free" "$TMP/mcp_free" && cp -R "$TMP/hdr" "$TMP/mcp_hdr" || no "(E2e) could not copy the corpora for the MCP twins"
+mcpTranscript "$TMP/e2_mcp_imp.rpc"       impact       full "path=$TMP/mcp_free" "symbol=api.h:helper"
+mcpTranscript "$TMP/e2_mcp_pth.rpc"       path_between full "path=$TMP/mcp_free" "from=unrelatedCaller" "to=api.h:helper"
+mcpTranscript "$TMP/e2_mcp_imp_clean.rpc" impact       full "path=$TMP/mcp_hdr"  "symbol=Store.h:putObject"
+mcpTranscript "$TMP/e2_mcp_pth_clean.rpc" path_between full "path=$TMP/mcp_hdr"  "from=driveTheStore" "to=Store.h:putObject"
+for n in e2_mcp_imp e2_mcp_pth e2_mcp_imp_clean e2_mcp_pth_clean; do
+    mcpPayload "$TMP/$n.rpc" >"$TMP/$n.xml"
+done
+
+e2Present "(E2e) --safe-delete=api.h:helper"               "$TMP/e2_sd.xml"      safe-delete 2 risk      none-found
+e2Present "(E2e) --impact=api.h:helper"                    "$TMP/e2_imp.xml"     impact      2 reaches   0
+e2Present "(E2e) --impact=api.h:helper --format=columnar"  "$TMP/e2_imp_col.xml" impact      2 reaches   0
+e2Present "(E2e) --path=unrelatedCaller,api.h:helper"      "$TMP/e2_pth.xml"     path        2 reachable 0
+e2Present "(E2e) MCP impact symbol=api.h:helper"           "$TMP/e2_mcp_imp.xml" impact      2 reaches   0
+e2Present "(E2e) MCP path_between to=api.h:helper"         "$TMP/e2_mcp_pth.xml" path        2 reachable 0
+# --json has no legend (the L2 rule): the key travels self-named, so PREMISE and PRESENT only.
+J_R="$( jsonKey "$TMP/e2_imp.json" reaches )"; J_U="$( jsonKey "$TMP/e2_imp.json" unproven_defs )"
+if [ "$J_R" != "0" ]; then
+    no "(E2e) --impact=api.h:helper --json premise broken — \"reaches\" is \"$J_R\", expected 0"
+elif [ "$J_U" = "2" ]; then
+    ok "(E2e) --impact=api.h:helper --json carries \"unproven_defs\":2 beside \"reaches\":0"
+else
+    no "(E2e) --impact=api.h:helper --json \"unproven_defs\" is \"${J_U:-<absent>}\", expected 2 — the drop reaches a JSON reader as a bare \"reaches\":0"
+fi
+
+e2Absent "(E2e) --safe-delete=Store.h:putObject, every candidate proven" "$TMP/e2_sd_clean.xml"      safe-delete callers   1
+e2Absent "(E2e) --safe-delete=helper, bare name"                         "$TMP/e2_sd_bare.xml"       safe-delete callers   2
+e2Absent "(E2e) --impact=Store.h:putObject, every candidate proven"      "$TMP/e2_imp_clean.xml"     impact      reaches   1
+e2Absent "(E2e) --impact=helper, bare name"                              "$TMP/e2_imp_bare.xml"      impact      reaches   2
+e2Absent "(E2e) --path to Store.h:putObject, every candidate proven"     "$TMP/e2_pth_clean.xml"     path        reachable 1
+e2Absent "(E2e) --path to the bare helper"                               "$TMP/e2_pth_bare.xml"      path        reachable 1
+e2Absent "(E2e) MCP impact symbol=Store.h:putObject, proven"             "$TMP/e2_mcp_imp_clean.xml" impact      reaches   1
+e2Absent "(E2e) MCP path_between to=Store.h:putObject, proven"           "$TMP/e2_mcp_pth_clean.xml" path        reachable 1
+
+echo
+echo "=== (E2f) --safe-delete's verdict: risk=none-found beside a residue is not left standing as a safety reading ==="
+# risk= keeps its three documented values (--help lists them); what it must not do is stand ALONE on a read that walked
+# none of the dropped definitions. So: the attribute rides the same root as the verdict, and the clause that defines it
+# addresses risk= itself — asserted on the clause's own span, never on a word somewhere in the legend.
+R_SD="$( rootEl "$TMP/e2_sd.xml" safe-delete )"
+if nonempty "(E2f) no <safe-delete> root for api.h:helper" "$R_SD"; then
+    CL_SD="$( clauseOf "$( legendOf "$TMP/e2_sd.xml" )" )"
+    if [ "$( attr "$R_SD" risk )" != "none-found" ]; then
+        no "(E2f) premise broken — risk=\"$( attr "$R_SD" risk )\", expected none-found; the verdict arm would be about another value"
+    elif [ -z "$( attr "$R_SD" unproven_defs )" ]; then
+        no "(E2f) risk=\"none-found\" stands with no unproven_defs= beside it — a safe-to-delete reading about two definitions nobody walked"
+    else
+        case "$CL_SD" in
+            *'risk='*) ok "(E2f) the unproven_defs= clause addresses risk= itself: none-found is qualified where it is defined" ;;
+            *)         no "(E2f) the unproven_defs= clause never names risk=, so none-found still reads as a finding: ${CL_SD:-<no clause>}" ;;
+        esac
+    fi
+fi
+
+echo
+echo "=== (E2g) --path sums both endpoints' residue — neither endpoint's drop is lost, neither is counted twice ==="
+# With (E2e)'s to=api.h:helper (the TO endpoint alone, 2), these tell a sum from src-only, dst-only and double counting.
+run "$TMP/two" --path=a.h:alpha,b.h:beta >"$TMP/e2_two_both.xml"
+run "$TMP/two" --path=a.h:alpha,useBeta  >"$TMP/e2_two_from.xml"
+e2Present "(E2g) --path=a.h:alpha,b.h:beta (one dropped per endpoint)" "$TMP/e2_two_both.xml" path 2 reachable 0
+e2Present "(E2g) --path=a.h:alpha,useBeta (the FROM endpoint alone)"   "$TMP/e2_two_from.xml" path 1 reachable 0
+
+echo
+echo "=== (E2h) under the compact legend, the existing unproven_defs row fires on all three roots ==="
+# compactlegend.h already carries an unproven_defs reading and reads it off any root's head, so these roots needed no new
+# term — asserted rather than assumed, on the CLI's --legend=compact and on the MCP server's default (compact).
+run2 "$TMP/free" --safe-delete=api.h:helper          --legend=compact >"$TMP/e2_sd_cmp.xml"
+run2 "$TMP/free" --impact=api.h:helper               --legend=compact >"$TMP/e2_imp_cmp.xml"
+run2 "$TMP/free" --path=unrelatedCaller,api.h:helper --legend=compact >"$TMP/e2_pth_cmp.xml"
+mcpTranscript "$TMP/e2_mcp_imp_cmp.rpc" impact "" "path=$TMP/mcp_free" "symbol=api.h:helper"
+mcpPayload "$TMP/e2_mcp_imp_cmp.rpc" >"$TMP/e2_mcp_imp_cmp.xml"
+for pair in "e2_sd_cmp.xml:safe-delete" "e2_imp_cmp.xml:impact" "e2_pth_cmp.xml:path" "e2_mcp_imp_cmp.xml:impact"; do
+    f="${pair%%:*}"; el="${pair#*:}"
+    R="$( rootEl "$TMP/$f" "$el" )"
+    nonempty "(E2h) no <$el> root in $f" "$R" || continue
+    L="$( legendOf "$TMP/$f" )"
+    if [ -z "$( attr "$R" unproven_defs )" ]; then
+        no "(E2h) $f: the compact <$el> root carries no unproven_defs= — nothing for the compact reading to define"
+    else
+        case "$L" in
+            *'unproven_defs=K:'*) ok "(E2h) $f: <$el unproven_defs=\"$( attr "$R" unproven_defs )\"> and the compact legend reads it" ;;
+            *)                    no "(E2h) $f: <$el> carries unproven_defs= under the compact legend with no unproven_defs=K: reading" ;;
+        esac
+    fi
+done
+
 echo
 echo "=== (F) MUTATION — every assertion shape above is shown able to fail ==="
 # (A)/(B) shape: the row-name reader must SEE a wrong caller when one is present…
@@ -579,6 +807,24 @@ printf 'UNIT FAIL\n' >"$TMP/m_e.out"
 grep -q '^UNIT ALL PASS$' "$TMP/m_e.out" \
     && no "(F) the (E) verdict reader accepts a driver run that failed" \
     || ok "(F) E-shape: a driver run without UNIT ALL PASS is NOT read as a pass"
+# (E2e) shape: the MCP transcript reader must hand back the payload, and must never hand back an error as one.
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}' \
+    '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"<impact of=\"x\" unproven_defs=\"3\"></impact>"}]}}' >"$TMP/m_rpc_ok.rpc"
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}' \
+    '{"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"symbol not found"}}' >"$TMP/m_rpc_err.rpc"
+mcpPayload "$TMP/m_rpc_ok.rpc"  >"$TMP/m_rpc_ok.xml"
+mcpPayload "$TMP/m_rpc_err.rpc" >"$TMP/m_rpc_err.xml"
+[ "$( attr "$( rootEl "$TMP/m_rpc_ok.xml" impact )" unproven_defs )" = "3" ] && [ -z "$( rootEl "$TMP/m_rpc_err.xml" impact )" ] \
+    && ok "(F) E2e-shape: the MCP reader returns the payload, and an error response yields no root to assert on" \
+    || no "(F) the MCP transcript reader cannot tell a payload from an error — every MCP arm would be inert or vacuous"
+# (E2f) shape: clauseOf must see risk= INSIDE the clause, and must not credit a risk= that sits before or after it.
+L_IN='<!-- risk= NAMES what was found. unproven_defs=K (absent when 0) so risk= describes defs= alone. counts_floor="1" means -->'
+L_OUT='<!-- risk= NAMES what was found. unproven_defs=K (absent when 0) counts definitions. counts_floor="1" risk= -->'
+case "$( clauseOf "$L_IN" )"  in *'risk='*) M_IN=1 ;;  *) M_IN=0 ;;  esac
+case "$( clauseOf "$L_OUT" )" in *'risk='*) M_OUT=1 ;; *) M_OUT=0 ;; esac
+[ "$M_IN" = 1 ] && [ "$M_OUT" = 0 ] \
+    && ok "(F) E2f-shape: clauseOf reads risk= inside the clause and does not credit one outside it" \
+    || no "(F) clauseOf cannot tell a clause that addresses risk= from a legend that merely contains it (in=$M_IN out=$M_OUT)"
 # VACUITY guard itself. Run in a subshell so it cannot set fail.
 if ( nonempty "probe" "" >/dev/null 2>&1 ); then
     no "(F) nonempty() accepts an empty capture — every arm's vacuity guard is inert"
@@ -595,7 +841,10 @@ run "$TMP/ns" --callers=a/Store.h:putObject >"$TMP/det1.xml"
 run "$TMP/ns" --callers=a/Store.h:putObject >"$TMP/det2.xml"
 if cmp -s "$TMP/det1.xml" "$TMP/det2.xml"; then ok "determinism: a/Store.h:putObject byte-identical run-to-run"; else no "non-deterministic --callers output"; fi
 if command -v xmllint >/dev/null 2>&1; then
-    if xmllint --noout "$TMP/a_far.xml" 2>/dev/null && xmllint --noout "$TMP/c_hdr_hdr.xml" 2>/dev/null; then
+    # The e2_* documents are the ones whose legends grew a clause — an XML comment may not hold a double hyphen (G4).
+    if xmllint --noout "$TMP/a_far.xml" 2>/dev/null && xmllint --noout "$TMP/c_hdr_hdr.xml" 2>/dev/null \
+       && xmllint --noout "$TMP/e2_sd.xml" 2>/dev/null && xmllint --noout "$TMP/e2_imp.xml" 2>/dev/null \
+       && xmllint --noout "$TMP/e2_pth.xml" 2>/dev/null && xmllint --noout "$TMP/e2_mcp_imp.xml" 2>/dev/null; then
         ok "xml well-formed"
     else
         no "xml malformed"


### PR DESCRIPTION
#173 made the C++ declaration→definition widening honest. A `file:name` selector that names a header declaration now keeps a candidate definition only when that definition is provably tied to the header, meaning it is in the same file or in a file that includes the header path-precisely. `--callers` and `--callees` disclose the definitions they drop as `unproven_defs=`.

Every other caller of that resolver passed no out-parameter. So three verbs answered from the declaration alone, which has no call edges, and printed a clean zero:

- `--safe-delete=api.h:helper` printed `callers="0" impact_reaches="0" uses="0" … risk="none-found"`, which anyone would read as "safe to delete".
- `--impact=api.h:helper` printed `reaches="0"` in XML, columnar, `--json` and MCP `impact`.
- `--path=unrelatedCaller,api.h:helper` printed `reachable="0" hops="0"`, and MCP `path_between` did the same.

## Fix

Each call site now takes the count, and the root carries `unproven_defs="K"` in every dialect the verb has. The attribute is absent when K is zero. It sits beside `reaches=` on `--impact`, right after `risk=` on `--safe-delete`, and beside `from_defs=`/`to_defs=` on `--path`, summed over both endpoints.

`src/graphlegend.h` gains one clause per verb, built on a shared proof sentence and printed only when K > 0. Each clause opens with `unproven_defs=`, so the compact term #185 added already covers all three roots.

`risk=` keeps its three values. It is defined as naming what was found, never as a verdict, and the defect was silence about what was not read. The safe-delete clause says so outright: "risk=none-found beside unproven_defs= is an INCOMPLETE read, never a sign that the name can go."

## Gate

`test/decltodefcheck.sh` gains arms E2e–E2h and two mutation rows in F. Together they check:

- the premise, the attribute and the clause for each verb, plus the rows where it must be absent;
- that the verdict sentence appears inside the clause;
- that `--path` sums both endpoints (2 and 1);
- that the compact row fires on all three roots.

22 rows failed on main. All 67 pass on the plain and ASan builds.

## Unchanged answers

All 41 answers that drop nothing are byte-identical before and after. The comparison covered bare names, fully proven `file:name` selectors, `--callers`/`--callees`, every dialect, compact output, and MCP full and default, on the fixtures and on the repo.

## Verification

- `gates=16 pass=16 skip=0 fail=0` across decltodef, safedelete, impactpartition, legendcoverage, graphlegendbudget, compactlegend, mcpattrparity, mcpclidiff, mcpmanifest, printffmtparity, xmlwellformed, donelegend, floormark, decline, impactimport and gitquotepath.
- `limits_build --check` and `gatecount_build --check` both exit 0.
- `--quality-delta` reports only short-horizon churn on the seven functions this change had to edit; the commit message explains it.

The remaining silent-zero sites (`--mentions`, `--affected`, `--uses`/`--verify`, `--edit-check`, `--slice` and the `resolveFocus` verbs) follow in their own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
