### PR TITLE
fix(graph): --uses, --mentions, --verify and --affected answered zero from a declaration and never mentioned the definitions they dropped

### DIFF
--- a/src/graphlegend.h
+++ b/src/graphlegend.h
@@ -34,6 +34,7 @@
 //
 // Gate: test/floormarkcheck.sh (all five verbs, CLI ≡ MCP wording, and the retired absolutism absent).
 
+#include <array>
 #include <cstdint>
 #include <utility>
 #include <cstdio>
@@ -521,28 +522,49 @@ inline constexpr const char* kUnprovenDefsPathLegend =
     "unproven_defs=K (absent when 0) counts same-named DEFINITIONS a file:name endpoint found and could not tie to the file it named, summed over from= and to= (a bare NAME endpoint never adds to it): they are NOT in from_defs= or to_defs=, the search neither started nor ended at them, and so reachable= and hops= say nothing about a path through them. ";
 inline constexpr const char* kUnprovenDefsSafeDeleteLegend =
     "unproven_defs=K (absent when 0) counts same-named DEFINITIONS this file:name selector found and could not tie to the file it named: they are NOT in defs=, and callers=, impact_reaches=, uses=, the tested partition and dead_code_candidate= were all read without them. So risk= describes defs= alone, and risk=none-found beside unproven_defs= is an INCOMPLETE read, never a sign that the name can go. ";
+// AND ON uses, mentions, verify AND affected (decltodefcheck arms E2i..E2m). The same resolver serves four more readers,
+// and on the same repro each met the drop as a zero with nothing beside it: uses count="0" (a call site is kept only where
+// it resolves to a def in defs=), mentions docs="0" (graph.h stores a doc edge on a body, never on a declaration, so the
+// declaration that stays carries none), verify count="0" or verdict="not-established" with limit= naming the model's
+// floor instead, and affected tests="0" reached="0". Same attribute, same tail, one clause each for what is missing.
+// verify's legend is a closed literal (verify.h kVerifyLegend), so runVerify wraps its clause as its own comment.
+inline constexpr const char* kUnprovenDefsUsesLegend =
+    "unproven_defs=K (absent when 0) counts same-named DEFINITIONS this file:name selector found and could not tie to the file it named: they are NOT in defs=, so a role=\"call\" site whose call resolves to one of them is in neither count= nor the rows (call_sites_of_name= still counts it). ";
+inline constexpr const char* kUnprovenDefsMentionsLegend =
+    "unproven_defs=K (absent when 0) counts same-named DEFINITIONS this file:name selector found and could not tie to the file it named: they are NOT in defs=, and a doc edge is stored on a definition's body, never on a declaration, so a doc whose edge lands only on them is in neither docs=, sections= nor the rows. ";
+inline constexpr const char* kUnprovenDefsVerifyLegend =
+    "unproven_defs=K (absent when 0) counts same-named DEFINITIONS a file:name symbol argument found and could not tie to the file it named, summed over both symbols of calls(): they are NOT in defs=, from_defs=, to_defs= or target_defs=, so no call path, witness or role=\"call\" site that reaches only them was read. verdict=confirmed or refuted still stands on the evidence it prints; verdict=not-established beside unproven_defs= is an INCOMPLETE read that limit= does not name, never a sign the claim is false. ";
+inline constexpr const char* kUnprovenDefsAffectedLegend =
+    "unproven_defs=K (absent when 0) counts same-named DEFINITIONS a file:name item found and could not tie to the file it named, summed item by item (a path item adds 0): they are NOT in seeds=, the caller walk never started from them, and so a test that reaches only them is in neither tests=, reached= nor the rows. A bare NAME item that also matches an indexed path is read as that path. ";
 inline constexpr const char* kUnprovenDefsProofTail =
     "A declaration widens to the definitions it stands for only where the definition is IN the named file, or its own file includes the named file, resolved path-precisely; a same-named body anywhere else is not evidence and is never served. Widen the file:name spelling to the bare NAME, or to Scope::name, to include them. ";
 
+// Append-only: unprovenDefsVerbLegend below indexes its clause rows by this order.
 enum class UnprovenDefsVerb : std::uint8_t
 {
     Impact,
     Path,
     SafeDelete,
+    Uses,
+    Mentions,
+    Verify,
+    Affected,
 };
 
 // `on` is the emitter's own `unprovenDefs > 0`, never a re-derivation; "" otherwise, so an answer that dropped
 // nothing stays byte-identical on every one of these verbs.
+//
+// ONE ROW PER UnprovenDefsVerb, in enum order. The rows are spelled INSIDE the arm that selects them rather than in a
+// named table: test/compactlegendcheck.sh (S) counts a clause as conditionally emitted when a ?: arm names it, and a
+// table declared elsewhere would take every row out of its population. A ternary chain names them too, at a nesting
+// that grows by one with every verb.
 inline std::string unprovenDefsVerbLegend( UnprovenDefsVerb verb, bool on )
 {
-    if( !on )
-    {
-        return {};
-    }
-    const char* const clause = verb == UnprovenDefsVerb::Impact ? kUnprovenDefsImpactLegend
-                               : verb == UnprovenDefsVerb::Path ? kUnprovenDefsPathLegend
-                                                                : kUnprovenDefsSafeDeleteLegend;
-    return std::string( clause ) + kUnprovenDefsProofTail;
+    const char* const clause = on ? std::array { kUnprovenDefsImpactLegend, kUnprovenDefsPathLegend, kUnprovenDefsSafeDeleteLegend,
+                                                 kUnprovenDefsUsesLegend, kUnprovenDefsMentionsLegend, kUnprovenDefsVerifyLegend,
+                                                 kUnprovenDefsAffectedLegend }[std::size_t( verb )]
+                                  : nullptr;
+    return clause != nullptr ? std::string( clause ) + kUnprovenDefsProofTail : std::string();
 }
 
 // M12's writeMultiRootTable/multiRootTableLegend (the multi-root roots-table disclosure --callers/--uses

--- a/src/testmap.h
+++ b/src/testmap.h
@@ -62,6 +62,7 @@ struct AffectedSeeds
     std::vector<NodeId>        seeds;                  // deduped seed symbols, id asc (both readings)
     std::vector<NodeId>        walkSeeds;              // seeds OUTSIDE test paths — the caller walk's roots
     std::vector<std::uint32_t> seedTestFiles;          // matched TEST files, file id asc, deduped
+    std::size_t                unprovenDefs  = 0;      // H1: the decl→def residue, summed over the SYMBOL items (a path item adds 0)
     bool                       sawFileItem   = false;  // at least one item read as a path pattern
     bool                       sawSymbolItem = false;  // at least one item read as a symbol
     bool                       ok            = true;   // false ⇒ badItem resolved under NEITHER reading
