### PR TITLE
fix(sidecars): a symlinked sidecar was still read through the link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ not published here — see `docs/EVALS.md` for the instruments behind the headli
 
 - **A sidecar must be a regular file: a symlink at a sidecar name is refused, on read as well as on write.**
   `.ripwire_notes`, `.ripwire_quality_baseline` and `.ripwire_arch_baseline` are opened with `O_NOFOLLOW`, so a
-  link at one of those names is not opened, wherever its target is. If you symlinked one on purpose (into a shared
+  link at one of those names is not opened, wherever its target is. Anything else at the name that is not a regular
+  file, a FIFO for example, is refused as well instead of being waited on. If you symlinked one on purpose (into a shared
   config directory, say), replace the link with a regular copy of its target. Until you do, every read of it prints
   a refusal on stderr, no notes surface, `--quality-delta` reports `baseline="git-HEAD (symlinked sidecar refused)"`
   and compares against HEAD, `--arch` reports every violation as new, and `--note-add`, `--quality-baseline`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ not published here — see `docs/EVALS.md` for the instruments behind the headli
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- **A sidecar must be a regular file: a symlink at a sidecar name is refused, on read as well as on write.**
+  `.ripwire_notes`, `.ripwire_quality_baseline` and `.ripwire_arch_baseline` are opened with `O_NOFOLLOW`, so a
+  link at one of those names is not opened, wherever its target is. If you symlinked one on purpose (into a shared
+  config directory, say), replace the link with a regular copy of its target. Until you do, every read of it prints
+  a refusal on stderr, no notes surface, `--quality-delta` reports `baseline="git-HEAD (symlinked sidecar refused)"`
+  and compares against HEAD, `--arch` reports every violation as new, and `--note-add`, `--quality-baseline`,
+  `--arch --baseline` and `--baseline-update` exit 1 without writing. `.ripwire_config` and
+  `.ripwire_quality_acks` are unchanged.
+
 ## [0.6.0] — 2026-09-11
 
 **Languages and integrations from outside the project, much faster on the largest trees, and answers that say where

--- a/src/arch.h
+++ b/src/arch.h
@@ -656,17 +656,41 @@ inline std::string archBaselinePath( const std::string& /*rulesPath*/ ) noexcept
     return ".ripwire_arch_baseline";
 }
 
-// Read the baseline sidecar.  Returns the set of violation hashes committed as accepted debt.
-// Returns empty set if the file does not exist (first run) — callers treat that as "no baseline".
-inline std::unordered_set<std::uint64_t> archReadBaseline( const std::string& sidecarPath ) noexcept
+// THE ONE PLACE THE ARCH BASELINE SIDECAR IS READ — openArchBaselineSidecar's other half, with the same answer
+// to a link: O_NOFOLLOW, refused in the open itself. A link here used to be followed, so the link chose which
+// file's hashes were accepted as debt. Why an in-tree link is refused too is round 3 of src/pathguard.h.
+// noexcept like its neighbours, with the same allocation exposure openArchBaselineSidecar describes.
+inline rw::pathguard::NoFollowRead readArchBaselineSidecar( const std::string& sidecarPath ) noexcept
+{
+    rw::pathguard::NoFollowRead sidecar = rw::pathguard::readWholeFileNoFollow( "the arch baseline sidecar", sidecarPath );
+    if( sidecar.refused ) { DEGRADED_PATH_ALERT( "arch: refusing to read the arch baseline sidecar through a symlink" ); }
+    return sidecar;
+}
+
+// What archReadBaseline found: the violation hashes committed as accepted debt, and whether there was a sidecar
+// to read at all. `present` is the open, not the hash count — a sidecar holding only its comment header accepts
+// nothing and is still a baseline in force. It replaces a SECOND open of the same path that the arch verb used
+// to make with a bare stream just to ask that question; that open followed a link as well and read nothing, so
+// no check on the verb's output could ever have seen it.
+struct ArchBaselineRead
 {
     std::unordered_set<std::uint64_t> hashes;
-    std::ifstream f( sidecarPath );
-    if( !f )
+    bool                              present = false;
+};
+
+// Read the baseline sidecar. An absent file (first run) and a refused link both come back with no hashes and not
+// present, which callers treat as "no baseline".
+inline ArchBaselineRead archReadBaseline( const std::string& sidecarPath ) noexcept
+{
+    ArchBaselineRead            baseline;
+    rw::pathguard::NoFollowRead sidecar = readArchBaselineSidecar( sidecarPath );
+    if( !sidecar.opened )
     {
-        return hashes;
+        return baseline;
     }
-    std::string line;
+    baseline.present = true;
+    std::istringstream f( std::move( sidecar.bytes ) );
+    std::string        line;
     while( std::getline( f, line ) )
     {
         // skip comment lines (start with '#') and blank lines
@@ -678,10 +702,10 @@ inline std::unordered_set<std::uint64_t> archReadBaseline( const std::string& si
         const std::uint64_t h   = std::strtoull( line.c_str(), &end, 16 );
         if( end != line.c_str() )
         {
-            hashes.insert( h );
+            baseline.hashes.insert( h );
         }
     }
-    return hashes;
+    return baseline;
 }
 
 // THE ONE PLACE THE ARCH BASELINE SIDECAR IS OPENED, and the whole of its CWE-59/CWE-367 story.

--- a/src/arch.h
+++ b/src/arch.h
@@ -662,7 +662,7 @@ inline std::string archBaselinePath( const std::string& /*rulesPath*/ ) noexcept
 // noexcept like its neighbours, with the same allocation exposure openArchBaselineSidecar describes.
 inline rw::pathguard::NoFollowRead readArchBaselineSidecar( const std::string& sidecarPath ) noexcept
 {
-    rw::pathguard::NoFollowRead sidecar = rw::pathguard::readWholeFileNoFollow( "the arch baseline sidecar", sidecarPath );
+    rw::pathguard::NoFollowRead sidecar = rw::pathguard::openNoFollowRead( "the arch baseline sidecar", sidecarPath );
     if( sidecar.refused ) { DEGRADED_PATH_ALERT( "arch: refusing to read the arch baseline sidecar through a symlink" ); }
     return sidecar;
 }
@@ -689,9 +689,8 @@ inline ArchBaselineRead archReadBaseline( const std::string& sidecarPath ) noexc
         return baseline;
     }
     baseline.present = true;