@@ -143,9 +144,14 @@ inline AffectedSeeds resolveAffectedSeeds( const IngestResult& ing, std::string_
             continue;
         }
 
-        const std::vector<NodeId> defs = resolveAllByNameQualified( ing, item );
+        // H1: the out-param is this item's decl→def residue — definitions a file:NAME item found and could not tie to
+        // the file it named, so they are no seed and the caller walk never starts from them. Summed item by item onto
+        // the answer, --path's rule for its two endpoints: a path item never reaches this line, a bare NAME never widens.
+        std::size_t               itemUnprovenDefs = 0;
+        const std::vector<NodeId> defs             = resolveAllByNameQualified( ing, item, &itemUnprovenDefs );
         if( defs.empty() ) { sel.ok = false;  sel.badItem.assign( item );  return sel; }
         sel.sawSymbolItem = true;
+        sel.unprovenDefs += itemUnprovenDefs;
         sel.seeds.insert( sel.seeds.end(), defs.begin(), defs.end() );
     }
     std::sort( sel.seeds.begin(), sel.seeds.end() );

--- a/src/verbs_change.h
+++ b/src/verbs_change.h
@@ -134,11 +134,17 @@ std::optional<int> runAffected( const MainDispatch& d )
                      "script-to-binary edges are NOT modelled, so those gates are invisible to this walk and never counted in tests=/reached=. "
                      "{}"     // H2H-Graft F1: the evidence-order clause, testmap.h's ONE wording (changed= is spelled seed_kind="test" here: the argument matched it)
                      "order=evidence says so on the root; partners= counts the partner rows. "
-                     "{}-->{}", rw::kTestRowEvidenceLegend,
+                     "{}{}-->{}", rw::kTestRowEvidenceLegend,
+                     // H1: the decl→def residue resolveAffectedSeeds summed over the symbol items. A file:name item whose
+                     // definitions were dropped seeded the walk with declarations alone, which reached the reader as a bare
+                     // tests="0" — on the verb whose answer is the list of tests to run. Exactly when the root carries it.
+                     rw::unprovenDefsVerbLegend( rw::UnprovenDefsVerb::Affected, sel.unprovenDefs > 0 ).c_str(),
                      rw::graphCountFloorBrief( g.unindexedFiles > 0 ).c_str(), rw::rootRelPathsLegend( afSingleRoot ) );
-        rw::emitTo( stdout, "<affected changed=\"{}\" seeded_by=\"{}\" seeds=\"{}\" seed_test_files=\"{}\" tests=\"{}\" reached=\"{}\" script_gates_unmodelled=\"{}\""
+        rw::emitTo( stdout, "<affected changed=\"{}\" seeded_by=\"{}\" seeds=\"{}\" seed_test_files=\"{}\" tests=\"{}\" reached=\"{}\"{} script_gates_unmodelled=\"{}\""
                      " order=\"evidence\" partners=\"{}\"{}{}>",
-                     ex( cfg.affectedFiles ).c_str(), rw::affectedSeededBy( sel ), seeds.size(), sel.seedTestFiles.size(), testFiles.size(), reach.size(), scriptGatesUnmodelledCount( ing ),
+                     ex( cfg.affectedFiles ).c_str(), rw::affectedSeededBy( sel ), seeds.size(), sel.seedTestFiles.size(), testFiles.size(), reach.size(),
+                     rw::unprovenDefsAttrXml( sel.unprovenDefs ).c_str(),   // H1: beside the zero it qualifies; absent at zero
+                     scriptGatesUnmodelledCount( ing ),
                      rw::testRowPartnerCount( answer.rows ),      // F1: how many rows stand on the name convention alone or as well
                      afRootAttr.c_str(),                          // M12: root= says what every <test p=> below is relative to
                      rw::graphCountFloorAttrXml( g ).c_str()  );   // H5/M15: gauge + marker; tests=/reached= are a transitive-caller walk over the name-based CSR

--- a/src/verbs_navigate.h
+++ b/src/verbs_navigate.h
@@ -526,9 +526,12 @@ std::optional<int> runUses( const MainDispatch& d )
         const std::string_view sym = cfg.usesSym;
 
         // resolveAllByNameQualified — the SAME resolver --callers/--impact/--expand/--path use — so --uses
-        // finally accepts "file:name" too; byte-identical to the old resolveAllByName on a bare name/id.
-        const std::vector<NodeId> defs = resolveAllByNameQualified( ing, sym );
-        const UsesSelector        sel  = resolveUsesSelector( ing, sym, defs.size() );
+        // finally accepts "file:name" too; byte-identical to the old resolveAllByName on a bare name/id. H1: the
+        // out-param is the decl→def widening's residue — definitions defs= does not hold, so the call-role narrowing
+        // below drops every site that resolves to them, which reached the reader as a bare count="0".
+        std::size_t               usUnprovenDefs = 0;
+        const std::vector<NodeId> defs           = resolveAllByNameQualified( ing, sym, &usUnprovenDefs );
+        const UsesSelector        sel            = resolveUsesSelector( ing, sym, defs.size() );
 
         // member-variable round (card A3): ONE resolved field takes the per-site path (fielduses.h — the renderer
         // the MCP twin returns); a bare field name declared by several owners refuses with the Owner.field
@@ -599,7 +602,8 @@ std::optional<int> runUses( const MainDispatch& d )
                      "chosen def (the callers verb's own narrowing, read the other way, so the two agree); read/write/import/extends carry no "
                      "resolution and stay name-matched across every def sharing the name. narrowed_roles= names what narrowed, and "
                      "defs_of_name=/call_sites_of_name= (file: qualifier only) are the un-narrowed totals. "
-                     "{}{}-->{}{}", rw::kUsesLegendOpen,
+                     "{}{}{}-->{}{}", rw::kUsesLegendOpen,
+                     rw::unprovenDefsVerbLegend( rw::UnprovenDefsVerb::Uses, usUnprovenDefs > 0 ).c_str(),   // H1: exactly when the root carries unproven_defs=
                      rw::capLegendClause( rw::computePageDisclosure( pageRows, sites.size(), upw.end,
                                                                     cfg.pageLimit, cfg.pageOffset, usDiscloseCap ).active ),
                      rw::graphCountDisclosure( g.unindexedFiles > 0 ).c_str(), rw::rootRelPathsLegend( usSingleRoot ),
@@ -622,13 +626,16 @@ std::optional<int> runUses( const MainDispatch& d )
             // a markdown SECTION heading reaches routinely. Same shape as runImpact / the callers arm.
             const std::string attr = "of=\"" + ex( sym ) + "\" defs=\"" + std::to_string( defs.size() )
                                    + "\" external=\"" + ( external ? "1" : "0" ) + "\" count=\"" + std::to_string( sites.size() ) + "\""
+                                   + rw::unprovenDefsAttrXml( usUnprovenDefs )   // H1: where the XML root carries it
                                    + selectorAttrs + usRootAttr + upage + rw::graphCountFloorAttrXml( g );   // §H4 §3.4
             emitColumnarUseSites( stdout, ing, attr, ufiles, ulines, uroles, uins, usRootPrefix );
             return 0;
         }
 
-        rw::emitTo( stdout, "<uses of=\"{}\" defs=\"{}\" external=\"{}\" count=\"{}\"{}{}{}{}>",
-                     ex( sym ).c_str(), defs.size(), external ? 1 : 0, sites.size(), selectorAttrs.c_str(), usRootAttr.c_str(), upage,
+        rw::emitTo( stdout, "<uses of=\"{}\" defs=\"{}\" external=\"{}\" count=\"{}\"{}{}{}{}{}>",
+                     ex( sym ).c_str(), defs.size(), external ? 1 : 0, sites.size(),
+                     rw::unprovenDefsAttrXml( usUnprovenDefs ).c_str(),   // H1: beside the count it qualifies; absent at zero
+                     selectorAttrs.c_str(), usRootAttr.c_str(), upage,
                      rw::graphCountFloorAttrXml( g ).c_str() );
         rw::writeMultiRootTable( stdout, ing );   // M12: the roots list this element's own root= cannot carry
         for( std::size_t siteIndex = upw.begin; siteIndex < upw.end; ++siteIndex )
@@ -1413,6 +1420,12 @@ std::optional<int> runVerify( const MainDispatch& d )
         return 1;
     };
 
+    // H1: the decl→def residue of the SYM arguments this claim resolves. The three shapes that resolve one set it before
+    // they open the root — calls() sums both symbols as --path sums its endpoints, uses()/unused() and reaches() take
+    // their one — and contains()/defines() resolve no SYM and leave it 0. openRoot reads it for the clause comment, so
+    // the comment rides exactly when a shape's facts carry unproven_defs=.
+    std::size_t vfUnprovenDefs = 0;
+
     // the root opener, shared by every shape so the attribute ORDER is fixed: claim, shape, verdict,
     // shape-specific facts, root= (M12), limit=, then the honesty attribute (complete= XOR counts_floor=),
     // then the disclosure pair. `honesty` is exactly one of kGraphCountFloorAttrXml / " complete=\"1\"" / "".
@@ -1422,8 +1435,13 @@ std::optional<int> runVerify( const MainDispatch& d )
         // #66: vfFloor above can carry graph_unindexed=, and kVerifyLegend is one closed literal that cannot
         // splice a conditional clause — so the clause rides as its own adjacent comment, emitted exactly when
         // the attribute is (graphlegend.h graphUnindexedLegendComment), ahead of the root= block.