-    std::istringstream f( std::move( sidecar.bytes ) );
-    std::string        line;
-    while( std::getline( f, line ) )
+    std::string line;
+    while( sidecar.readLine( line ) )
     {
         // skip comment lines (start with '#') and blank lines
         if( line.empty() || line[0] == '#' )

--- a/src/mcpverbs.h
+++ b/src/mcpverbs.h
@@ -3214,6 +3214,13 @@ inline const char* mcpBaselineMarker( const rw::quality::BaselineSelection& sele
     {
         return selection.marker;
     }
+    // Round 3 (pathguard.h): a refused link is decided by the refused open itself. The probe below FOLLOWS a link
+    // (std::filesystem::exists is a stat, not an lstat), so asking it would call a refusal "unreadable" whenever
+    // the link's target exists and "no sidecar" whenever it does not — an answer about some other file entirely.
+    if( selection.sidecarSymlinkRefused )
+    {
+        return selection.marker;
+    }
 
     std::error_code sidecarEc;
     if( std::filesystem::exists( std::filesystem::path( sidecarPath ), sidecarEc ) && !sidecarEc )
@@ -3258,7 +3265,11 @@ inline QualityDeltaOutcome computeQualityDelta( const std::string& root )
             // (baseSel.isStaleFileOnDisk() is true whenever isSidecarStale() is) — "delete it" is therefore
             // always the true instruction and the wording needs no removed-vs-ignored split. The CLI twin,
             // which unlinks, does branch on isStaleFileOnDisk().
-            oc.errMsg = baseSel.isSidecarStale()
+            // Round 3 (pathguard.h): a refused link gets the CLI twin's refused-link wording, per-arm verb aside —
+            // "no <file>" is false while the link is sitting at the name.
+            oc.errMsg = baseSel.sidecarSymlinkRefused
+                ? std::string( rw::quality::kBaselineFile ) + " is a symlink, which is refused on read exactly as on write (it was not opened), and there is no git HEAD to auto-compare against — replace the link with a regular copy of its target, or remove it and run the quality_baseline verb"
+                : baseSel.isSidecarStale()
                 ? std::string( rw::quality::kBaselineFile ) + " is STALE (pinned at a different HEAD) and there is no current HEAD tree to fall back to — delete it or re-run the quality_baseline verb"
                 : std::string( "no " ) + rw::quality::kBaselineFile + " and no git HEAD to auto-compare against — run the quality_baseline verb BEFORE the change you want to measure";
             return oc;

--- a/src/notes.h
+++ b/src/notes.h
@@ -308,16 +308,31 @@ inline void splitNoteTail( std::string_view rest, std::string& text, std::string
     branch = std::string( tail.substr( t4 + 1 ) );
 }
 
+// THE ONE PLACE THE NOTES SIDECAR IS READ — openNotesSidecar's other half, with the same answer to a link.
+//
+// A link at `.ripwire_notes` used to be followed on the way in, so the link chose what was read as notes. The
+// read now refuses a link with
+// the same O_NOFOLLOW the write uses, one syscall with nothing in front of it to race; why an in-tree link is
+// refused too, rather than followed the way the crawl follows one, is round 3 of src/pathguard.h. Refused or
+// absent, the caller reads no notes, and only the refusal says anything.
+inline rw::pathguard::NoFollowRead readNotesSidecar( const std::string& path )
+{
+    rw::pathguard::NoFollowRead sidecar = rw::pathguard::readWholeFileNoFollow( "the field-notes sidecar", path );
+    if( sidecar.refused ) { DEGRADED_PATH_ALERT( "notes: refusing to read the notes sidecar through a symlink" ); }
+    return sidecar;
+}
+
 // tolerant read (readAckRecords precedent): skip blank/'#'/CRLF; a line missing either of the first two tabs
 // degrades+skips. splitNoteTail (above) owns the legacy-vs-stamped decision for everything after them.
 inline std::vector<Note> readNotes( const std::string& path )
 {
-    std::vector<Note> notes;
-    std::ifstream f( path );
-    if( !f )
+    std::vector<Note>           notes;
+    rw::pathguard::NoFollowRead sidecar = readNotesSidecar( path );
+    if( !sidecar.opened )
     {
         return notes;
     }
+    std::istringstream f( std::move( sidecar.bytes ) );
     std::string line;
     while( std::getline( f, line ) )
     {

--- a/src/notes.h
+++ b/src/notes.h
@@ -317,7 +317,7 @@ inline void splitNoteTail( std::string_view rest, std::string& text, std::string
 // absent, the caller reads no notes, and only the refusal says anything.
 inline rw::pathguard::NoFollowRead readNotesSidecar( const std::string& path )
 {
-    rw::pathguard::NoFollowRead sidecar = rw::pathguard::readWholeFileNoFollow( "the field-notes sidecar", path );
+    rw::pathguard::NoFollowRead sidecar = rw::pathguard::openNoFollowRead( "the field-notes sidecar", path );
     if( sidecar.refused ) { DEGRADED_PATH_ALERT( "notes: refusing to read the notes sidecar through a symlink" ); }
     return sidecar;
 }
@@ -332,9 +332,8 @@ inline std::vector<Note> readNotes( const std::string& path )
     {
         return notes;
     }
-    std::istringstream f( std::move( sidecar.bytes ) );
     std::string line;
-    while( std::getline( f, line ) )
+    while( sidecar.readLine( line ) )
     {
         while( !line.empty() && ( line.back() == '\r' || line.back() == '\n' ) )
         {

--- a/src/pathguard.h
+++ b/src/pathguard.h
@@ -30,7 +30,7 @@
 // ofstream, and not true of the problem: the writers do not need ofstream, they need a descriptor. So the
 // check and the create are now ONE syscall, and it is the only one a writer makes:
 //
-//     ::open( path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0666 )
+//     ::open( path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_NONBLOCK, 0666 )   (O_NONBLOCK and the fstat after it: round 4)
 //
 // O_NOFOLLOW makes the KERNEL refuse a final component that is a symlink, at the instant of resolution.
 // There is no window because there is no second resolution — whatever the entry is when the kernel looks
@@ -130,25 +130,50 @@
 //   - Directory components. O_NOFOLLOW constrains the final component only, exactly as for the writes.
 //
 // Each sidecar keeps ONE read seam (readNotesSidecar / readBaselineSidecar / readArchBaselineSidecar) that
-// calls readWholeFileNoFollow below and carries its own DEGRADED_PATH_ALERT, for the same once-per-site
-// reason the write seams keep theirs.
+// calls openNoFollowRead below and carries its own DEGRADED_PATH_ALERT, for the same once-per-site reason the
+// write seams keep theirs.
 //
-// It carries no index/graph dependency on purpose — the emitter and the degrade macro are the whole of it —
-// so it stays includable from any layer, which is the property that let the rule be missing in the first
-// place. It is NOT under src/infra/: that layer is vendored into a sibling repo and may not name this
-// project (test/infraportcheck.sh rule (C)), and every sentence below has to.
+// ── ROUND 4: A NON-REGULAR FILE AT THE NAME, AND A READ THAT HOLDS ONE LINE ─────────────────────────────
+//
+// Two review findings on round 3, both confirmed before anything changed.
+//
+// A FIFO planted AT a sidecar name, with no link involved, blocked BOTH opens: a read open waits for a writer
+// and a write open waits for a reader. It predates round 3 (the streams these descriptors replaced blocked the
+// same way) and a git checkout cannot contain a FIFO, but a blocked open is still wrong, and fixing the reader
+// alone would have been half a fix.
+// So both opens carry O_NONBLOCK, which lets the open RETURN whatever sits at the name, and both then ask
+// fstat whether it is a regular file before a byte moves. A writer refuses anything else, loudly, with nothing
+// written. A reader treats it as a sidecar that is there but unreadable, which is what the stream it replaced
+// reported for a directory at the name. O_NONBLOCK changes nothing about a regular file's reads or writes.
+//
+// The round-3 read also held the WHOLE file in memory before parsing began, where the std::ifstream it
+// replaced held one line. The remedy is streaming, not a size cap: the crawl's --max-file-size is a ceiling
+// for SOURCE files, and applying it here would refuse a legitimately large quality baseline, which is a wrong
+// answer rather than a guard. The read now hands its caller one line at a time through POSIX getline over the
+// descriptor's stream, which costs what the std::ifstream readers cost. Two other shapes were ruled out first:
+// a call per byte (rw::readByteSafeLine's fgetc loop) measured ~15× slower on 64 MB of sidecar lines, and a
+// custom std::streambuf under std::getline would narrow a high byte through libc++'s no-get-area fallback,
+// which aborts the sanitizer build (src/infra/stdinline.h records that trap).
+//
+// It carries no index/graph dependency on purpose — the emitter and the degrade macro are the whole of it — so
+// it stays includable from any layer, which is the property that let the rule be missing in the first place.
+// It is NOT under src/infra/: that layer is vendored into a sibling repo and may not name this project
+// (test/infraportcheck.sh rule (C)), and every sentence below has to.
 //
 // Gated by test/sidecarsymlinkcheck.sh, whose three symlink arms were observed RED before this header
-// existed, whose (e)/(f) mechanism arms were observed RED before the open below replaced the check, and
-// whose round-3 read arms were observed RED against the round-2 binary before the read below existed.
+// existed, whose (e)/(f) mechanism arms were observed RED before the open below replaced the check, whose
+// round-3 read arms were observed RED against the round-2 binary before the read below existed, and whose
+// round-4 arms were observed RED against the round-3 binary and source.
 
 #include "infra/emit.h"   // rw::emitTo — the refusal goes to stderr through THE emitter, not fprintf
 
-#include <fcntl.h>        // ::open + O_NOFOLLOW — the whole mechanism, in one syscall
-#include <sys/stat.h>     // ::lstat + S_ISLNK — mcpedit's predicate, and the post-ELOOP wording decision
+#include <fcntl.h>        // ::open + O_NOFOLLOW + O_NONBLOCK — the whole mechanism, in one syscall
+#include <sys/stat.h>     // ::lstat + S_ISLNK (mcpedit, and the post-ELOOP wording); ::fstat + S_ISREG (round 4)
 #include <unistd.h>       // ::write / ::close — the descriptor the writers hold instead of a stream
 #include <cerrno>
 #include <cstddef>
+#include <cstdio>         // std::FILE / ::fdopen / ::getline / std::fclose — the read half's line stream
+#include <cstdlib>        // std::free — POSIX getline's buffer
 #include <cstring>        // std::strerror — an honest reason for a failure that is not a link
 #include <string>
 #include <string_view>
@@ -195,12 +220,28 @@ struct OpenedFile
 // O_NOFOLLOW constrains the FINAL component only; an intermediate symlinked directory is still traversed.
 // That is the same reach the lstat check had, so nothing regressed with the change — and widening it would
 // mean refusing every repository that lives under a symlinked path, which is most of them.
+//
+// NOT A REGULAR FILE (round 4). O_NONBLOCK lets the open return for a FIFO instead of waiting for a reader:
+// with nobody reading, it fails at once with ENXIO and takes the plain-errno branch below. The fstat then
+// refuses whatever DID open but is not a regular file, before any byte is written. O_TRUNC has run by that
+// point and does nothing to a FIFO; on a regular file nothing here is refused. That refusal reports EINVAL,
+// because no syscall failed: the name holds something a sidecar cannot be.
 inline OpenedFile openNoFollowTruncate( std::string_view what, const std::string& path )
 {
-    const int fd = ::open( path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0666 );
+    const int fd = ::open( path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_NONBLOCK, 0666 );
     if( fd >= 0 )
     {
-        return { fd, 0 };
+        struct stat openedSt{};
+        if( ::fstat( fd, &openedSt ) == 0 && S_ISREG( openedSt.st_mode ) )
+        {
+            return { fd, 0 };
+        }
+        ::close( fd );
+        rw::emitTo( stderr,
+                    "ripwire: refusing to write {} at '{}': that path is not a regular file (a FIFO, for example), so there is no\n"
+                    "  sidecar there to write. Nothing was written. Remove it and re-run.\n",
+                    what, path );
+        return { -1, EINVAL };
     }
     const int err = errno;
 
@@ -269,33 +310,89 @@ inline bool writeAllAndClose( int fd, std::string_view bytes ) noexcept
 
 // ── the read half (round 3) ───────────────────────────────────────────────────────────────────────────
 
-// What the no-follow read produced. `opened` is the OPEN, not the content: a directory at the name opens and
-// then fails its first read, exactly as the std::ifstream this replaces did, so a caller that tells "a
-// sidecar is there" from "no sidecar" (readBaseline's `present`, the arch verb's baseline-in-force) keeps
-// telling them apart the way it always has.
+// What the no-follow open produced, and the handle the caller reads through. `opened` is the OPEN, not the
+// content: something that is not a symlink sits at the name and it opened, so a caller that tells "a sidecar is
+// there" from "no sidecar" (readBaseline's `present`, the arch verb's baseline-in-force) reads that. readLine then
+// yields the sidecar one line at a time, and yields nothing at all when what opened is not a regular file —
+// which is how a directory or a FIFO at the name reads: present, and unreadable.
+//
+// It OWNS the stream, so it moves and never copies, and the stream closes with the handle. The shape follows
+// ingest_cache.h's ReadFd, which this header cannot include without taking on the cache layer.
 struct NoFollowRead
 {
-    std::string bytes;             // every byte read before EOF or the first read error
-    bool        opened  = false;   // the open succeeded: something that is not a symlink sits at the name
-    bool        refused = false;   // the open failed with ELOOP — nothing was followed, and stderr says why
-    int         err     = 0;       // errno of the open or read that failed; 0 when neither did
+    std::FILE*  file    = nullptr;   // the sidecar, open for reading — null unless it opened as a regular file
+    bool        opened  = false;     // the open succeeded: something that is not a symlink sits at the name
+    bool        refused = false;     // the open failed with ELOOP — nothing was followed, and stderr says why
+    int         err     = 0;         // errno of the open or fdopen that failed; 0 when neither did
+    char*       lineBuf = nullptr;   // POSIX getline's buffer: grown by getline, reused for every line, freed here
+    std::size_t lineCap = 0;         // its capacity, as getline tracks it
+
+    NoFollowRead() = default;
+    NoFollowRead( const NoFollowRead& )            = delete;
+    NoFollowRead& operator=( const NoFollowRead& ) = delete;
+    NoFollowRead& operator=( NoFollowRead&& )      = delete;
+    NoFollowRead( NoFollowRead&& other ) noexcept
+        : file( other.file ), opened( other.opened ), refused( other.refused ), err( other.err ),
+          lineBuf( other.lineBuf ), lineCap( other.lineCap )
+    {
+        other.file    = nullptr;
+        other.lineBuf = nullptr;
+        other.lineCap = 0;
+    }
+    ~NoFollowRead()
+    {
+        if( file != nullptr )
+        {
+            std::fclose( file );
+        }
+        std::free( lineBuf );
+    }
+
+    // One line into `line`, with std::getline's contract: the '\n' is consumed and not kept, a '\r' before it IS
+    // kept, an embedded NUL is kept, and a last line with no '\n' is still delivered once. False only at the end of
+    // the stream or on a read error — and always false when no regular file opened.
+    //
+    // WHY POSIX getline. It scans the stream's own buffer, so this costs what the std::ifstream readers cost; a
+    // call per byte (fgetc) measured ~15× slower on 64 MB of sidecar lines. And it is the C API, so no byte goes
+    // through libc++ std::getline's no-get-area fallback, which narrows a high byte and aborts the sanitizer build
+    // (src/infra/stdinline.h records that trap).
+    bool readLine( std::string& line )
+    {
+        if( file == nullptr )
+        {
+            return false;
+        }
+        const ssize_t got = ::getline( &lineBuf, &lineCap, file );
+        if( got < 0 )
+        {
+            return false;
+        }
+        std::size_t length = static_cast<std::size_t>( got );
+        if( length > 0 && lineBuf[length - 1] == '\n' )
+        {
+            --length;
+        }
+        line.assign( lineBuf, length );
+        return true;
+    }
 };
 
-// Read all of `path` WITHOUT following a symlink at the final component — openNoFollowTruncate's read twin:
-// the same O_NOFOLLOW, the same single syscall with no lstat in front of it to race, and the same rule that a
-// refusal is loud.
+// Open `path` for reading WITHOUT following a symlink at the final component — openNoFollowTruncate's read
+// twin: the same O_NOFOLLOW, the same single syscall with no lstat in front of it to race, the same O_NONBLOCK
+// and fstat check, and the same rule that a refusal is loud.
 //
 // ONLY THE REFUSAL IS LOUD. An absent file is every sidecar's first-run case and says nothing, and any other
-// open or read failure stays exactly as silent as the stream this replaces — the callers already read those as
-// "no sidecar", and making them loud is a behaviour change with questions of its own, not a rider on this
-// one. A read refused over a link is different in kind: the file is RIGHT THERE, and a caller that went quiet
-// about it would leave the user believing there is no sidecar at all.
+// open failure stays exactly as silent as the stream this replaced — the callers already read those as "no
+// sidecar", and making them loud is a behaviour change with questions of its own, not a rider on this one. A
+// read refused over a link is different in kind: the file is RIGHT THERE, and a caller that went quiet about it
+// would leave the user believing there is no sidecar at all. Something at the name that is not a regular file
+// is quiet the way the stream was about a directory there: present, and it yields no lines.
 //
 // `what` names the sidecar in the user's words, as for the write.
-inline NoFollowRead readWholeFileNoFollow( std::string_view what, const std::string& path )
+inline NoFollowRead openNoFollowRead( std::string_view what, const std::string& path )
 {
     NoFollowRead result;
-    const int    fd = ::open( path.c_str(), O_RDONLY | O_NOFOLLOW );
+    const int    fd = ::open( path.c_str(), O_RDONLY | O_NOFOLLOW | O_NONBLOCK );
     if( fd < 0 )
     {
         result.err = errno;
@@ -325,29 +422,18 @@ inline NoFollowRead readWholeFileNoFollow( std::string_view what, const std::str
     }
 
     result.opened = true;
-    constexpr std::size_t kReadChunkBytes = 64 * 1024;   // how much one read(2) asks for, not how much is kept
-    std::size_t           used            = 0;
-    for( ;; )
+    struct stat openedSt{};
+    if( ::fstat( fd, &openedSt ) != 0 || !S_ISREG( openedSt.st_mode ) )
     {
-        result.bytes.resize( used + kReadChunkBytes );
-        const ssize_t n = ::read( fd, result.bytes.data() + used, kReadChunkBytes );
-        if( n > 0 )
-        {
-            used += static_cast<std::size_t>( n );
-            continue;
-        }
-        if( n < 0 && errno == EINTR )
-        {
-            continue;
-        }
-        if( n < 0 )
-        {
-            result.err = errno;
-        }
-        break;
+        ::close( fd );   // a FIFO, a directory, a device: present, and no lines — never a read that could wait
+        return result;
     }
-    result.bytes.resize( used );
-    ::close( fd );
+    result.file = ::fdopen( fd, "r" );
+    if( result.file == nullptr )
+    {
+        result.err = errno;
+        ::close( fd );   // fdopen did not take the descriptor, so it is still this function's to close
+    }
     return result;
 }
 

--- a/src/pathguard.h
+++ b/src/pathguard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-// pathguard.h — THE ONE RULE for "this write destination is a symlink, so do not write through it", and
-// the single atomic open that ENFORCES it rather than merely describing it.
+// pathguard.h — THE ONE RULE for "this sidecar name is a symlink, so do not write OR read through it", and
+// the two atomic opens that ENFORCE it rather than merely describing it (round 3 added the read; see below).
 //
 // WHY IT IS ITS OWN HEADER. The rule was born at the MCP edit seam (mcpedit.h, A4-F14) because that is
 // where following a link loses an agent's edit. It was never given to the SIDECAR writers, and that gap was
@@ -28,7 +28,7 @@
 //
 // The stated reason for stopping there was that std::ofstream cannot express O_NOFOLLOW portably. True of
 // ofstream, and not true of the problem: the writers do not need ofstream, they need a descriptor. So the
-// check and the create are now ONE syscall, and it is the only one:
+// check and the create are now ONE syscall, and it is the only one a writer makes:
 //
 //     ::open( path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0666 )
 //
@@ -76,13 +76,71 @@
 // asserted: test/sidecarsymlinkcheck.sh's (g) arms create each sidecar under `umask 000` and require 0666,
 // which is the only umask under which a wrong 0644 is visible at all.
 //
+// ── ROUND 3: THE READERS OF THE SAME NAMES REFUSE A LINK TOO — A DECISION, NOT A DEFAULT ─────────────
+//
+// Rounds 1-2 guarded the writes and left every reader of these three names following a link:
+// notes::readNotes, quality::readBaseline / readBaselineHeadSha / readBaselineAbsorbed, archReadBaseline,
+// and a bare stream the arch verb opened only to learn whether the sidecar existed. So a link at one of the
+// names still decided which file those readers opened, inside the tree or out of it, and its lines were read
+// as sidecar records.
+//
+// No privilege is crossed; the user could read those files anyway. The boundary is the one the crawl already
+// holds (ingest.h, withinCanonicalRoot): repository content does not choose which of the user's files the
+// tool reads. Three answers were on the table, and the choice is pinned by the round-3 arms of
+// test/sidecarsymlinkcheck.sh rather than left to whoever next edits a reader:
+//
+//   (a) Leave the readers following. REJECTED: a link would keep deciding what is read at three fixed names,
+//       right beside a crawl that no longer lets one.
+//   (c) Refuse only a link that leaves the crawl root, which is the crawl's own rule. REJECTED, three ways:
+//       - It does not keep the setup that argues for it. A sidecar symlinked into a SHARED config directory
+//         points outside the tree, and (c) refuses that as well. What (c) keeps beyond (b) is a link to
+//         another file INSIDE the tree — which the writers already refuse, so it is readable and never
+//         again updatable.
+//       - It cannot be one syscall. "Where does the link lead" is realpath() followed by an open: the
+//         check-then-open shape round 2 removed from the writers, or a descriptor-then-verify dance to close
+//         that same race a second time.
+//       - It has no single anchor. The arch baseline resolves against the process CWD (archBaselinePath),
+//         not the crawl root, so "leaves the root" is not even defined for one of the three.
+//   (b) Refuse a link on READ exactly as on write: O_NOFOLLOW at the open. CHOSEN. One sentence covers every
+//       site — a sidecar is a regular file at its fixed name, read or written — and the kernel enforces it
+//       in the very syscall that would otherwise have followed the link.
+//
+// The crawl follows an in-tree link and these readers do not, and that is not an inconsistency. A source
+// tree's links are the user's content; a sidecar is this tool's own state file, which it never creates as
+// a link and, since round 1, will not write through one. git draws the same line: since 2.32 it opens the
+// in-tree .gitattributes, .gitignore and .mailmap with O_NOFOLLOW.
+//
+// MIGRATION. A repository that symlinks one of these sidecars on purpose now gets a stderr refusal on every
+// read and no sidecar in force: no notes surface, quality-delta reports baseline="git-HEAD (symlinked
+// sidecar refused)" and compares against HEAD, and the arch verb reports every violation as new. Replace
+// the link with a regular copy of its target — copy the target to a temporary name beside the link, then
+// mv that over the link — and if it must track a shared original, copy it in as a CI step instead.
+//
+// NOT COVERED, and why:
+//   - `.ripwire_quality_acks` (readAckRecords). Its writer publishes by tmp+rename, which REPLACES a link
+//     instead of following it, so what a refused read should make that writer do belongs to the lane that
+//     guards the writer. The reader moves with it.
+//   - `.ripwire_config` (readRegisterMacrosConfig). User-authored, never written by the tool, and the one
+//     of these names where a link into a shared directory is the ordinary setup. Whether it takes this rule
+//     is its own decision.
+//   - An in-document disclosure where the document has no channel for one. The refusal reaches stderr from
+//     every surface, and the document only where a marker already tells "no sidecar" from "a sidecar not
+//     used" (quality-delta, CLI and MCP). A refused note is simply absent from --for, --expand and the MCP
+//     verbs, and an MCP client never sees the server's stderr.
+//   - Directory components. O_NOFOLLOW constrains the final component only, exactly as for the writes.
+//
+// Each sidecar keeps ONE read seam (readNotesSidecar / readBaselineSidecar / readArchBaselineSidecar) that
+// calls readWholeFileNoFollow below and carries its own DEGRADED_PATH_ALERT, for the same once-per-site
+// reason the write seams keep theirs.
+//
 // It carries no index/graph dependency on purpose — the emitter and the degrade macro are the whole of it —
 // so it stays includable from any layer, which is the property that let the rule be missing in the first
 // place. It is NOT under src/infra/: that layer is vendored into a sibling repo and may not name this
 // project (test/infraportcheck.sh rule (C)), and every sentence below has to.
 //
 // Gated by test/sidecarsymlinkcheck.sh, whose three symlink arms were observed RED before this header
-// existed and whose (e)/(f) mechanism arms were observed RED before the open below replaced the check.
+// existed, whose (e)/(f) mechanism arms were observed RED before the open below replaced the check, and
+// whose round-3 read arms were observed RED against the round-2 binary before the read below existed.
 
 #include "infra/emit.h"   // rw::emitTo — the refusal goes to stderr through THE emitter, not fprintf
 
@@ -207,6 +265,90 @@ inline bool writeAllAndClose( int fd, std::string_view bytes ) noexcept
         wrote = false;
     }
     return wrote;
+}
+
+// ── the read half (round 3) ───────────────────────────────────────────────────────────────────────────
+
+// What the no-follow read produced. `opened` is the OPEN, not the content: a directory at the name opens and
+// then fails its first read, exactly as the std::ifstream this replaces did, so a caller that tells "a
+// sidecar is there" from "no sidecar" (readBaseline's `present`, the arch verb's baseline-in-force) keeps
+// telling them apart the way it always has.
+struct NoFollowRead
+{
+    std::string bytes;             // every byte read before EOF or the first read error
+    bool        opened  = false;   // the open succeeded: something that is not a symlink sits at the name
+    bool        refused = false;   // the open failed with ELOOP — nothing was followed, and stderr says why
+    int         err     = 0;       // errno of the open or read that failed; 0 when neither did
+};
+
+// Read all of `path` WITHOUT following a symlink at the final component — openNoFollowTruncate's read twin:
+// the same O_NOFOLLOW, the same single syscall with no lstat in front of it to race, and the same rule that a
+// refusal is loud.
+//
+// ONLY THE REFUSAL IS LOUD. An absent file is every sidecar's first-run case and says nothing, and any other
+// open or read failure stays exactly as silent as the stream this replaces — the callers already read those as
+// "no sidecar", and making them loud is a behaviour change with questions of its own, not a rider on this
+// one. A read refused over a link is different in kind: the file is RIGHT THERE, and a caller that went quiet
+// about it would leave the user believing there is no sidecar at all.
+//
+// `what` names the sidecar in the user's words, as for the write.
+inline NoFollowRead readWholeFileNoFollow( std::string_view what, const std::string& path )
+{
+    NoFollowRead result;
+    const int    fd = ::open( path.c_str(), O_RDONLY | O_NOFOLLOW );
+    if( fd < 0 )
+    {
+        result.err = errno;
+        if( result.err != ELOOP )
+        {
+            return result;
+        }
+        result.refused = true;
+        if( isSymlink( path ) )
+        {
+            rw::emitTo( stderr,
+                        "ripwire: refusing to read {} at '{}': that path is a symlink, and reading through it would open whatever it points at\n"
+                        "  — outside this tree, if that is where it leads — and use its contents as {}. Nothing was read. A sidecar behind a\n"
+                        "  symlink is refused on read exactly as on write: replace the link with a regular copy of its target (or remove it) and re-run.\n",
+                        what, path, what );
+        }
+        else
+        {
+            // As for the write: ELOOP with no link at the final component is a loop in an earlier directory
+            // component, and "that path is a symlink" would be a claim about a component that is not one.
+            rw::emitTo( stderr,
+                        "ripwire: refusing to read {} at '{}': the path could not be resolved without following a symlink loop\n"
+                        "  in one of its directory components (ELOOP). Nothing was read.\n",
+                        what, path );
+        }
+        return result;
+    }
+
+    result.opened = true;
+    constexpr std::size_t kReadChunkBytes = 64 * 1024;   // how much one read(2) asks for, not how much is kept
+    std::size_t           used            = 0;
+    for( ;; )
+    {
+        result.bytes.resize( used + kReadChunkBytes );
+        const ssize_t n = ::read( fd, result.bytes.data() + used, kReadChunkBytes );
+        if( n > 0 )
+        {
+            used += static_cast<std::size_t>( n );
+            continue;
+        }
+        if( n < 0 && errno == EINTR )
+        {
+            continue;
+        }
+        if( n < 0 )
+        {
+            result.err = errno;
+        }
+        break;
+    }
+    result.bytes.resize( used );
+    ::close( fd );
+    return result;
 }
 
 } // namespace rw::pathguard

--- a/src/pathguard.h
+++ b/src/pathguard.h
@@ -30,7 +30,8 @@
 // ofstream, and not true of the problem: the writers do not need ofstream, they need a descriptor. So the
 // check and the create are now ONE syscall, and it is the only one a writer makes:
 //
-//     ::open( path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_NONBLOCK, 0666 )   (O_NONBLOCK and the fstat after it: round 4)
+//     ::open( path, O_WRONLY | O_CREAT | O_NOFOLLOW | O_NONBLOCK, 0666 )   (round 4: O_NONBLOCK, then fstat, then ftruncate
+//                                                                          in place of the O_TRUNC it once carried)
 //
 // O_NOFOLLOW makes the KERNEL refuse a final component that is a symlink, at the instant of resolution.
 // There is no window because there is no second resolution — whatever the entry is when the kernel looks
@@ -223,25 +224,43 @@ struct OpenedFile
 //
 // NOT A REGULAR FILE (round 4). O_NONBLOCK lets the open return for a FIFO instead of waiting for a reader:
 // with nobody reading, it fails at once with ENXIO and takes the plain-errno branch below. The fstat then
-// refuses whatever DID open but is not a regular file, before any byte is written. O_TRUNC has run by that
-// point and does nothing to a FIFO; on a regular file nothing here is refused. That refusal reports EINVAL,
+// refuses whatever DID open but is not a regular file, before any byte is written. That refusal reports EINVAL,
 // because no syscall failed: the name holds something a sidecar cannot be.
+//
+// TRUNCATION COMES LAST. The open does not carry O_TRUNC: with it, an existing regular sidecar was emptied before
+// fstat had looked at anything, so a failure there returned an error over a file already destroyed. The descriptor
+// is truncated with ftruncate only once fstat has confirmed a regular file, so every refusal and every failure
+// before that point leaves the old sidecar exactly as it was.
 inline OpenedFile openNoFollowTruncate( std::string_view what, const std::string& path )
 {
-    const int fd = ::open( path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_NONBLOCK, 0666 );
+    const int fd = ::open( path.c_str(), O_WRONLY | O_CREAT | O_NOFOLLOW | O_NONBLOCK, 0666 );
     if( fd >= 0 )
     {
         struct stat openedSt{};
-        if( ::fstat( fd, &openedSt ) == 0 && S_ISREG( openedSt.st_mode ) )
+        if( ::fstat( fd, &openedSt ) != 0 )
         {
-            return { fd, 0 };
+            const int statErr = errno;
+            ::close( fd );
+            rw::emitTo( stderr, "ripwire: could not inspect {} at '{}': {}. Nothing was written.\n", what, path, std::strerror( statErr ) );
+            return { -1, statErr };
         }
-        ::close( fd );
-        rw::emitTo( stderr,
-                    "ripwire: refusing to write {} at '{}': that path is not a regular file (a FIFO, for example), so there is no\n"
-                    "  sidecar there to write. Nothing was written. Remove it and re-run.\n",
-                    what, path );
-        return { -1, EINVAL };
+        if( !S_ISREG( openedSt.st_mode ) )
+        {
+            ::close( fd );
+            rw::emitTo( stderr,
+                        "ripwire: refusing to write {} at '{}': that path is not a regular file (a FIFO, for example), so there is no\n"
+                        "  sidecar there to write. Nothing was written. Remove it and re-run.\n",
+                        what, path );
+            return { -1, EINVAL };
+        }
+        if( ::ftruncate( fd, 0 ) != 0 )
+        {
+            const int truncErr = errno;
+            ::close( fd );
+            rw::emitTo( stderr, "ripwire: could not truncate {} at '{}' for writing: {}. Nothing was written.\n", what, path, std::strerror( truncErr ) );
+            return { -1, truncErr };
+        }
+        return { fd, 0 };
     }
     const int err = errno;
 

--- a/src/quality.h
+++ b/src/quality.h
@@ -3740,20 +3740,34 @@ inline bool baselineHeaderIsForeign( const std::string& line ) noexcept
 struct BaselineReadStats
 {
     bool        present        = false;   // the file opened
+    bool        symlinkRefused = false;   // a SYMLINK sits at the name: refused unopened (pathguard.h round 3), so `present` stays false
     bool        unrecognizable = false;   // opened, but no line of the format's structure in it
     bool        preQ1          = false;   // structure, but no per-symbol loc records: origin cannot be classified
     std::size_t badLines       = 0;       // lines of a known kind whose payload did not parse — skipped
 };
 
+// THE ONE PLACE THE BASELINE SIDECAR IS READ — shared by readBaseline, readBaselineHeadSha and
+// readBaselineAbsorbed, and openBaselineSidecar's other half with the same answer to a link: O_NOFOLLOW, refused
+// in the open itself. A link here used to be followed on the way in, so the link chose which file was honored as
+// the floor. Why an in-tree link is refused too is round 3 of src/pathguard.h.
+inline rw::pathguard::NoFollowRead readBaselineSidecar( const std::string& path )
+{
+    rw::pathguard::NoFollowRead sidecar = rw::pathguard::readWholeFileNoFollow( "the quality baseline sidecar", path );
+    if( sidecar.refused ) { DEGRADED_PATH_ALERT( "quality: refusing to read the baseline sidecar through a symlink" ); }
+    return sidecar;
+}
+
 inline bool readBaseline( const std::string& path, Snapshot& out, BaselineReadStats& stats )
 {
     stats = BaselineReadStats{};
-    std::ifstream f( path );
-    if( !f )
+    rw::pathguard::NoFollowRead sidecar = readBaselineSidecar( path );
+    if( !sidecar.opened )
     {
+        stats.symlinkRefused = sidecar.refused;   // "no sidecar" and "a sidecar refused unopened" are different answers
         return false;
     }
     stats.present = true;
+    std::istringstream f( std::move( sidecar.bytes ) );
     std::size_t recognizedLineCount = 0;
     std::string line;
     while( std::getline( f, line ) )
@@ -3875,11 +3889,12 @@ inline bool readBaseline( const std::string& path, Snapshot& out, BaselineReadSt
 // obeyed. `writeBaseline` only ever writes `gitHeadSha`'s output, so no legitimate sidecar is affected.
 inline std::string readBaselineHeadSha( const std::string& path )
 {
-    std::ifstream f( path );
-    if( !f )
+    rw::pathguard::NoFollowRead sidecar = readBaselineSidecar( path );
+    if( !sidecar.opened )
     {
         return {};
     }
+    std::istringstream f( std::move( sidecar.bytes ) );
     std::string line;
     while( std::getline( f, line ) )
     {
@@ -3909,11 +3924,12 @@ inline std::string readBaselineHeadSha( const std::string& path )
 // one the report has something to say about.
 inline std::size_t readBaselineAbsorbed( const std::string& path )
 {
-    std::ifstream f( path );
-    if( !f )
+    rw::pathguard::NoFollowRead sidecar = readBaselineSidecar( path );
+    if( !sidecar.opened )
     {
         return 0;
     }
+    std::istringstream f( std::move( sidecar.bytes ) );
     std::string line;
     while( std::getline( f, line ) )
     {
@@ -3985,6 +4001,7 @@ struct BaselineSelection
     const char*    marker = "git-HEAD";                        // static storage; safe to hold as a bare pointer
     bool           staleFileRemoved = false;                   // Stale only: the unlink LANDED (file gone from disk)
     bool           sidecarUnreadable = false;                  // a sidecar EXISTS but could not be read (unrecognizable or pre-Q1): ignored, named
+    bool           sidecarSymlinkRefused = false;              // a SYMLINK sits at the name and was refused unopened (pathguard.h round 3): ignored, named
     std::size_t    sidecarBadLines   = 0;                      // honored sidecar: lines skipped as unparseable
 
     bool isSidecarHonored() const noexcept { return source == BaselineSource::Sidecar; }
@@ -4014,7 +4031,15 @@ inline BaselineSelection selectBaseline( const std::string& root, const std::str
         sel.snapshot = Snapshot{};                             // readBaseline already clears on the unrecognizable path; belt and braces
         sel.source   = BaselineSource::Absent;
         sel.marker   = "git-HEAD";
-        if( readStats.present && ( readStats.unrecognizable || readStats.preQ1 ) )
+        if( readStats.symlinkRefused )
+        {
+            // Round 3 (pathguard.h): a link at the name is refused on read as on write. Never "no sidecar existed"
+            // (the git-HEAD marker) about an entry that is right there, and never "unreadable" about bytes that
+            // were deliberately not opened.
+            sel.sidecarSymlinkRefused = true;
+            sel.marker                = "git-HEAD (symlinked sidecar refused)";
+        }
+        else if( readStats.present && ( readStats.unrecognizable || readStats.preQ1 ) )
         {
             sel.sidecarUnreadable = true;                      // 2026-09-06: never "no sidecar existed" about a file that is right there
             sel.marker            = "git-HEAD (sidecar unreadable)";

--- a/src/quality.h
+++ b/src/quality.h
@@ -3752,7 +3752,7 @@ struct BaselineReadStats
 // the floor. Why an in-tree link is refused too is round 3 of src/pathguard.h.
 inline rw::pathguard::NoFollowRead readBaselineSidecar( const std::string& path )
 {
-    rw::pathguard::NoFollowRead sidecar = rw::pathguard::readWholeFileNoFollow( "the quality baseline sidecar", path );
+    rw::pathguard::NoFollowRead sidecar = rw::pathguard::openNoFollowRead( "the quality baseline sidecar", path );
     if( sidecar.refused ) { DEGRADED_PATH_ALERT( "quality: refusing to read the baseline sidecar through a symlink" ); }
     return sidecar;
 }
@@ -3767,10 +3767,9 @@ inline bool readBaseline( const std::string& path, Snapshot& out, BaselineReadSt
         return false;
     }
     stats.present = true;
-    std::istringstream f( std::move( sidecar.bytes ) );
     std::size_t recognizedLineCount = 0;
     std::string line;
-    while( std::getline( f, line ) )
+    while( sidecar.readLine( line ) )
     {
         if( line.empty() )
         {
@@ -3894,9 +3893,8 @@ inline std::string readBaselineHeadSha( const std::string& path )
     {
         return {};
     }
-    std::istringstream f( std::move( sidecar.bytes ) );
     std::string line;
-    while( std::getline( f, line ) )
+    while( sidecar.readLine( line ) )
     {
         if( line.rfind( "head ", 0 ) == 0 )
         {
@@ -3929,9 +3927,8 @@ inline std::size_t readBaselineAbsorbed( const std::string& path )
     {
         return 0;
     }
-    std::istringstream f( std::move( sidecar.bytes ) );
     std::string line;
-    while( std::getline( f, line ) )
+    while( sidecar.readLine( line ) )
     {
         if( line.rfind( "absorbed ", 0 ) != 0 )
         {

--- a/src/verbs_quality.h
+++ b/src/verbs_quality.h
@@ -29,6 +29,12 @@ std::string noBaselineFatalMessage( const std::string& baselineFile, const rw::q
     // auto-compare against" errMsg) has always carried both halves for the identical state, so a CLI reader
     // could not tell the fallback had even been tried and would look for a bug in the sidecar. Same two
     // clauses, same order, same verb-name spelling convention as the stale arms below.
+    if( sel.sidecarSymlinkRefused )
+    {
+        // Round 3 (pathguard.h): "no <file>" is false while a link sits at the name, so say what happened to it.
+        return "ripwire: " + baselineFile + " is a symlink, which is refused on read exactly as on write (it was not opened), and there is no git HEAD to auto-compare against — "
+               "replace the link with a regular copy of its target, or remove it and run `ripwire <dir> --quality-baseline` BEFORE the change you want to measure\n";
+    }
     if( !sel.isSidecarStale() )
     {
         return "ripwire: no " + baselineFile + " and no git HEAD to auto-compare against — run `ripwire <dir> --quality-baseline` BEFORE the change you want to measure\n";
@@ -244,8 +250,9 @@ std::optional<int> resolveDeltaBasis( const MainDispatch& d, const std::string& 
             rw::emitTo( stderr, "ripwire: {} exists but is not a readable baseline (unrecognizable, or a pre-Q1 sidecar without per-symbol loc records) — IGNORED; "
                                   "auto-comparing the working tree vs git HEAD; re-pin it with --quality-baseline\n", baselineFile.c_str() );
         }
-        else if( !out.baseSel.isSidecarStale() )
-        { // the stale/healed case is silent by design — only the true "never baselined" case is informative
+        else if( !out.baseSel.isSidecarStale() && !out.baseSel.sidecarSymlinkRefused )
+        { // the stale/healed case is silent by design — only the true "never baselined" case is informative. A refused
+          // link (pathguard.h round 3) is not "never baselined" either, and pathguard has already said why on stderr.
             rw::emitTo( stderr, "ripwire: no {} — auto-comparing the working tree vs git HEAD (commit the baseline with --quality-baseline to pin it)\n",
                           baselineFile.c_str() );
         }
@@ -534,6 +541,10 @@ inline constexpr const char* kQdBaseHeadUnreadable =
     "working tree was compared against the HEAD tree — re-pin it with quality-baseline. baseline_bad_lines= and "
     "acks_bad_lines=, when present, count sidecar lines of a known kind whose payload did not parse and were "
     "skipped (absent means none). ";
+inline constexpr const char* kQdBaseHeadSymlinkRefused =
+    "baseline=\"git-HEAD (symlinked sidecar refused)\" means .ripwire_quality_baseline is a SYMLINK, which is refused on "
+    "read exactly as on write: it was not opened, so the working tree was compared against the HEAD tree — replace "
+    "the link with a regular copy of its target, or remove it and re-pin with quality-baseline. ";
 inline constexpr const char* kQdBaseHeadIgnored =
     "baseline=\"git-HEAD (stale sidecar ignored)\" is the same staleness verdict, but the file was left on "
     "disk (the read-only MCP arm, or an unlink that failed), and the comparison fell back to the HEAD "
@@ -721,6 +732,7 @@ inline void emitQualityDeltaLegend( const QualityDeltaLegendParts& p )
     else if( p.marker == "git-HEAD (stale sidecar removed)" ) { std::fputs( kQdBaseHeadRemoved, stdout ); }
     else if( p.marker == "git-HEAD (stale sidecar ignored)" ) { std::fputs( kQdBaseHeadIgnored, stdout ); }
     else if( p.marker == "git-HEAD (sidecar unreadable)"     ) { std::fputs( kQdBaseHeadUnreadable, stdout ); }
+    else if( p.marker == "git-HEAD (symlinked sidecar refused)" ) { std::fputs( kQdBaseHeadSymlinkRefused, stdout ); }
     else                                                      { std::fputs( kQdBaseHead,        stdout ); }
     if( p.baselineAbsorbed > 0 )
     {

--- a/src/verbs_report.h
+++ b/src/verbs_report.h
@@ -605,7 +605,7 @@ std::optional<int> runArchViews( const MainDispatch& d )
         // --baseline-update: merge current violations into an existing (or new) sidecar; exit 0.
         if( cfg.baselineUpdate )
         {
-            std::unordered_set<std::uint64_t> hashes = archReadBaseline( sidecarPath );
+            std::unordered_set<std::uint64_t> hashes = archReadBaseline( sidecarPath ).hashes;
             for( const Viol& v : viols )
             {
                 hashes.insert( v.hash );
@@ -629,14 +629,12 @@ std::optional<int> runArchViews( const MainDispatch& d )
             return 0;
         }
 
-        // Normal run: load baseline (if present) and split violations into baselined vs new.
-        const std::unordered_set<std::uint64_t> baseline    = archReadBaseline( sidecarPath );
-        const bool                              hasBaseline  = !baseline.empty() || [ &sidecarPath ]()
-        {
-            // detect sidecar presence even if it contains only comments (0 hashes)
-            std::ifstream probe( sidecarPath );
-            return probe.good();
-        }();
+        // Normal run: load baseline (if present) and split violations into baselined vs new. Presence is the READ's
+        // own answer (a comment-only sidecar is present with 0 hashes). It used to be a second, bare open of the
+        // same path, which followed a link and read nothing — see ArchBaselineRead.
+        const ArchBaselineRead                   baselineRead = archReadBaseline( sidecarPath );
+        const std::unordered_set<std::uint64_t>& baseline     = baselineRead.hashes;
+        const bool                               hasBaseline  = baselineRead.present;
 
         std::vector<const Viol*> newViols, basedViols;
         for( const Viol& v : viols )

--- a/test/sidecarsymlinkcheck.sh
+++ b/test/sidecarsymlinkcheck.sh
@@ -72,9 +72,10 @@
 #                       emitters report no failed write, and fclose answers only for its own final flush, so a
 #                       failed EARLIER flush could still come back true. The two siblings already had the shape,
 #                       so on them these rows are green before and after — a regression guard there
-#     once:         (f) MECHANISM: src/pathguard.h has exactly ONE ::open and it carries all four of
-#                       O_WRONLY/O_CREAT/O_TRUNC/O_NOFOLLOW; and refuseSymlinkWrite — the advisory
-#                       check-then-open guard — is gone from src/ entirely, not merely unused
+#     once:         (f) MECHANISM: src/pathguard.h has exactly TWO ::open — one write open carrying all four of
+#                       O_WRONLY/O_CREAT/O_TRUNC/O_NOFOLLOW (f1), and one read open carrying O_RDONLY|O_NOFOLLOW
+#                       (f3, round 3); and refuseSymlinkWrite — the advisory check-then-open guard — is gone
+#                       from src/ entirely, not merely unused (f2)
 #
 # Arms that are green before AND after are labelled so rather than left to look like coverage they are not
 # (CONTRIBUTING §2, shape 7 — an arm asserting something strictly weaker than its name implies). They still
@@ -106,6 +107,35 @@
 #         success, because when EVERY write is refused its fclose still returns the failure. The defect (e5)/(e6)
 #         pin needs an earlier failed flush followed by a final one that succeeds — a transient failure no gate
 #         can schedule deterministically — so (e5)/(e6) are the proof and (x) only holds the contract in place.
+#
+# ROUND 3 — THE READERS OF THE SAME THREE NAMES. A deliberate decision, pinned here rather than assumed.
+# Rounds 1-2 closed the WRITE half and left every reader following a link: notes::readNotes,
+# quality::readBaseline / readBaselineHeadSha / readBaselineAbsorbed, archReadBaseline, and a bare ifstream
+# presence probe in the arch verb, whether the link's target was inside the crawl root or not. The round-3
+# arms at the bottom of this file were red on the round-2 binary.
+#
+# DECISION (b): refuse the link on READ too, by O_NOFOLLOW at the open. Not (a), leave the readers following;
+# not (c), refuse only a link that leaves the crawl root. The argument is in src/pathguard.h. The arms, each
+# named for the alternative it fails under:
+#
+#     per sidecar:  (n) NEGATIVE CONTROL: the same payload as a REGULAR file is still read and used. Green
+#                       before and after; without it, "never read the sidecar" passes every arm below
+#                   (k) a link to a VALID payload OUTSIDE the tree is not used, the verb still produces its
+#                       document, and stderr names the refusal. Red under (a). For arch, (k2) also requires
+#                       the violation that payload would have accepted to come back NEW, with exit 2
+#                   (i) THE DECISION PIN: a link to the same payload INSIDE the crawl root is refused as well.
+#                       Red under (a) AND under (c) — the only arm that tells (b) from (c)
+#                   (t) NEVER OPENED: with the link aimed at a FIFO, no reading verb opens its target at all.
+#                       A read whose bytes are discarded (--note-add reads before it writes; the arch probe
+#                       reads nothing) can never fail a content arm, so this is its only observable. (t0) is
+#                       the probe's positive control: `cat` on the same FIFO must count as an open (shape 5)
+#     quality:      (q) the refusal is named IN the document — baseline="git-HEAD (symlinked sidecar refused)"
+#                       from the CLI and from MCP, never the "no sidecar existed" marker — and a tree with no
+#                       HEAD to fall back to fails without calling the linked sidecar missing
+#     per reader:   (m) MECHANISM (source arms, like (e)): each reader takes its bytes from its sidecar's read
+#                       seam, the seam reads through pathguard's O_NOFOLLOW read and carries the site's own
+#                       DEGRADED_PATH_ALERT, and no following open survives in a reader or in the arch verb;
+#                       (f3) pins the read open's flags
 #
 # Usage:
 #   bash test/sidecarsymlinkcheck.sh                 |  bash test/sidecarsymlinkcheck.sh asan/ripwire
@@ -356,20 +386,30 @@ mechArm archbaseline    src/arch.h    'inline int openArchBaselineSidecar( const
         'inline bool archWriteBaseline( const std::string&' 'openArchBaselineSidecar' \
         'arch: refusing to write the arch baseline sidecar through a symlink'
 
-# ── (f) MECHANISM: the one open, and the advisory guard that must not come back ───────────────────────
+# ── (f) MECHANISM: the two opens, and the advisory guard that must not come back ──────────────────────
+# Round 3 put the READ open beside the write open, so the census is two, and each is pinned by the flags that
+# make it what it is: a second write open, a write open without O_NOFOLLOW, or a read open that lost it all
+# fail here rather than hiding inside a count that happens to still be right.
 PG="$ROOT/src/pathguard.h"
 PGCODE="$TMP/pathguard_code.txt"
 grep -v '^[[:space:]]*//' "$PG" >"$PGCODE"
 openLines="$( grep -c '::open(' "$PGCODE" | tr -d ' ' )"
-if [ "$openLines" = "1" ] \
-   && grep -q '::open(' "$PGCODE" \
-   && grep '::open(' "$PGCODE" | grep -q 'O_WRONLY' \
-   && grep '::open(' "$PGCODE" | grep -q 'O_CREAT' \
-   && grep '::open(' "$PGCODE" | grep -q 'O_TRUNC' \
-   && grep '::open(' "$PGCODE" | grep -q 'O_NOFOLLOW'; then
-    ok "pathguard: (f1) exactly one ::open, carrying O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW"
+writeOpens="$( grep '::open(' "$PGCODE" | grep -c 'O_WRONLY' | tr -d ' ' )"
+readOpens="$( grep '::open(' "$PGCODE" | grep -c 'O_RDONLY' | tr -d ' ' )"
+if [ "$openLines" = "2" ] && [ "$writeOpens" = "1" ] \
+   && grep '::open(' "$PGCODE" | grep 'O_WRONLY' | grep -q 'O_CREAT' \
+   && grep '::open(' "$PGCODE" | grep 'O_WRONLY' | grep -q 'O_TRUNC' \
+   && grep '::open(' "$PGCODE" | grep 'O_WRONLY' | grep -q 'O_NOFOLLOW'; then
+    ok "pathguard: (f1) exactly two ::open, and the one write open carries O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW"
 else
-    no "pathguard: (f1) expected exactly one ::open carrying all four flags — found $openLines: $( grep '::open(' "$PGCODE" | head -c 160 )"
+    no "pathguard: (f1) expected two ::open, exactly one of them a write open carrying all four flags — found $openLines open(s), $writeOpens write: $( grep '::open(' "$PGCODE" | tr '\n' ' ' | head -c 240 )"
+fi
+if [ "$readOpens" = "1" ] \
+   && grep '::open(' "$PGCODE" | grep 'O_RDONLY' | grep -q 'O_NOFOLLOW' \
+   && ! grep '::open(' "$PGCODE" | grep 'O_RDONLY' | grep -qE 'O_WRONLY|O_CREAT|O_TRUNC'; then
+    ok "pathguard: (f3) exactly one read ::open, carrying O_RDONLY|O_NOFOLLOW and nothing that creates or truncates"
+else
+    no "pathguard: (f3) expected exactly one read ::open carrying O_RDONLY|O_NOFOLLOW — found $readOpens: $( grep '::open(' "$PGCODE" | tr '\n' ' ' | head -c 240 )"
 fi
 
 if grep -rq 'refuseSymlinkWrite' "$ROOT/src"; then
@@ -670,6 +710,387 @@ PY
     raceArm qualitybaseline .ripwire_quality_baseline runQualityBaseline
     raceArm notes           .ripwire_notes            runNoteAdd
     raceArm archbaseline    .ripwire_arch_baseline    runArchBaseline
+fi
+
+# ══ ROUND 3 — THE READERS (decision and arm map in the header) ════════════════════════════════════════════
+
+# ONE valid record on a target the fixture really defines, so --notes lists it the moment the file is read. The
+# sentinel is its text; nothing else in any output can spell it.
+READ_SENTINEL='sidecar-read-sentinel-outside-note'
+# Anchored on the ELEMENT, not the bare attribute: the quality legend states each marker's meaning in a sentence
+# that quotes the marker, so an unanchored pattern could be satisfied by the dictionary instead of the verdict.
+# The element opens `<quality-delta schema="ripwire.quality-delta/v1" baseline="…"`; the legend spells the schema
+# with a colon after it, never a quote, so `v1" baseline=` can only be the element.
+QD_LIVE='<quality-delta schema="'
+QD_HONORED='quality-delta/v1" baseline="sidecar"'
+QD_REFUSED='quality-delta/v1" baseline="git-HEAD (symlinked sidecar refused)"'
+
+# mkTree's rules produce NO violation — fine for the writer arms, where an empty accepted set is still a write,
+# and useless here: a baseline that accepts nothing suppresses nothing, so "the linked baseline was not used"
+# would pass for the emptiest reason (shape 3). So this is mkTree plus one include that crosses a denied pair
+# in archcheck's fixture shape, with the rules replaced to deny exactly that pair: one violation, no more.
+mkArchViolTree()
+{
+    local dir="$1"
+    mkTree "$dir"
+    mkdir -p "$dir/render" "$dir/test"
+    printf 'int shade( int x ) { return x; }\n' >"$dir/render/shader.h"
+    printf '#include "../render/shader.h"\nint main( void ) { return shade( 1 ); }\n' >"$dir/test/main.cpp"
+    printf 'deny test -> render\n' >"$dir/rules.txt"
+}
+
+# The quality marker needs a HEAD to fall back to, and a sidecar is honored only when its pin EQUALS that HEAD.
+# So the payload is pinned in THIS repo and every mode reuses the repo: a second repo would carry a different
+# sha, and the control would read "stale" instead of "sidecar".
+mkQualityRepo()
+{
+    local dir="$1"
+    rm -rf "$dir"; mkdir -p "$dir"
+    printf 'int helper( int x ) { return x + 1; }\nint main( void ) { return helper( 1 ); }\n' >"$dir/a.c"
+    ( cd "$dir" && git init -q && git config user.email x@y && git config user.name x && git add a.c && git commit -qm init ) >/dev/null 2>&1
+}
+
+# placeSidecar MODE TREE SIDECAR PAYLOAD — PAYLOAD's bytes reachable at TREE/SIDECAR in MODE's way, with nothing
+# left over from the previous mode:
+#   ctl  a REGULAR file at the name
+#   out  a symlink at the name → a copy in a SIBLING of the tree, i.e. outside the crawl root
+#   in   a RELATIVE symlink at the name → a copy under TREE/docs/, so the link never leaves the crawl root
+placeSidecar()
+{
+    local mode="$1" tree="$2" sidecar="$3" payload="$4"
+    rm -rf "$tree/$sidecar" "$tree/docs" "$tree.outside"
+    case "$mode" in
+        ctl) cp "$payload" "$tree/$sidecar" ;;
+        out) mkdir -p "$tree.outside" && cp "$payload" "$tree.outside/shared-sidecar" \
+                 && ln -s "$tree.outside/shared-sidecar" "$tree/$sidecar" ;;
+        in)  mkdir -p "$tree/docs" && cp "$payload" "$tree/docs/shared-sidecar" \
+                 && ( cd "$tree" && ln -s docs/shared-sidecar "$sidecar" ) ;;
+    esac
+}
+
+# runReadMode MODE ARM WHERE LABEL TREE SIDECAR PAYLOAD LIVE RUNNER — plant the payload MODE's way, run the verb,
+# and keep stdout/stderr/rc as $TMP/<label>_read_<mode>.{out,err,rc} for the arms that read them. Returns non-zero,
+# after saying why, when the run can prove nothing:
+#   - PRESENCE GUARD: the entry is not the shape MODE claims, or does not resolve to the payload's bytes;
+#   - LIVE GUARD: the verb printed no normal document, so a crash would pass "the payload is absent" (shape 3).
+runReadMode()
+{
+    local mode="$1" arm="$2" where="$3" label="$4" tree="$5" sidecar="$6" payload="$7" live="$8" runner="$9"
+    local base="$TMP/${label}_read_$mode" isLink=0 rc=0
+
+    placeSidecar "$mode" "$tree" "$sidecar" "$payload"
+    [ -L "$tree/$sidecar" ] && isLink=1
+    if ! cmp -s "$payload" "$tree/$sidecar" || { [ "$mode" = ctl ] && [ "$isLink" = 1 ]; } || { [ "$mode" != ctl ] && [ "$isLink" = 0 ]; }; then
+        no "$label: ($arm/guard) could not plant the payload $where at $sidecar — ($arm) is void"
+        return 1
+    fi
+
+    "$runner" "$tree" >"$base.out" 2>"$base.err" || rc=$?
+    printf '%s\n' "$rc" >"$base.rc"
+    if ! grep -qF "$live" "$base.out"; then
+        no "$label: ($arm/guard) the verb produced no normal document (rc=$rc) with the payload $where — ($arm) is void: $( head -c 160 "$base.err" | tr '\n' ' ' )"
+        return 1
+    fi
+}
+
+# readArm LABEL TREE SIDECAR PAYLOAD USED LIVE RUNNER — the control, then the two link modes, over one tree.
+#   USED  a fixed string whose presence in stdout means the payload was read AND used
+#   LIVE  a fixed string every normal run of the verb prints (see runReadMode's LIVE GUARD)
+# The control must show USED before either link mode's ABSENCE of it is allowed to mean anything.
+readArm()
+{
+    local label="$1" tree="$2" sidecar="$3" payload="$4" used="$5" live="$6" runner="$7" mode arm where base
+
+    if [ ! -s "$payload" ]; then
+        no "$label: (read/guard) no payload was produced to plant — (n)/(k)/(i) are void"
+        return
+    fi
+    runReadMode ctl n "as a regular file" "$label" "$tree" "$sidecar" "$payload" "$live" "$runner" || return
+    if ! grep -qF "$used" "$TMP/${label}_read_ctl.out"; then
+        no "$label: (n) the regular sidecar's payload was not used — the fixture or the reader is broken, and (k)/(i) are void"
+        return
+    fi
+    ok "$label: (n) a REGULAR sidecar is still read and used — the document shows: $used"
+
+    for mode in out in; do
+        arm="k"; where="outside the tree"
+        [ "$mode" = in ] && { arm="i"; where="INSIDE the crawl root"; }
+        runReadMode "$mode" "$arm" "$where" "$label" "$tree" "$sidecar" "$payload" "$live" "$runner" || continue
+        base="$TMP/${label}_read_$mode"
+        if grep -qF "$used" "$base.out"; then
+            no "$label: ($arm) a symlink at $sidecar → a valid payload $where was READ AND USED (rc=$( cat "$base.rc" )): $used"
+        else
+            ok "$label: ($arm) a symlink at $sidecar → a valid payload $where was not used"
+        fi
+        if grep -q 'refusing to read' "$base.err" && grep -q 'symlink' "$base.err"; then
+            ok "$label: ($arm) stderr names the read refusal and the reason (symlink)"
+        else
+            no "$label: ($arm) stderr carries no read refusal — the sidecar went unused without saying why: $( head -c 160 "$base.err" | tr '\n' ' ' )"
+        fi
+    done
+}
+
+readNotesList(){ "$BIN" "$1" --notes --no-cache; }
+readQualityDelta(){ "$BIN" "$1" --quality-delta --legend=compact --no-cache; }
+readArchCheck(){ ( cd "$1" && "$BIN" "$1" --arch=rules.txt --no-cache ); }
+
+# ── notes ─────────────────────────────────────────────────────────────────────────────────────────────────
+printf 'a.c\t2026-01-01\t%s\n' "$READ_SENTINEL" >"$TMP/payload_notes"
+RN="$TMP/notes_read/tree"
+mkTree "$RN"
+readArm notes "$RN" .ripwire_notes "$TMP/payload_notes" "$READ_SENTINEL" '<notes>' readNotesList
+
+# ── quality baseline: (n)/(k)/(i), then (q) — where the refusal is disclosed ──────────────────────────────
+RQ="$TMP/qualitybaseline_read/tree"
+mkQualityRepo "$RQ"
+"$BIN" "$RQ" --quality-baseline --no-cache >/dev/null 2>&1
+if [ -f "$RQ/.ripwire_quality_baseline" ] && grep -qE '^head [0-9a-f]{40}' "$RQ/.ripwire_quality_baseline"; then
+    mv "$RQ/.ripwire_quality_baseline" "$TMP/payload_quality"
+    readArm qualitybaseline "$RQ" .ripwire_quality_baseline "$TMP/payload_quality" "$QD_HONORED" "$QD_LIVE" readQualityDelta
+
+    QOUT="$TMP/qualitybaseline_read_out.out"; QERR="$TMP/qualitybaseline_read_out.err"
+    if [ -s "$QOUT" ] && grep -qF "$QD_REFUSED" "$QOUT"; then
+        ok "qualitybaseline: (q1) the CLI report names the floor it could not use: $QD_REFUSED"
+    else
+        no "qualitybaseline: (q1) the CLI report does not carry $QD_REFUSED — it says: $( grep -o 'quality-delta/v1" baseline="[^"]*"' "$QOUT" 2>/dev/null | head -1 )"
+    fi
+    # Absence of two FALSE sentences. Green on the round-2 binary (it printed neither, because it used the link);
+    # observed RED on an intermediate build that refused the read and left the wording alone, which said the
+    # sidecar did not exist while the link was sitting right there.
+    if grep -q 'ripwire: no ' "$QERR" || grep -q 'not a readable baseline' "$QERR"; then
+        no "qualitybaseline: (q2) stderr calls the refused link missing or unrecognizable — it is neither: $( grep -E 'ripwire: no |not a readable baseline' "$QERR" | head -c 200 )"
+    else
+        ok "qualitybaseline: (q2) stderr does not describe the refused link as missing or unrecognizable"
+    fi
+
+    # MCP has its own marker step (mcpverbs.h::mcpBaselineMarker), which probes the path itself — so it is
+    # asserted on its own, against the same link.
+    placeSidecar out "$RQ" .ripwire_quality_baseline "$TMP/payload_quality"
+    MCPLINE="$( printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
+                  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"quality_delta","arguments":{"path":"'"$RQ"'"}}}' \
+                | "$BIN" --mcp 2>/dev/null | tail -1 )"
+    if ! printf '%s' "$MCPLINE" | grep -q 'baseline'; then
+        no "qualitybaseline: (q3/guard) MCP quality_delta returned no baseline marker at all — (q3) is void: $( printf '%s' "$MCPLINE" | head -c 200 )"
+    elif printf '%s' "$MCPLINE" | grep -qF 'git-HEAD (symlinked sidecar refused)'; then
+        ok "qualitybaseline: (q3) MCP quality_delta names the refused link in its marker"
+    else
+        no "qualitybaseline: (q3) MCP quality_delta does not name the refused link — it says: $( printf '%s' "$MCPLINE" | grep -o 'baseline[^,]*' | head -1 )"
+    fi
+else
+    no "qualitybaseline: (read/guard) could not pin a HEAD-stamped payload in a git fixture — (n)/(k)/(i)/(q1)-(q3) are void"
+fi
+
+# NO HEAD: the refused link leaves no floor at all, so the verb must fail — and its fatal must not say the
+# sidecar is missing, which is false while the link is right there. mkTree lives under $TMP, not in a checkout.
+RQN="$TMP/qualitybaseline_nogit/tree"
+mkTree "$RQN"
+"$BIN" "$RQN" --quality-baseline --no-cache >/dev/null 2>&1
+if [ -f "$RQN/.ripwire_quality_baseline" ] && mv "$RQN/.ripwire_quality_baseline" "$TMP/payload_quality_nogit"; then
+    placeSidecar out "$RQN" .ripwire_quality_baseline "$TMP/payload_quality_nogit"
+    rc=0
+    "$BIN" "$RQN" --quality-delta --legend=compact --no-cache >"$TMP/q_nogit.out" 2>"$TMP/q_nogit.err" || rc=$?
+    if [ "$rc" -ne 0 ] && ! grep -qF "$QD_HONORED" "$TMP/q_nogit.out"; then
+        ok "qualitybaseline: (q4) with no HEAD to fall back to, the refused link is a failure ($rc), not an honored floor"
+    else
+        no "qualitybaseline: (q4) with no HEAD to fall back to, the verb exited $rc and reported $( grep -o 'quality-delta/v1" baseline="[^"]*"' "$TMP/q_nogit.out" | head -1 )"
+    fi
+    if grep -q 'refusing to read' "$TMP/q_nogit.err" && ! grep -q 'ripwire: no ' "$TMP/q_nogit.err"; then
+        ok "qualitybaseline: (q5) the no-HEAD fatal names the refusal and does not call the sidecar missing"
+    else
+        no "qualitybaseline: (q5) the no-HEAD fatal is not honest about the link: $( head -c 240 "$TMP/q_nogit.err" | tr '\n' ' ' )"
+    fi
+    # The MCP twin of (q5). Its no-HEAD answer is mcpverbs.h's own errMsg, not the CLI's fatal, so it can be wrong
+    # on its own and is asserted on its own.
+    MCPNG="$( printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
+                '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"quality_delta","arguments":{"path":"'"$RQN"'"}}}' \
+              | "$BIN" --mcp 2>/dev/null | tail -1 )"
+    if printf '%s' "$MCPNG" | grep -q 'is a symlink' && ! printf '%s' "$MCPNG" | grep -q 'no \.ripwire_quality_baseline'; then
+        ok "qualitybaseline: (q6) MCP quality_delta's no-HEAD answer names the refused link and does not call the sidecar missing"
+    else
+        no "qualitybaseline: (q6) MCP quality_delta's no-HEAD answer is not honest about the link: $( printf '%s' "$MCPNG" | head -c 240 )"
+    fi
+else
+    no "qualitybaseline: (q4/guard) could not pin a payload in a non-git tree — (q4)/(q5) are void"
+fi
+
+# ── arch baseline ─────────────────────────────────────────────────────────────────────────────────────────
+RA="$TMP/archbaseline_read/tree"
+mkArchViolTree "$RA"
+( cd "$RA" && "$BIN" "$RA" --arch=rules.txt --baseline --no-cache ) >/dev/null 2>&1
+if [ -f "$RA/.ripwire_arch_baseline" ] && grep -qE '^[0-9a-f]{8,}' "$RA/.ripwire_arch_baseline"; then
+    mv "$RA/.ripwire_arch_baseline" "$TMP/payload_arch"
+    readArm archbaseline "$RA" .ripwire_arch_baseline "$TMP/payload_arch" 'baselined="1"' '<arch layers=' readArchCheck
+    # FAIL-CLOSED, not merely unused: the one violation the refused baseline would have accepted is reported NEW
+    # and the verb exits 2, exactly as with no sidecar at all.
+    if grep -qF 'new_violations="1"' "$TMP/archbaseline_read_out.out" 2>/dev/null \
+       && [ "$( cat "$TMP/archbaseline_read_out.rc" 2>/dev/null )" = "2" ]; then
+        ok "archbaseline: (k2) the violation the refused baseline would have accepted is reported NEW, exit 2"
+    else
+        no "archbaseline: (k2) the refused baseline still changed the verdict: $( grep -o '<arch [^>]*>' "$TMP/archbaseline_read_out.out" 2>/dev/null ) rc=$( cat "$TMP/archbaseline_read_out.rc" 2>/dev/null )"
+    fi
+else
+    no "archbaseline: (read/guard) could not pin a baseline holding a real violation hash — (n)/(k)/(k2)/(i) are void"
+fi
+
+# ── (t) NEVER OPENED ──────────────────────────────────────────────────────────────────────────────────────
+# A reader that follows the link opens whatever is at its end. Aimed at a FIFO with no writer, that open BLOCKS
+# until something opens the other end, so the probe opens the FIFO for writing with O_NONBLOCK — which succeeds
+# only while a reader holds or awaits it (ENXIO otherwise) — counts the success, and closes to let the reader go
+# on. The verdict is opens=0 or not, and it does not depend on speed: an O_NOFOLLOW open is refused with ELOOP
+# without reaching the FIFO at all, and a following open cannot complete before the probe has seen it, because
+# the probe is the only writer there is. The COUNT is approximate (a reader still draining EOF can be seen twice)
+# and nothing asserts on it.
+if ! command -v python3 >/dev/null 2>&1; then
+    no "read: python3 is not on PATH — the (t) arms cannot run, and a skipped arm proves nothing"
+else
+    cat >"$TMP/fifoopens.py" <<'PY'
+import errno, os, subprocess, sys, time
+fifo, cwd, argv = sys.argv[1], sys.argv[2], sys.argv[3:]
+p = subprocess.Popen( argv, cwd=cwd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL )
+opens, deadline = 0, time.time() + 60.0
+while p.poll() is None and time.time() < deadline:
+    try:
+        fd = os.open( fifo, os.O_WRONLY | os.O_NONBLOCK )
+    except OSError as e:
+        if e.errno != errno.ENXIO:
+            raise
+        time.sleep( 0.002 )
+        continue
+    opens += 1
+    os.close( fd )
+    time.sleep( 0.02 )
+if p.poll() is None:
+    p.kill()
+    p.wait()
+    print( 'opens=%d rc=hung' % opens )
+else:
+    print( 'opens=%d rc=%d' % ( opens, p.returncode ) )
+PY
+
+    # fifoLink DIR SIDECAR — DIR/tree already built; plants DIR/outside/fifo and a link at the sidecar name to it.
+    fifoLink()
+    {
+        local dir="$1" sidecar="$2"
+        mkdir -p "$dir/outside" && mkfifo "$dir/outside/fifo" && ln -s "$dir/outside/fifo" "$dir/tree/$sidecar" \
+            && [ -p "$dir/outside/fifo" ] && [ -L "$dir/tree/$sidecar" ]
+    }
+
+    # opensArm LABEL VERB CWD FIFO ARGV... — the verb, run from CWD, must never open FIFO.
+    opensArm()
+    {
+        local label="$1" verb="$2" cwd="$3" fifo="$4" res
+        shift 4
+        res="$( python3 "$TMP/fifoopens.py" "$fifo" "$cwd" "$@" 2>&1 )"
+        case "$res" in
+            'opens=0 rc='[0-9]*) ok "$label: (t) $verb never opened the link's target ($res)" ;;
+            *)                   no "$label: (t) $verb OPENED the link's target, or hung — $res" ;;
+        esac
+    }
+
+    mkdir -p "$TMP/fifo_ctl" && mkfifo "$TMP/fifo_ctl/fifo"
+    CTLRES="$( python3 "$TMP/fifoopens.py" "$TMP/fifo_ctl/fifo" "$TMP/fifo_ctl" cat "$TMP/fifo_ctl/fifo" 2>&1 )"
+    case "$CTLRES" in
+        'opens='[1-9]*' rc=0')
+            ok "read: (t0/guard) the probe counts a real open of the FIFO — cat gave $CTLRES"
+
+            mkTree "$TMP/notes_fifo/tree"
+            if fifoLink "$TMP/notes_fifo" .ripwire_notes; then
+                FT="$TMP/notes_fifo/tree"; FF="$TMP/notes_fifo/outside/fifo"
+                opensArm notes --notes    "$FT" "$FF" "$BIN" "$FT" --notes --no-cache
+                opensArm notes --note-add "$FT" "$FF" "$BIN" "$FT" --note-add="a.c: read-side probe" --no-cache
+                opensArm notes --for      "$FT" "$FF" "$BIN" "$FT" --for=helper --no-cache
+            else
+                no "notes: (t/guard) could not plant a FIFO behind a link at .ripwire_notes — (t) is void"
+            fi
+
+            mkTree "$TMP/qualitybaseline_fifo/tree"
+            if fifoLink "$TMP/qualitybaseline_fifo" .ripwire_quality_baseline; then
+                FT="$TMP/qualitybaseline_fifo/tree"; FF="$TMP/qualitybaseline_fifo/outside/fifo"
+                opensArm qualitybaseline --quality-delta "$FT" "$FF" "$BIN" "$FT" --quality-delta --no-cache
+            else
+                no "qualitybaseline: (t/guard) could not plant a FIFO behind a link at .ripwire_quality_baseline — (t) is void"
+            fi
+
+            mkArchViolTree "$TMP/archbaseline_fifo/tree"
+            if fifoLink "$TMP/archbaseline_fifo" .ripwire_arch_baseline; then
+                FT="$TMP/archbaseline_fifo/tree"; FF="$TMP/archbaseline_fifo/outside/fifo"
+                opensArm archbaseline --arch            "$FT" "$FF" "$BIN" "$FT" --arch=rules.txt --no-cache
+                opensArm archbaseline --baseline-update "$FT" "$FF" "$BIN" "$FT" --arch=rules.txt --baseline-update --no-cache
+            else
+                no "archbaseline: (t/guard) could not plant a FIFO behind a link at .ripwire_arch_baseline — (t) is void"
+            fi
+            ;;
+        *)
+            no "read: (t0/guard) the probe did not count cat's open of the FIFO ($CTLRES) — every (t) arm is void"
+            ;;
+    esac
+fi
+
+# ── (m) MECHANISM (source): every reader of the three names reads through its sidecar's seam ──────────────
+# Like (e): these read $ROOT/src and do not follow $BIN. The reader half is checked even when the seam cannot be
+# extracted, so a tree that never grew a seam shows the following open that is still there, not only a void.
+readMechArm()
+{
+    local label="$1" src="$2" readerSig="$3" readerFn="$4" seamSig="$5" seamFn="$6" alert="$7" checkSeam="$8"
+    local rd="$TMP/rd_${label}_$readerFn.txt" sm="$TMP/seam_${label}_$seamFn.txt" rdLines smLines
+
+    extractFn "$ROOT/$src" "$readerSig" >"$rd"
+    rdLines="$( wc -l <"$rd" | tr -d ' ' )"
+    if [ "$rdLines" -ge 5 ] && grep -q 'return' "$rd"; then
+        ok "$label: (m0/guard) extracted $rdLines code lines of $readerFn from $src"
+    else
+        no "$label: (m0/guard) could not extract $readerFn from $src ($rdLines lines) — (m1) is void"
+        return
+    fi
+    if grep -q "$seamFn(" "$rd" && ! grep -qE 'std::ifstream|std::fopen|readWholeFile\(' "$rd"; then
+        ok "$label: (m1) $readerFn takes its bytes from $seamFn and opens nothing itself"
+    else
+        no "$label: (m1) $readerFn does not read through $seamFn, or still opens the sidecar itself: $( grep -E 'std::ifstream|std::fopen|readWholeFile\(' "$rd" | head -c 160 )"
+    fi
+
+    [ "$checkSeam" = 1 ] || return
+    extractFn "$ROOT/$src" "$seamSig" >"$sm"
+    smLines="$( wc -l <"$sm" | tr -d ' ' )"
+    if [ "$smLines" -lt 4 ] || ! grep -q 'return' "$sm"; then
+        no "$label: (m2/guard) could not extract the read seam $seamFn from $src ($smLines lines) — (m2)/(m3) are void"
+        return
+    fi
+    if grep -q 'readWholeFileNoFollow' "$sm"; then
+        ok "$label: (m2) $seamFn reads through pathguard's O_NOFOLLOW read"
+    else
+        no "$label: (m2) $seamFn does not read through rw::pathguard::readWholeFileNoFollow"
+    fi
+    if grep -qF "$alert" "$sm"; then
+        ok "$label: (m3) $seamFn carries the site's own DEGRADED_PATH_ALERT for the refused link"
+    else
+        no "$label: (m3) $seamFn does not carry the expected alert: $alert"
+    fi
+}
+
+readMechArm notes           src/notes.h   'inline std::vector<Note> readNotes( const std::string& path )' readNotes \
+            'readNotesSidecar( const std::string& path )' readNotesSidecar \
+            'notes: refusing to read the notes sidecar through a symlink' 1
+readMechArm qualitybaseline src/quality.h 'inline bool readBaseline( const std::string& path, Snapshot& out, BaselineReadStats& stats )' readBaseline \
+            'readBaselineSidecar( const std::string& path )' readBaselineSidecar \
+            'quality: refusing to read the baseline sidecar through a symlink' 1
+readMechArm qualitybaseline src/quality.h 'inline std::string readBaselineHeadSha( const std::string& path )' readBaselineHeadSha \
+            'readBaselineSidecar( const std::string& path )' readBaselineSidecar '' 0
+readMechArm qualitybaseline src/quality.h 'inline std::size_t readBaselineAbsorbed( const std::string& path )' readBaselineAbsorbed \
+            'readBaselineSidecar( const std::string& path )' readBaselineSidecar '' 0
+readMechArm archbaseline    src/arch.h    'archReadBaseline( const std::string& sidecarPath )' archReadBaseline \
+            'readArchBaselineSidecar( const std::string& sidecarPath )' readArchBaselineSidecar \
+            'arch: refusing to read the arch baseline sidecar through a symlink' 1
+
+# The arch verb used to open the sidecar a SECOND time, with a bare stream, only to learn whether it existed. It
+# read nothing, so no content arm could ever see it; (t) sees it behaviourally and this sees its shape.
+VRCODE="$TMP/verbs_report_code.txt"
+grep -v '^[[:space:]]*//' "$ROOT/src/verbs_report.h" >"$VRCODE"
+if ! grep -q 'archReadBaseline(' "$VRCODE"; then
+    no "archbaseline: (m4/guard) src/verbs_report.h no longer calls archReadBaseline — (m4) is void"
+elif grep -qE 'ifstream[^;]*sidecarPath' "$VRCODE"; then
+    no "archbaseline: (m4) the arch verb still opens the sidecar with a following stream: $( grep -E 'ifstream[^;]*sidecarPath' "$VRCODE" | head -c 160 )"
+else
+    ok "archbaseline: (m4) the arch verb holds no following open of the sidecar — presence comes from the reader"
 fi
 
 [ "$fail" = 0 ] && echo "ALL PASS" || echo "FAILURES ABOVE"

--- a/test/sidecarsymlinkcheck.sh
+++ b/test/sidecarsymlinkcheck.sh
@@ -29,7 +29,8 @@
 # made the write follow a link after all. The guard was ADVISORY — it described the destination, it did not
 # constrain the open. The remedy is that the check and the create are now ONE syscall:
 #
-#     ::open( path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_NONBLOCK, 0666 )   (src/pathguard.h; O_NONBLOCK since round 4)
+#     ::open( path, O_WRONLY | O_CREAT | O_NOFOLLOW | O_NONBLOCK, 0666 )   (src/pathguard.h; O_NONBLOCK since round 4, and the
+#     O_TRUNC it once carried is now an ftruncate that runs only after the regular-file check)
 #
 # and the three writers hold the resulting descriptor. There is no window because there is no second
 # resolution. The pre-open lstat is GONE from all three writers — which is what makes the (a)/(b) arms
@@ -72,8 +73,9 @@
 #                       emitters report no failed write, and fclose answers only for its own final flush, so a
 #                       failed EARLIER flush could still come back true. The two siblings already had the shape,
 #                       so on them these rows are green before and after — a regression guard there
-#     once:         (f) MECHANISM: src/pathguard.h has exactly TWO ::open — one write open carrying all four of
-#                       O_WRONLY/O_CREAT/O_TRUNC/O_NOFOLLOW (f1), and one read open carrying O_RDONLY|O_NOFOLLOW
+#     once:         (f) MECHANISM: src/pathguard.h has exactly TWO ::open — one write open carrying
+#                       O_WRONLY/O_CREAT/O_NOFOLLOW and no O_TRUNC, truncating with ftruncate only after its
+#                       regular-file check (f1), and one read open carrying O_RDONLY|O_NOFOLLOW
 #                       (f3, round 3); and refuseSymlinkWrite — the advisory check-then-open guard — is gone
 #                       from src/ entirely, not merely unused (f2)
 #
@@ -415,13 +417,20 @@ grep -v '^[[:space:]]*//' "$PG" >"$PGCODE"
 openLines="$( grep -c '::open(' "$PGCODE" | tr -d ' ' )"
 writeOpens="$( grep '::open(' "$PGCODE" | grep -c 'O_WRONLY' | tr -d ' ' )"
 readOpens="$( grep '::open(' "$PGCODE" | grep -c 'O_RDONLY' | tr -d ' ' )"
-if [ "$openLines" = "2" ] && [ "$writeOpens" = "1" ] \
+# The write open does NOT truncate. With O_TRUNC on the open, an existing regular sidecar was emptied before the
+# fstat check had looked at anything; the writer now truncates the descriptor with ftruncate, and only after fstat has
+# confirmed a regular file. (w2) is the behavioural half: a rewrite over a longer planted baseline must still come
+# out byte-identical, which it cannot if the truncation stopped happening.
+WTRUNC="$TMP/pathguard_truncate_fn.txt"
+awk '/inline OpenedFile openNoFollowTruncate\(/ { f = 1 } f { print } f && /^}$/ { exit }' "$PGCODE" >"$WTRUNC"
+if [ "$openLines" = "2" ] && [ "$writeOpens" = "1" ] && [ -s "$WTRUNC" ] \
    && grep '::open(' "$PGCODE" | grep 'O_WRONLY' | grep -q 'O_CREAT' \
-   && grep '::open(' "$PGCODE" | grep 'O_WRONLY' | grep -q 'O_TRUNC' \
-   && grep '::open(' "$PGCODE" | grep 'O_WRONLY' | grep -q 'O_NOFOLLOW'; then
-    ok "pathguard: (f1) exactly two ::open, and the one write open carries O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW"
+   && grep '::open(' "$PGCODE" | grep 'O_WRONLY' | grep -q 'O_NOFOLLOW' \
+   && ! grep '::open(' "$PGCODE" | grep 'O_WRONLY' | grep -q 'O_TRUNC' \
+   && awk '/S_ISREG/ { seen = 1 } seen && /::ftruncate\(/ { found = 1 } END { exit !found }' "$WTRUNC"; then
+    ok "pathguard: (f1) exactly two ::open; the write open carries O_WRONLY|O_CREAT|O_NOFOLLOW and no O_TRUNC, and ::ftruncate runs only after the S_ISREG check"
 else
-    no "pathguard: (f1) expected two ::open, exactly one of them a write open carrying all four flags — found $openLines open(s), $writeOpens write: $( grep '::open(' "$PGCODE" | tr '\n' ' ' | head -c 240 )"
+    no "pathguard: (f1) expected two ::open, one write open with O_WRONLY|O_CREAT|O_NOFOLLOW and no O_TRUNC, and an ::ftruncate after the S_ISREG check — found $openLines open(s), $writeOpens write, $( wc -l <"$WTRUNC" | tr -d ' ' ) line(s) of openNoFollowTruncate: $( grep '::open(' "$PGCODE" | tr '\n' ' ' | head -c 200 )"
 fi
 if [ "$readOpens" = "1" ] \
    && grep '::open(' "$PGCODE" | grep 'O_RDONLY' | grep -q 'O_NOFOLLOW' \

--- a/test/sidecarsymlinkcheck.sh
+++ b/test/sidecarsymlinkcheck.sh
@@ -29,7 +29,7 @@
 # made the write follow a link after all. The guard was ADVISORY — it described the destination, it did not
 # constrain the open. The remedy is that the check and the create are now ONE syscall:
 #
-#     ::open( path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0666 )   (src/pathguard.h)
+#     ::open( path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_NONBLOCK, 0666 )   (src/pathguard.h; O_NONBLOCK since round 4)
 #
 # and the three writers hold the resulting descriptor. There is no window because there is no second
 # resolution. The pre-open lstat is GONE from all three writers — which is what makes the (a)/(b) arms
@@ -136,6 +136,25 @@
 #                       seam, the seam reads through pathguard's O_NOFOLLOW read and carries the site's own
 #                       DEGRADED_PATH_ALERT, and no following open survives in a reader or in the arch verb;
 #                       (f3) pins the read open's flags
+#
+# ROUND 4 — A NON-REGULAR FILE AT THE NAME, AND A READ THAT HOLDS ONE LINE. A FIFO planted AT a sidecar name
+# (no link involved) blocked both opens, read and write, and the round-3 read kept the whole file in memory
+# where the stream it replaced held one line. Both opens now carry
+# O_NONBLOCK and refuse anything fstat does not report as a regular file, and the readers stream from the
+# descriptor:
+#
+#     per sidecar:  (v1) a READ verb finishes with a FIFO at the name — red on the round-3 binary, which blocked
+#                   (v2) a WRITE verb finishes too, exits non-zero, and leaves the FIFO in place — red likewise
+#                   (v3) a WRITE verb with a READER holding that FIFO open — the one case where the open succeeds —
+#                       exits non-zero and puts no byte into the pipe. Red on the round-3 binary, which wrote the
+#                       sidecar into the pipe and exited 0 (or, for --note-add, waited in its read first)
+#     once:         (f4) MECHANISM: both opens carry O_NONBLOCK and an fstat S_ISREG check decides before any
+#                       byte moves — the pin for non-regular files this gate cannot plant (a device node needs root)
+#                   (f5) MECHANISM: the read half holds no whole-file buffer and reads a line at a time through
+#                       POSIX getline — neither a buffered copy of the file nor a call per byte
+#     per reader:   (m5) MECHANISM: the reader parses a line at a time from the sidecar handle
+#     (f5) and (m5) pin memory and cost by SHAPE. Nothing here measures either: RSS and timing are not comparable
+#     between the dev and ASan builds this gate runs on, so a threshold would be a guess.
 #
 # Usage:
 #   bash test/sidecarsymlinkcheck.sh                 |  bash test/sidecarsymlinkcheck.sh asan/ripwire
@@ -410,6 +429,33 @@ if [ "$readOpens" = "1" ] \
     ok "pathguard: (f3) exactly one read ::open, carrying O_RDONLY|O_NOFOLLOW and nothing that creates or truncates"
 else
     no "pathguard: (f3) expected exactly one read ::open carrying O_RDONLY|O_NOFOLLOW — found $readOpens: $( grep '::open(' "$PGCODE" | tr '\n' ' ' | head -c 240 )"
+fi
+
+# Round 4: a descriptor that is not a regular file is refused before a byte moves. O_NONBLOCK is what lets the
+# open RETURN for a FIFO with nobody at the other end; the fstat check is what refuses it, and any other
+# non-regular file, once it has. Either half alone is wrong: without the first the open still waits, without
+# the second the tool reads from, or writes into, a pipe.
+nonblockOpens="$( grep '::open(' "$PGCODE" | grep -c 'O_NONBLOCK' | tr -d ' ' )"
+fstatCalls="$( grep -c '::fstat(' "$PGCODE" | tr -d ' ' )"
+regChecks="$( grep -c 'S_ISREG' "$PGCODE" | tr -d ' ' )"
+if [ "$nonblockOpens" = "2" ] && [ "$fstatCalls" -ge 2 ] && [ "$regChecks" -ge 2 ]; then
+    ok "pathguard: (f4) both opens carry O_NONBLOCK, and an fstat S_ISREG check follows each"
+else
+    no "pathguard: (f4) expected O_NONBLOCK on both opens and an fstat S_ISREG check after each — found O_NONBLOCK on $nonblockOpens open(s), $fstatCalls fstat call(s), $regChecks S_ISREG test(s)"
+fi
+
+# Round 4: the read half hands its caller a LINE at a time. The round-3 read accumulated the whole file into a
+# string (`std::string bytes`, grown by `resize( used + … )`) before any parsing began; the stream it replaced
+# held one line. It now reads through POSIX getline over the descriptor's stream, a buffered read as cheap as the
+# std::ifstream readers. Not rw::readByteSafeLine: a call per byte measured ~15× slower on 64 MB of sidecar
+# lines. Not a custom streambuf under std::getline: libc++ narrows a high byte through its no-get-area fallback,
+# which aborts the sanitizer build (src/infra/stdinline.h). This arm pins the SHAPE; it measures no cost.
+if grep -qE 'std::string[[:space:]]+bytes|resize\( used' "$PGCODE"; then
+    no "pathguard: (f5) the read half still accumulates the whole file: $( grep -nE 'std::string[[:space:]]+bytes|resize\( used' "$PGCODE" | tr '\n' ' ' | head -c 200 )"
+elif ! grep -q '::getline(' "$PGCODE" || grep -q 'readByteSafeLine(' "$PGCODE"; then
+    no "pathguard: (f5) the read half does not read a line at a time through POSIX ::getline — a per-byte reader, or some other shape whose cost is unpinned"
+else
+    ok "pathguard: (f5) the read half holds no whole-file buffer and reads a line at a time through POSIX ::getline"
 fi
 
 if grep -rq 'refuseSymlinkWrite' "$ROOT/src"; then
@@ -1047,6 +1093,12 @@ readMechArm()
     else
         no "$label: (m1) $readerFn does not read through $seamFn, or still opens the sidecar itself: $( grep -E 'std::ifstream|std::fopen|readWholeFile\(' "$rd" | head -c 160 )"
     fi
+    # Round 4: a line at a time from the sidecar handle, never a buffered copy of the whole file.
+    if grep -q 'sidecar\.readLine(' "$rd" && ! grep -q 'sidecar\.bytes' "$rd"; then
+        ok "$label: (m5) $readerFn parses a line at a time from the sidecar handle, not a buffered copy of the file"
+    else
+        no "$label: (m5) $readerFn still parses a buffered copy of the whole sidecar: $( grep -E 'sidecar\.bytes|istringstream f\(' "$rd" | head -c 160 )"
+    fi
 
     [ "$checkSeam" = 1 ] || return
     extractFn "$ROOT/$src" "$seamSig" >"$sm"
@@ -1055,10 +1107,12 @@ readMechArm()
         no "$label: (m2/guard) could not extract the read seam $seamFn from $src ($smLines lines) — (m2)/(m3) are void"
         return
     fi
-    if grep -q 'readWholeFileNoFollow' "$sm"; then
-        ok "$label: (m2) $seamFn reads through pathguard's O_NOFOLLOW read"
+    # Round 4 renamed the read half: it no longer reads the WHOLE file, so the old name would have been a claim
+    # about a shape the code no longer has.
+    if grep -q 'openNoFollowRead' "$sm"; then
+        ok "$label: (m2) $seamFn opens through pathguard's O_NOFOLLOW read"
     else
-        no "$label: (m2) $seamFn does not read through rw::pathguard::readWholeFileNoFollow"
+        no "$label: (m2) $seamFn does not open through rw::pathguard::openNoFollowRead"
     fi
     if grep -qF "$alert" "$sm"; then
         ok "$label: (m3) $seamFn carries the site's own DEGRADED_PATH_ALERT for the refused link"
@@ -1091,6 +1145,122 @@ elif grep -qE 'ifstream[^;]*sidecarPath' "$VRCODE"; then
     no "archbaseline: (m4) the arch verb still opens the sidecar with a following stream: $( grep -E 'ifstream[^;]*sidecarPath' "$VRCODE" | head -c 160 )"
 else
     ok "archbaseline: (m4) the arch verb holds no following open of the sidecar — presence comes from the reader"
+fi
+
+# ── (v) A NON-REGULAR FILE AT THE NAME: no sidecar verb may wait on it ────────────────────────────────────
+# A FIFO planted AT a sidecar name, with no link involved, used to block both opens: a read open waits for a
+# writer, a write open for a reader. Each verb runs under a 20 s deadline. The fixed build finishes in well under a second and the guarded failure is an UNBOUNDED wait, so the
+# deadline never has to decide a close call. A write verb must also exit non-zero and leave the FIFO in place.
+if ! command -v python3 >/dev/null 2>&1; then
+    no "nonregular: python3 is not on PATH — the (v) arms cannot run, and a skipped arm proves nothing"
+else
+    cat >"$TMP/bounded.py" <<'PY'
+import subprocess, sys
+deadline, cwd, argv = float( sys.argv[1] ), sys.argv[2], sys.argv[3:]
+try:
+    r = subprocess.run( argv, cwd=cwd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=deadline )
+    print( 'rc=%d' % r.returncode )
+except subprocess.TimeoutExpired:
+    print( 'hung' )
+PY
+
+    # nonRegularArm LABEL SIDECAR MAKER READ_ARG -- WRITE_ARGS... — run from inside the tree, so the CWD-relative
+    # arch sidecar resolves to the planted FIFO like the root-qualified ones do.
+    nonRegularArm()
+    {
+        local label="$1" sidecar="$2" maker="$3" readArg="$4"
+        shift 4
+        [ "$1" = "--" ] && shift
+        local tree="$TMP/${label}_fifoname/tree" res
+        "$maker" "$tree"
+        mkfifo "$tree/$sidecar"
+        if [ ! -p "$tree/$sidecar" ] || [ -L "$tree/$sidecar" ]; then
+            no "$label: (v/guard) could not plant a FIFO at $sidecar — (v1)/(v2) are void"
+            return
+        fi
+
+        res="$( python3 "$TMP/bounded.py" 20 "$tree" "$BIN" "$tree" "$readArg" --no-cache 2>&1 )"
+        case "$res" in
+            rc=*) ok "$label: (v1) $readArg finished with a FIFO at $sidecar ($res)" ;;
+            *)    no "$label: (v1) $readArg did not finish with a FIFO at $sidecar — the read open waited for a writer ($res)" ;;
+        esac
+
+        res="$( python3 "$TMP/bounded.py" 20 "$tree" "$BIN" "$tree" "$@" --no-cache 2>&1 )"
+        case "$res" in
+            rc=0) no "$label: (v2) $* exited 0 with a FIFO at $sidecar — a write that could not happen reported success" ;;
+            rc=*) if [ -p "$tree/$sidecar" ] && [ ! -L "$tree/$sidecar" ]; then
+                      ok "$label: (v2) $* refused a FIFO at $sidecar without waiting ($res), and left it in place"
+                  else
+                      no "$label: (v2) $* finished ($res) but the FIFO at $sidecar was replaced or removed"
+                  fi ;;
+            *)    no "$label: (v2) $* did not finish with a FIFO at $sidecar — the write open waited for a reader ($res)" ;;
+        esac
+    }
+
+    nonRegularArm notes           .ripwire_notes            mkTree         --notes          -- "--note-add=a.c: fifo at the name"
+    nonRegularArm qualitybaseline .ripwire_quality_baseline mkTree         --quality-delta  -- --quality-baseline
+    nonRegularArm archbaseline    .ripwire_arch_baseline    mkArchViolTree --arch=rules.txt -- --arch=rules.txt --baseline
+
+    # (v3) A READER ALREADY HOLDS THE FIFO OPEN. That is the one case where a write open on a FIFO SUCCEEDS, so only
+    # the regular-file check stands between the verb and writing the sidecar into somebody else's pipe. The probe
+    # opens the FIFO for reading (non-blocking), runs the write verb, and counts every byte that arrives. A verb that
+    # waits instead (a read before its write, say) is killed at the deadline and reported as a failure, never passed.
+    cat >"$TMP/fifowriter.py" <<'PY'
+import os, subprocess, sys, time
+deadline, fifo, cwd, argv = float( sys.argv[1] ), sys.argv[2], sys.argv[3], sys.argv[4:]
+rfd = os.open( fifo, os.O_RDONLY | os.O_NONBLOCK )
+p = subprocess.Popen( argv, cwd=cwd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL )
+got, end = 0, time.time() + deadline
+def drain():
+    n = 0
+    while True:
+        try:
+            chunk = os.read( rfd, 65536 )
+        except BlockingIOError:
+            return n
+        if not chunk:
+            return n
+        n += len( chunk )
+while True:
+    got += drain()
+    if p.poll() is not None:
+        got += drain()
+        break
+    if time.time() > end:
+        p.kill(); p.wait(); os.close( rfd )
+        print( 'hung bytes=%d' % got ); sys.exit( 0 )
+    time.sleep( 0.005 )
+os.close( rfd )
+print( 'rc=%d bytes=%d' % ( p.returncode, got ) )
+PY
+
+    # readerAttachedArm LABEL SIDECAR MAKER WRITE_ARGS...
+    readerAttachedArm()
+    {
+        local label="$1" sidecar="$2" maker="$3" tree res
+        shift 3
+        tree="$TMP/${label}_fiforeader/tree"
+        "$maker" "$tree"
+        mkfifo "$tree/$sidecar"
+        if [ ! -p "$tree/$sidecar" ] || [ -L "$tree/$sidecar" ]; then
+            no "$label: (v3/guard) could not plant a FIFO at $sidecar — (v3) is void"
+            return
+        fi
+        res="$( python3 "$TMP/fifowriter.py" 20 "$tree/$sidecar" "$tree" "$BIN" "$tree" "$@" --no-cache 2>&1 )"
+        case "$res" in
+            'rc=0 '*)       no "$label: (v3) $* exited 0 with a reader on the FIFO at $sidecar — $res" ;;
+            rc=*' bytes=0') if [ -p "$tree/$sidecar" ] && [ ! -L "$tree/$sidecar" ]; then
+                                ok "$label: (v3) $* refused a FIFO a reader held open ($res): no byte reached the pipe"
+                            else
+                                no "$label: (v3) $* finished ($res) but the FIFO at $sidecar was replaced or removed"
+                            fi ;;
+            *)              no "$label: (v3) $* with a reader on the FIFO at $sidecar: $res — it wrote into the pipe, or waited" ;;
+        esac
+    }
+
+    readerAttachedArm notes           .ripwire_notes            mkTree         "--note-add=a.c: fifo with a reader"
+    readerAttachedArm qualitybaseline .ripwire_quality_baseline mkTree         --quality-baseline
+    readerAttachedArm archbaseline    .ripwire_arch_baseline    mkArchViolTree --arch=rules.txt --baseline
 fi
 
 [ "$fail" = 0 ] && echo "ALL PASS" || echo "FAILURES ABOVE"


### PR DESCRIPTION
The readers of `.ripwire_notes`, `.ripwire_quality_baseline` and `.ripwire_arch_baseline` now open them with
`O_NOFOLLOW`, the same refusal the writers got in #178. A link at one of those names is not opened, whether its
target is inside the tree or not. Two further commits, from review, make the readers and the writers refuse anything
at the name that is not a regular file instead of waiting on it, make the readers stream a line at a time, and make
the writer truncate only after it has confirmed a regular file.

## What changed

- `rw::pathguard::openNoFollowRead` (`src/pathguard.h`) opens a sidecar without following a link at its final
  component and returns an owning handle that yields one line at a time through POSIX `getline`. Each sidecar
  has one read seam that calls it and keeps its own `DEGRADED_PATH_ALERT`, the same shape as the write seams.
- Every reader of the three names goes through its seam: `notes::readNotes`, `quality::readBaseline`,
  `readBaselineHeadSha`, `readBaselineAbsorbed` and `archReadBaseline`.
- `archReadBaseline` now reports whether a sidecar was present. The arch verb uses that instead of a second open it
  made only to test for the file.
- A refused read is named on stderr. `--quality-delta`, on the CLI and over MCP, reports it as
  `baseline="git-HEAD (symlinked sidecar refused)"` with its own legend sentence, instead of the marker that means no
  sidecar existed. With no git HEAD to fall back to, the CLI and MCP errors say the sidecar is a refused symlink
  instead of calling it missing. `mcpBaselineMarker` decides this from the refusal itself, before its
  `std::filesystem::exists` check, which follows links.
- Both opens, read and write, carry `O_NONBLOCK` and check with `fstat` that what opened is a regular file. A FIFO at
  a sidecar name used to block the open; now a writer refuses it with nothing written, and a reader treats it as
  present but unreadable.
- The write open no longer carries `O_TRUNC`. The descriptor is truncated with `ftruncate` only after `fstat` has
  confirmed a regular file, so a refusal or a failed `fstat` leaves an existing sidecar untouched.
- The readers no longer buffer the whole file, so memory is bounded by the longest line, as it was with the
  `std::ifstream` readers they replaced. There is no size cap: `--max-file-size` is the crawl's ceiling for source
  files, and applying it to a sidecar could refuse a legitimately large quality baseline.
- CHANGELOG: an Upgrade note with the migration — replace the link with a regular copy of its target.

## Why a link inside the tree is refused too

The reasoning is in `src/pathguard.h`, "ROUND 3". In short: the writers already refuse every link at these names, so
a linked sidecar could be read but never updated; refusing only a link that leaves the root would need a
realpath-then-open check, which brings back the race the writers just closed; and the arch sidecar resolves against
the working directory, not the crawl root. A sidecar is ripwire's own state file, so the rule fits in one sentence:
it is a regular file at its fixed name, whether it is being read or written.

## Verification

- `test/sidecarsymlinkcheck.sh`: 132 arms, ALL PASS on the dev and ASan builds. The round-3 read arms fail against
  main (18b73fa3). The round-4 arms fail against this PR's first commit (5523cdbe): a FIFO at each sidecar name for a
  read verb and a write verb, the same FIFO held open by a reader for each write verb (the case where the open
  succeeds), `O_NONBLOCK` and the regular-file check on both opens, and every reader reading a line at a time.
- ASan/UBSan sweep: 28 runs — a regular file, a symlink, a directory and a FIFO at each name, across seven verbs,
  including a notes file with non-ASCII bytes — plus each write verb against a FIFO a reader holds open: no sanitizer
  output, no hangs, and no byte into the pipe.
- Sidecar read cost (median CPU of three interleaved runs, `--quality-delta` on a tiny tree whose 64 MB
  baseline is read three times): comment-only lines 0.15 s vs 0.14 s on main; realistic records 1.63 s vs
  1.54 s. A per-byte reader measured 2.13 s and 3.52 s on the same files and was not used.
- llvm-project cold parse (182,555 files), main vs this branch: mean CPU 50.5 s on both across two interleaved `--no-cache` runs, with byte-identical output.
- Full suite (`python3 test/pargates.py . ./build/ripwire -j 6`): 620 gates; 618 pass. `versioncheck` failed on a stale build stamp (the binary was
  built before the commit was amended) and passes after a rebuild. `pagingsweepcheck`'s cold `--whereis` determinism
  arm failed once under the parallel run: `--whereis` counts refs in the git ref namespace other sessions on the
  machine write, and `refs_scanned` moved between its two runs. It passes alone on this commit, 335 of 335.
- `--quality-delta`: exit 0, gating 0. Two non-gating rows: `emitQualityDeltaLegend` goes from complexity
  29 to 30 (one more marker branch), and the three per-sidecar read seams are flagged as clones — kept separate so
  each keeps its own `DEGRADED_PATH_ALERT` site, as the write seams do.
- `docs/gatecount_build.py --check` and `docs/limits_build.py --check`: rc 0. No new gate file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