-        rw::emitTo( stdout, "{}{}{}<verify claim=\"{}\" shape=\"{}\" verdict=\"{}\"{}{}", verify::kVerifyLegend,
+        // H1: the unproven_defs= clause takes the same route for the same reason, opened `<!-- ripwire verify: ` so the
+        // compact dialect strips it as the prose it is (compactlegend.h kCompactProsePrefixes) and states its own row.
+        const std::string vfUnprovenClause  = rw::unprovenDefsVerbLegend( rw::UnprovenDefsVerb::Verify, vfUnprovenDefs > 0 );
+        const std::string vfUnprovenComment = vfUnprovenClause.empty() ? std::string() : "<!-- ripwire verify: " + vfUnprovenClause + "-->";
+        rw::emitTo( stdout, "{}{}{}{}<verify claim=\"{}\" shape=\"{}\" verdict=\"{}\"{}{}", verify::kVerifyLegend,
                      rw::graphUnindexedLegendComment( g.unindexedFiles > 0 ).c_str(),
+                     vfUnprovenComment.c_str(),
                      rw::rootRelPathsLegend( verSingleRoot ),
                      ex( cfg.verifyClaim ).c_str(), verify::kShapeTags[ std::size_t( claim.shape ) ], verdict, facts.c_str(),
                      verRootAttr.c_str() );
@@ -1441,8 +1459,12 @@ std::optional<int> runVerify( const MainDispatch& d )
     // ── calls( A , B ) — does A transitively call B (directed, name-based call graph) ────────────────
     if( claim.shape == verify::ClaimShape::Calls )
     {
-        const std::vector<NodeId> srcDefs = resolveAllByNameQualified( ing, claim.arg1 );
-        const std::vector<NodeId> dstDefs = resolveAllByNameQualified( ing, claim.arg2 );
+        // H1: each symbol's decl→def residue, summed onto the root exactly as --path sums its two endpoints.
+        std::size_t               srcUnprovenDefs = 0;
+        std::size_t               dstUnprovenDefs = 0;
+        const std::vector<NodeId> srcDefs         = resolveAllByNameQualified( ing, claim.arg1, &srcUnprovenDefs );
+        const std::vector<NodeId> dstDefs         = resolveAllByNameQualified( ing, claim.arg2, &dstUnprovenDefs );
+        vfUnprovenDefs                            = srcUnprovenDefs + dstUnprovenDefs;
         if( srcDefs.empty() || dstDefs.empty() )
         {
             const std::string_view missing = srcDefs.empty() ? claim.arg1 : claim.arg2;
@@ -1451,6 +1473,7 @@ std::optional<int> runVerify( const MainDispatch& d )
         }
         const std::vector<NodeId> path = rw::shortestPathAny( g, srcDefs, dstDefs );
         const std::string         facts = " from_defs=\"" + std::to_string( srcDefs.size() ) + "\" to_defs=\"" + std::to_string( dstDefs.size() ) + "\""
+                                        + rw::unprovenDefsAttrXml( vfUnprovenDefs )   // H1: beside the defs counts it is not in; absent at zero
                                         + ( path.empty() ? std::string{} : " hops=\"" + std::to_string( path.size() - 1 ) + "\"" );
         if( !path.empty() )
         {
@@ -1472,7 +1495,7 @@ std::optional<int> runVerify( const MainDispatch& d )
     if( claim.shape == verify::ClaimShape::Uses || claim.shape == verify::ClaimShape::Unused )
     {
         const std::string_view    sym  = claim.arg1;
-        const std::vector<NodeId> defs = resolveAllByNameQualified( ing, sym );
+        const std::vector<NodeId> defs = resolveAllByNameQualified( ing, sym, &vfUnprovenDefs );   // H1: the residue --uses discloses
         const UsesSelector        sel  = resolveUsesSelector( ing, sym, defs.size() );
         const std::vector<char>   isChosenCaller = sel.fileQualified ? usesChosenCallers( ing, g, defs ) : std::vector<char>{};
         const auto [ sites, callSitesOfName ]    = collectUseSites( ing, sel, isChosenCaller,
@@ -1488,7 +1511,8 @@ std::optional<int> runVerify( const MainDispatch& d )
         const std::size_t total    = sites.size();
         const PageWindow  w        = pageWindow( total, kEvidenceCap, 0 );
         const std::string facts    = " defs=\"" + std::to_string( defs.size() ) + "\" external=\"" + ( external ? "1" : "0" )
-                                   + "\" count=\"" + std::to_string( total ) + "\"";
+                                   + "\" count=\"" + std::to_string( total ) + "\""
+                                   + rw::unprovenDefsAttrXml( vfUnprovenDefs );   // H1: beside the count it qualifies; absent at zero
         const bool        anySites = total > 0;
         const char*       verdict  = claim.shape == verify::ClaimShape::Uses ? ( anySites ? "confirmed" : "not-established" )
                                                                         : ( anySites ? "refuted"   : "not-established" );
@@ -1631,7 +1655,7 @@ std::optional<int> runVerify( const MainDispatch& d )
 
     // ── reaches( SYM , "FILE" | LAYER ) — does code there transitively CALL the target (impact-based) ─
     VERIFY( claim.shape == verify::ClaimShape::Reaches );
-    const std::vector<NodeId> targetDefs = resolveAllByNameQualified( ing, claim.arg1 );
+    const std::vector<NodeId> targetDefs = resolveAllByNameQualified( ing, claim.arg1, &vfUnprovenDefs );   // H1: the residue, as --impact's
     if( targetDefs.empty() )
     {
         rw::emitTo( stderr, "{}\n", selectorNotFoundMessage( ing, "ripwire: --verify symbol not found: ", claim.arg1, "--verify=" ).c_str() );
@@ -1659,7 +1683,9 @@ std::optional<int> runVerify( const MainDispatch& d )
             witnesses.push_back( n );
         }
     }
-    const std::string facts = " target_defs=\"" + std::to_string( targetDefs.size() ) + "\" witnesses=\"" + std::to_string( witnesses.size() ) + "\"";
+    const std::string facts = " target_defs=\"" + std::to_string( targetDefs.size() ) + "\""
+                            + rw::unprovenDefsAttrXml( vfUnprovenDefs )   // H1: beside the defs count it is not in; absent at zero
+                            + " witnesses=\"" + std::to_string( witnesses.size() ) + "\"";
     if( !witnesses.empty() )
     {
         const std::vector<NodeId> path = rw::shortestPathAny( g, witnesses, targetDefs );
@@ -2263,7 +2289,11 @@ std::optional<int> runMentions( const MainDispatch& d )
         // §B11.1 — the --owners twin, same defect, same fix: the shared file:name grammar and the shared
         // refusal that names which half is at fault. A qualified spelling now NARROWS the mention scan to the
         // definitions in that file instead of being refused as an unknown symbol.
-        const std::vector<NodeId> defs = resolveAllByNameQualified( ing, cfg.mentionsSym );
+        // H1: the out-param is the decl→def widening's residue. graph.h stores a doc edge on a BODY, never on a
+        // declaration, so a file:name selector whose definitions were dropped kept only edge-less declarations and
+        // answered a bare docs="0" about the docs that name the definitions it never read.
+        std::size_t               mnUnprovenDefs = 0;
+        const std::vector<NodeId> defs           = resolveAllByNameQualified( ing, cfg.mentionsSym, &mnUnprovenDefs );
         if( defs.empty() )
         {
             rw::emitTo( stderr, "{}\n", selectorNotFoundMessage( ing, "ripwire: --mentions symbol not found: ",
@@ -2289,9 +2319,11 @@ std::optional<int> runMentions( const MainDispatch& d )
         const auto        ex = [ & ]( std::string_view s ) -> std::string { return std::string( escapeXml( s, esc ) ); };
         rw::emitTo( stdout, "<!-- ripwire mentions: markdown FILES that name this symbol in a `backtick` (doc<->code; NOT a call edge). "
                      "docs= is the row count (distinct files); sections= counts the underlying markdown-section mentions "
-                     "before file-collapse (docs <= sections). Each row's mentions= is its own section-mention count. "
+                     "before file-collapse (docs <= sections). Each row's mentions= is its own section-mention count. {}"
                      "An @FILE:LINE seed rebinds to the innermost definition enclosing that line — sym= names it, of= echoes the seed as typed. "
-                     "No line locator: the doc edge is stored at file granularity — a fabricated always-1 l= was removed; absent beats fake -->{}", rw::rootRelPathsLegend( mnSingleRoot ) );
+                     "No line locator: the doc edge is stored at file granularity — a fabricated always-1 l= was removed; absent beats fake -->{}",
+                     rw::unprovenDefsVerbLegend( rw::UnprovenDefsVerb::Mentions, mnUnprovenDefs > 0 ).c_str(),   // H1: exactly when the root carries unproven_defs=
+                     rw::rootRelPathsLegend( mnSingleRoot ) );
         // §P15/§P16: fileRows is deterministic (file path order) and printed unconditionally, no historic
         // display cap — pageWindow directly on cfg.pageLimit/cfg.pageOffset, discloseCap=false so the
         // un-paginated tag stays byte-identical.
@@ -2303,8 +2335,9 @@ std::optional<int> runMentions( const MainDispatch& d )
         const std::string mnSymAttr  = ( !cfg.mentionsSym.empty() && cfg.mentionsSym.front() == '@' )
                                      ? " sym=\"" + ex( ing.symbols[ defs[0] ].name ) + "\""
                                      : std::string();
-        rw::emitTo( stdout, "<mentions of=\"{}\"{} defs=\"{}\" docs=\"{}\" sections=\"{}\"{}{}>", ex( cfg.mentionsSym ).c_str(), mnSymAttr.c_str(), defs.size(),
+        rw::emitTo( stdout, "<mentions of=\"{}\"{} defs=\"{}\" docs=\"{}\" sections=\"{}\"{}{}{}>", ex( cfg.mentionsSym ).c_str(), mnSymAttr.c_str(), defs.size(),
                      fileRows.size(), sectionCount,
+                     rw::unprovenDefsAttrXml( mnUnprovenDefs ).c_str(),   // H1: beside the zero counts it qualifies; absent at zero
                      pageDisclosure( mentionsAb, sizeof( mentionsAb ), mentionsPw.end - mentionsPw.begin, fileRows.size(), mentionsPw.end,
                                      cfg.pageLimit, cfg.pageOffset, false ),
                      mnRootAttr.c_str() );

--- a/test/decltodefcheck.sh
+++ b/test/decltodefcheck.sh
@@ -52,6 +52,14 @@
 #       unproven_defs= with a clause worded for that verb (--path sums both endpoints, E2g), --safe-delete's clause
 #       addresses risk= itself so none-found does not stand as a safety reading (E2f), the existing compact row
 #       fires on all of them (E2h), and a fully-proven file:name or a bare name carries neither (E2e absent rows).
+#   (E2i..E2m) THE SAME RESIDUE ON --uses, --mentions, --verify AND --affected. Each resolves its SYM through the same
+#       resolver and met the same drop as count="0" (--uses, and --verify's uses()/unused()), docs="0" (a doc edge is
+#       stored on a body, never on a declaration), verdict="not-established" (--verify's calls()/reaches()) and tests="0"
+#       reached="0" (--affected). Each now carries unproven_defs= with a clause worded for that verb (E2i); --verify's
+#       rides as its own comment beside a closed legend and addresses verdict= itself (E2k); verify's calls() sums both
+#       symbols and --affected sums its symbol items (E2l); the existing compact row fires and the full clause is
+#       stripped (E2m). The MCP uses/mentions twins resolve through resolveAllByName and refuse a file:name spelling as
+#       CLI-only, so there is no zero there to disclose — asserted, not assumed (E2j). There is no MCP verify/affected.
 #   (F) MUTATION — every assertion SHAPE above is shown able to fail, against hand-built inputs.
 #
 # WHAT (E) AND (E2) EACH COVER, since between them they close what was once a stated gap. (E) reads the
@@ -164,9 +172,17 @@ import re,sys
 m=re.search(r"unproven_defs=K\b.*?(?=counts_floor=|-->)",sys.argv[1],re.S)
 sys.stdout.write(m.group(0) if m else "")' "$1"; }
 
+# 1 when a legend holds the FULL unproven_defs= clause (its `(absent when 0)` opening), else 0 — what (E2m) asserts the
+# compact dialect strips, and what (F) shows able to fail.
+fullClauseIn(){ case "$1" in *'unproven_defs=K (absent when 0)'*) printf 1 ;; *) printf 0 ;; esac; }
+
+# 1 when an MCP transcript's last response is the refusal of a qualified spelling as CLI-only, else 0 — an answer, or an
+# error about something else, is not that refusal (E2j, and its (F) row).
+refusesAsCliOnly(){ case "$( mcpPayload "$1" )" in '__ERROR__:'*'CLI-only'*) printf 1 ;; *) printf 0 ;; esac; }
+
 # ── corpora, built here rather than committed: each is a minimal repro and a committed .h/.cpp fixture
 #    would also join every OTHER gate's view of test/. ────────────────────────────────────────────────
-mkdir -p "$TMP/ns/a" "$TMP/ns/b" "$TMP/free" "$TMP/hdr" "$TMP/split/include" "$TMP/split/src" "$TMP/same" "$TMP/two"
+mkdir -p "$TMP/ns/a" "$TMP/ns/b" "$TMP/free" "$TMP/hdr" "$TMP/split/include" "$TMP/split/src" "$TMP/same" "$TMP/two" "$TMP/combo/test"
 
 # (A) two namespaces, one class name, one shared basename.
 cat > "$TMP/ns/a/Store.h" <<'EOF'
@@ -334,6 +350,33 @@ int beta(int b)
 int useBeta(int b)
 {
     return beta(b);
+}
+EOF
+
+# (E2i) DOCS AND TESTS over (B) and (C1) side by side: a markdown file naming both in backticks (--mentions) and one test
+#       per shape reaching it through its caller (--affected), so the dropping selector and its proven and bare-name
+#       controls answer over ONE tree. The names are disjoint, so neither half's include proof touches the other, and
+#       neither test file is named after a source file, so a control's test row is the caller WALK's, never the partner
+#       convention's.
+cp "$TMP/free/"* "$TMP/hdr/"* "$TMP/combo/"
+cat > "$TMP/combo/NOTES.md" <<'EOF'
+# Notes
+
+The `helper` function doubles its argument, and `putObject` stores a key.
+EOF
+cat > "$TMP/combo/test/test_uses_helper.cpp" <<'EOF'
+int unrelatedCaller(int a);
+int testUsesHelper()
+{
+    return unrelatedCaller(3);
+}
+EOF
+cat > "$TMP/combo/test/test_drive_store.cpp" <<'EOF'
+class Store;
+int driveTheStore(Store& s);
+int testDriveStore(Store& s)
+{
+    return driveTheStore(s);
 }
 EOF
 
@@ -752,6 +795,145 @@ for pair in "e2_sd_cmp.xml:safe-delete" "e2_imp_cmp.xml:impact" "e2_pth_cmp.xml:
     fi
 done
 
+# ── (E2i..E2m) THE SAME RESIDUE ON --uses, --mentions, --verify AND --affected ─────────────────────────────────────────
+# Four more verbs resolve SYM through the same resolver, and on the same repros answered the drop as silence:
+# --uses=api.h:helper read count="0" (a call site is kept only where it resolves to a def in defs=, and the one def
+# kept is the bodyless declaration), --mentions read docs="0" (graph.h stores a doc edge on a body, never on a
+# declaration), --verify's uses()/unused() read count="0" and calls()/reaches() verdict="not-established" with limit=
+# naming the model floor rather than the drop, and --affected read tests="0" reached="0" — the zero on the verb whose
+# answer is the list of tests to run. Same four questions per verb as (E2e): PREMISE, PRESENT, DEFINED, ABSENT.
+# Dialects: --uses has XML and --format=columnar (its --json refuses); the other three have XML alone.
+
+echo
+echo "=== (E2i) --uses, --mentions, --verify and --affected carry the residue beside their zero ==="
+run  "$TMP/free"  --uses=api.h:helper                                >"$TMP/e2_us.xml"
+run2 "$TMP/free"  --uses=api.h:helper --format=columnar              >"$TMP/e2_us_col.xml"
+run  "$TMP/combo" --mentions=api.h:helper                            >"$TMP/e2_mn.xml"
+run  "$TMP/free"  '--verify=uses(api.h:helper)'                      >"$TMP/e2_vf_uses.xml"
+run  "$TMP/free"  '--verify=unused(api.h:helper)'                    >"$TMP/e2_vf_unused.xml"
+run  "$TMP/free"  '--verify=calls(unrelatedCaller,api.h:helper)'     >"$TMP/e2_vf_calls.xml"
+run  "$TMP/free"  '--verify=reaches(api.h:helper,"other.cpp")'       >"$TMP/e2_vf_reaches.xml"
+run  "$TMP/combo" --affected=api.h:helper                            >"$TMP/e2_af.xml"
+run  "$TMP/hdr"   --uses=Store.h:putObject                           >"$TMP/e2_us_clean.xml"
+run  "$TMP/free"  --uses=helper                                      >"$TMP/e2_us_bare.xml"
+run  "$TMP/combo" --mentions=Store.h:putObject                       >"$TMP/e2_mn_clean.xml"
+run  "$TMP/combo" --mentions=helper                                  >"$TMP/e2_mn_bare.xml"
+run  "$TMP/hdr"   '--verify=uses(Store.h:putObject)'                 >"$TMP/e2_vf_uses_clean.xml"
+run  "$TMP/free"  '--verify=uses(helper)'                            >"$TMP/e2_vf_uses_bare.xml"
+run  "$TMP/hdr"   '--verify=calls(driveTheStore,Store.h:putObject)'  >"$TMP/e2_vf_calls_clean.xml"
+run  "$TMP/free"  '--verify=calls(unrelatedCaller,helper)'           >"$TMP/e2_vf_calls_bare.xml"
+run  "$TMP/hdr"   '--verify=reaches(Store.h:putObject,"Caller.cpp")' >"$TMP/e2_vf_reaches_clean.xml"
+run  "$TMP/free"  '--verify=reaches(helper,"other.cpp")'             >"$TMP/e2_vf_reaches_bare.xml"
+run  "$TMP/combo" --affected=Store.h:putObject                       >"$TMP/e2_af_clean.xml"
+run  "$TMP/combo" --affected=helper                                  >"$TMP/e2_af_bare.xml"
+
+e2Present "(E2i) --uses=api.h:helper"                          "$TMP/e2_us.xml"         uses     2 count     0
+e2Present "(E2i) --uses=api.h:helper --format=columnar"        "$TMP/e2_us_col.xml"     uses     2 count     0
+e2Present "(E2i) --mentions=api.h:helper"                      "$TMP/e2_mn.xml"         mentions 2 docs      0
+e2Present "(E2i) --verify=uses(api.h:helper)"                  "$TMP/e2_vf_uses.xml"    verify   2 count     0
+e2Present "(E2i) --verify=unused(api.h:helper)"                "$TMP/e2_vf_unused.xml"  verify   2 count     0
+e2Present "(E2i) --verify=calls(unrelatedCaller,api.h:helper)" "$TMP/e2_vf_calls.xml"   verify   2 verdict   not-established
+e2Present "(E2i) --verify=reaches(api.h:helper,\"other.cpp\")" "$TMP/e2_vf_reaches.xml" verify   2 witnesses 0
+e2Present "(E2i) --affected=api.h:helper"                      "$TMP/e2_af.xml"         affected 2 tests     0
+
+e2Absent "(E2i) --uses=Store.h:putObject, every candidate proven"           "$TMP/e2_us_clean.xml"         uses     count     1
+e2Absent "(E2i) --uses=helper, bare name"                                   "$TMP/e2_us_bare.xml"          uses     count     2
+e2Absent "(E2i) --mentions=Store.h:putObject, every candidate proven"       "$TMP/e2_mn_clean.xml"         mentions docs      1
+e2Absent "(E2i) --mentions=helper, bare name"                               "$TMP/e2_mn_bare.xml"          mentions docs      1
+e2Absent "(E2i) --verify=uses(Store.h:putObject), every candidate proven"   "$TMP/e2_vf_uses_clean.xml"    verify   count     1
+e2Absent "(E2i) --verify=uses(helper), bare name"                           "$TMP/e2_vf_uses_bare.xml"     verify   count     2
+e2Absent "(E2i) --verify=calls(driveTheStore,Store.h:putObject), proven"    "$TMP/e2_vf_calls_clean.xml"   verify   verdict   confirmed
+e2Absent "(E2i) --verify=calls(unrelatedCaller,helper), bare name"          "$TMP/e2_vf_calls_bare.xml"    verify   verdict   confirmed
+e2Absent "(E2i) --verify=reaches(Store.h:putObject,\"Caller.cpp\"), proven" "$TMP/e2_vf_reaches_clean.xml" verify   witnesses 1
+e2Absent "(E2i) --verify=reaches(helper,\"other.cpp\"), bare name"          "$TMP/e2_vf_reaches_bare.xml"  verify   witnesses 1
+e2Absent "(E2i) --affected=Store.h:putObject, every candidate proven"       "$TMP/e2_af_clean.xml"         affected tests     1
+e2Absent "(E2i) --affected=helper, bare name"                               "$TMP/e2_af_bare.xml"          affected tests     1
+
+echo
+echo "=== (E2j) the MCP uses and mentions twins refuse a file:name spelling — there is no zero there to disclose ==="
+# Both twins resolve through resolveAllByName, which never runs the widening, and both refuse a qualified spelling as
+# CLI-only instead of answering it. A twin that began to ANSWER api.h:helper would answer from the same declaration and
+# would owe the attribute the CLI now carries, so the refusal is asserted rather than left as a sentence in a header.
+cp -R "$TMP/combo" "$TMP/mcp_combo" || no "(E2j) could not copy the corpus for the MCP twins"
+mcpTranscript "$TMP/e2_mcp_us.rpc"      uses     "" "path=$TMP/mcp_combo" "symbol=api.h:helper"
+mcpTranscript "$TMP/e2_mcp_mn.rpc"      mentions "" "path=$TMP/mcp_combo" "symbol=api.h:helper"
+mcpTranscript "$TMP/e2_mcp_mn_bare.rpc" mentions "" "path=$TMP/mcp_combo" "symbol=helper"
+# CONTROL FIRST: the same server answers the bare name, so a refusal below is about the spelling, not a dead transcript.
+P_MN_BARE="$( mcpPayload "$TMP/e2_mcp_mn_bare.rpc" )"
+case "$P_MN_BARE" in
+    '__ERROR__:'*|'') no "(E2j) control broken — MCP mentions symbol=helper did not answer ($( printf '%s' "$P_MN_BARE" | head -c 160 )); the refusal rows would be about a server that answers nothing" ;;
+    *'"docs":1'*)
+        ok "(E2j) control: MCP mentions symbol=helper answers \"docs\":1"
+        for n in e2_mcp_us e2_mcp_mn; do
+            if [ "$( refusesAsCliOnly "$TMP/$n.rpc" )" = 1 ]; then
+                ok "(E2j) $n: the twin refuses api.h:helper as a CLI-only spelling"
+            else
+                no "(E2j) $n: the twin no longer refuses api.h:helper ($( mcpPayload "$TMP/$n.rpc" | head -c 160 )) — an answer comes from the declaration and owes unproven_defs="
+            fi
+        done ;;
+    *) no "(E2j) control broken — MCP mentions symbol=helper answered without \"docs\":1: $( printf '%s' "$P_MN_BARE" | head -c 160 )" ;;
+esac
+
+echo
+echo "=== (E2k) --verify's verdict: not-established beside a residue is qualified where it is defined ==="
+# verdict= keeps its three values (the claim grammar and --help close the set). limit= names the MODEL's floor, which is
+# a different reason from a selector that dropped definitions, and a reader acts on the two differently — so the clause
+# that defines unproven_defs= addresses verdict= and not-established itself, asserted on the clause's own span. --verify's
+# legend is one closed literal, so the clause rides as its own comment; legendOf reads the whole leading run.
+R_VF="$( rootEl "$TMP/e2_vf_uses.xml" verify )"
+if nonempty "(E2k) no <verify> root for uses(api.h:helper)" "$R_VF"; then
+    CL_VF="$( clauseOf "$( legendOf "$TMP/e2_vf_uses.xml" )" )"
+    if [ "$( attr "$R_VF" verdict )" != "not-established" ]; then
+        no "(E2k) premise broken — verdict=\"$( attr "$R_VF" verdict )\", expected not-established; the verdict arm would be about another value"
+    elif [ -z "$( attr "$R_VF" unproven_defs )" ]; then
+        no "(E2k) verdict=\"not-established\" stands with no unproven_defs= beside it — limit= names the model floor, never the two definitions nobody read"
+    else
+        case "$CL_VF" in
+            *'verdict='*'not-established'*) ok "(E2k) the unproven_defs= clause addresses verdict= and not-established within its own span" ;;
+            *)                              no "(E2k) the unproven_defs= clause never names verdict= and not-established: ${CL_VF:-<no clause>}" ;;
+        esac
+    fi
+fi
+
+echo
+echo "=== (E2l) --verify=calls sums both symbols' residue; --affected sums its symbol items and a path item adds nothing ==="
+# With (E2i)'s calls(unrelatedCaller,api.h:helper) (the TO symbol alone, 2), these tell a sum from src-only, dst-only and
+# double counting; the --affected pair tells a per-item sum from first-item-only and from a path item that counts.
+run "$TMP/two" '--verify=calls(a.h:alpha,b.h:beta)' >"$TMP/e2_vf_two_both.xml"
+run "$TMP/two" '--verify=calls(a.h:alpha,useBeta)'  >"$TMP/e2_vf_two_from.xml"
+run "$TMP/two" --affected=a.h:alpha,b.h:beta         >"$TMP/e2_af_two_both.xml"
+run "$TMP/two" --affected=x.cpp,a.h:alpha            >"$TMP/e2_af_two_mixed.xml"
+e2Present "(E2l) --verify=calls(a.h:alpha,b.h:beta) (one dropped per symbol)" "$TMP/e2_vf_two_both.xml"  verify   2 verdict not-established
+e2Present "(E2l) --verify=calls(a.h:alpha,useBeta) (the FROM symbol alone)"   "$TMP/e2_vf_two_from.xml"  verify   1 verdict not-established
+e2Present "(E2l) --affected=a.h:alpha,b.h:beta (one dropped per item)"        "$TMP/e2_af_two_both.xml"  affected 2 tests   0
+e2Present "(E2l) --affected=x.cpp,a.h:alpha (the path item adds nothing)"     "$TMP/e2_af_two_mixed.xml" affected 1 tests   0
+
+echo
+echo "=== (E2m) under the compact legend, the existing unproven_defs row fires on the four roots and the full clause goes ==="
+# No compact term was added: the row compactlegend.h already carries reads unproven_defs= off any root's head. --verify's
+# clause is the one that could survive, being its own comment rather than a sentence inside a stripped legend, so every
+# document here is also asserted to have lost the full clause.
+run2 "$TMP/free"  --uses=api.h:helper           --legend=compact >"$TMP/e2_us_cmp.xml"
+run2 "$TMP/combo" --mentions=api.h:helper       --legend=compact >"$TMP/e2_mn_cmp.xml"
+run2 "$TMP/free"  '--verify=uses(api.h:helper)' --legend=compact >"$TMP/e2_vf_cmp.xml"
+run2 "$TMP/combo" --affected=api.h:helper       --legend=compact >"$TMP/e2_af_cmp.xml"
+for pair in "e2_us_cmp.xml:uses" "e2_mn_cmp.xml:mentions" "e2_vf_cmp.xml:verify" "e2_af_cmp.xml:affected"; do
+    f="${pair%%:*}"; el="${pair#*:}"
+    R="$( rootEl "$TMP/$f" "$el" )"
+    nonempty "(E2m) no <$el> root in $f" "$R" || continue
+    L="$( legendOf "$TMP/$f" )"
+    if [ -z "$( attr "$R" unproven_defs )" ]; then
+        no "(E2m) $f: the compact <$el> root carries no unproven_defs= — nothing for the compact reading to define"
+    elif [ "$( fullClauseIn "$L" )" = 1 ]; then
+        no "(E2m) $f: the FULL unproven_defs= clause survived into the compact dialect beside its compact reading"
+    else
+        case "$L" in
+            *'unproven_defs=K:'*) ok "(E2m) $f: <$el unproven_defs=\"$( attr "$R" unproven_defs )\">, the compact legend reads it, and the full clause is gone" ;;
+            *)                    no "(E2m) $f: <$el> carries unproven_defs= under the compact legend with no unproven_defs=K: reading" ;;
+        esac
+    fi
+done
+
 echo
 echo "=== (F) MUTATION — every assertion shape above is shown able to fail ==="
 # (A)/(B) shape: the row-name reader must SEE a wrong caller when one is present…
@@ -825,6 +1007,23 @@ case "$( clauseOf "$L_OUT" )" in *'risk='*) M_OUT=1 ;; *) M_OUT=0 ;; esac
 [ "$M_IN" = 1 ] && [ "$M_OUT" = 0 ] \
     && ok "(F) E2f-shape: clauseOf reads risk= inside the clause and does not credit one outside it" \
     || no "(F) clauseOf cannot tell a clause that addresses risk= from a legend that merely contains it (in=$M_IN out=$M_OUT)"
+# (E2j) shape: only a refusal of the spelling as CLI-only counts — an ANSWER (the silent zero itself) and an error about
+# something else must both read as "not refused", or the arm would pass on a twin that answers.
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}' \
+    '{"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"qualified file:name selectors are CLI-only on this verb"}}' >"$TMP/m_e2j_ref.rpc"
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}' \
+    '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"<uses of=\"api.h:helper\" defs=\"1\" count=\"0\"></uses>"}]}}' >"$TMP/m_e2j_ans.rpc"
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}' \
+    '{"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"unknown field: legend"}}' >"$TMP/m_e2j_err.rpc"
+[ "$( refusesAsCliOnly "$TMP/m_e2j_ref.rpc" )" = 1 ] && [ "$( refusesAsCliOnly "$TMP/m_e2j_ans.rpc" )" = 0 ] && [ "$( refusesAsCliOnly "$TMP/m_e2j_err.rpc" )" = 0 ] \
+    && ok "(F) E2j-shape: refusesAsCliOnly reads the CLI-only refusal, and neither an answer nor another error" \
+    || no "(F) refusesAsCliOnly cannot tell the refusal from an answer or another error — (E2j) would pass on a twin that answers"
+# (E2m) shape: a compact leading run that KEPT the full clause beside its compact reading must be told from one that did not.
+printf '<!-- ripwire verify ripwire.verify/v1: x. unproven_defs=K: K defs. --><!-- ripwire verify: unproven_defs=K (absent when 0) counts --><verify unproven_defs="2"></verify>' >"$TMP/m_e2m_kept.xml"
+printf '<!-- ripwire verify ripwire.verify/v1: x. unproven_defs=K: K defs. --><verify unproven_defs="2"></verify>' >"$TMP/m_e2m_gone.xml"
+[ "$( fullClauseIn "$( legendOf "$TMP/m_e2m_kept.xml" )" )" = 1 ] && [ "$( fullClauseIn "$( legendOf "$TMP/m_e2m_gone.xml" )" )" = 0 ] \
+    && ok "(F) E2m-shape: a full clause kept in a compact leading run IS detected, and a compact reading alone is not" \
+    || no "(F) fullClauseIn cannot tell a compact legend that kept the full clause from one that dropped it"
 # VACUITY guard itself. Run in a subshell so it cannot set fail.
 if ( nonempty "probe" "" >/dev/null 2>&1 ); then
     no "(F) nonempty() accepts an empty capture — every arm's vacuity guard is inert"
@@ -844,7 +1043,10 @@ if command -v xmllint >/dev/null 2>&1; then
     # The e2_* documents are the ones whose legends grew a clause — an XML comment may not hold a double hyphen (G4).
     if xmllint --noout "$TMP/a_far.xml" 2>/dev/null && xmllint --noout "$TMP/c_hdr_hdr.xml" 2>/dev/null \
        && xmllint --noout "$TMP/e2_sd.xml" 2>/dev/null && xmllint --noout "$TMP/e2_imp.xml" 2>/dev/null \
-       && xmllint --noout "$TMP/e2_pth.xml" 2>/dev/null && xmllint --noout "$TMP/e2_mcp_imp.xml" 2>/dev/null; then
+       && xmllint --noout "$TMP/e2_pth.xml" 2>/dev/null && xmllint --noout "$TMP/e2_mcp_imp.xml" 2>/dev/null \
+       && xmllint --noout "$TMP/e2_us.xml" 2>/dev/null && xmllint --noout "$TMP/e2_us_col.xml" 2>/dev/null \
+       && xmllint --noout "$TMP/e2_mn.xml" 2>/dev/null && xmllint --noout "$TMP/e2_vf_calls.xml" 2>/dev/null \
+       && xmllint --noout "$TMP/e2_af.xml" 2>/dev/null; then
         ok "xml well-formed"
     else
         no "xml malformed"


### PR DESCRIPTION
Follows #190. A `file:name` selector that names bodyless C++ declarations keeps only the definitions it can prove are tied to that header, and drops the rest. #173 and #190 made `--callers`, `--callees`, `--impact`, `--safe-delete` and `--path` say how many they dropped. Four more verbs were answering from the declaration alone and printing a clean zero. On a fixture where `api.h:helper`'s real definition sits in a file the proof cannot tie to the header:

- **`--uses`:** `defs="1" count="0"`, with `defs_of_name="3" call_sites_of_name="2"` as the only hint. The XML and columnar forms agree.
- **`--mentions`:** `docs="0" sections="0"`, because doc edges attach only to bodies.
- **`--verify`:** `uses(api.h:helper)` and `unused(api.h:helper)` answered `verdict="not-established" … count="0"`. `calls(unrelatedCaller,api.h:helper)` answered `from_defs="1" to_defs="1"`, and `reaches(api.h:helper,"other.cpp")` answered `target_defs="1" witnesses="0"`.
- **`--affected`:** `seeds="1" tests="0" reached="0"`.

## Fix

Each verb now carries `unproven_defs="K"` on its root, following #190's pattern. The attribute is absent at zero. Each verb also gets a legend clause worded for it, printed only when K > 0:

- **`--uses`:** after `count=`, in XML and columnar. Its `--json` form refuses, as before.
- **`--mentions`:** after `sections=`.
- **`--verify`:** all three resolving shapes. `calls()` sums both endpoints, as `--path` does. `verdict=` keeps its three values, and the clause says `not-established` beside `unproven_defs=` is an incomplete read.
- **`--affected`:** summed over the seed items. A path item adds 0. Exit codes are unchanged.

The existing `unproven_defs` compact term covers all four roots, so no compact term was added. MCP has no verify or affected tool, and its uses and mentions tools refuse `file:name` selectors as CLI-only. `test/decltodefcheck.sh` (E2j) asserts that, so `mcpverbs.h` is untouched.

## Gate

`test/decltodefcheck.sh` gains, for each verb: a premise, presence and clause rows, absent rows, and a mutation row. 29 rows failed on main, and all 113 pass on the plain and ASan builds.

## Unchanged answers

We compared 76 answers between main and this branch:

- **67 drop nothing:** bare names, fully proven `file:name`, every dialect, and compact output.
- **9 are #190's verbs** on the dropping selector.

71 are byte-identical. The other 5 are MCP responses that differ only in the `_index` hash, which also varies between two runs of the same binary.

## Verification

- `gates=34 pass=34 skip=0 fail=0`: decltodef, uses, usesselector, mentions, mentionsverb, affected, verify, legendcoverage, graphlegendbudget, compactlegend, mcpattrparity, mcpclidiff, mcpmanifest, printffmtparity, xmlwellformed, and 19 neighbouring gates.
- `scripts/formatcheck.sh` passes. `src/graphlegend.h` is one of the files it checks.
- `limits_build --check` and `gatecount_build --check` both return 0.
- `--quality-delta` reports only short-horizon churn on the functions this change edits, explained in the commit message.

## Still to come

`--around`, `--lego`, `--connect` and the MCP lego and connect tools resolve through `resolveFocus` in `graph.h`, which has no out-parameter yet. `--owners`, `--edit-check`, `--slice`, `--whereis` and a few MCP and main-path callers still pass none. Whether any of them produce a zero, rather than a narrower answer, is not yet established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
