### PR TITLE
docs(readme): the four commands to learn first never said who their output is for

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,9 @@ ripwire . --callers=someFunction                   # who calls it
 ripwire . --test-gate                              # before you commit: which tests must run
 ```
 
+> **Written for your agent.** Every command prints compact XML sized for an AI agent to read, not for a person
+> scanning a terminal. Human-readable output is on the roadmap.
+
 <details>
 <summary>CLI or MCP, the <code>-DCMAKE_BUILD_TYPE=Release</code> trap, and the honesty contract in one line</summary>
 


### PR DESCRIPTION
The Quickstart's four commands to learn first (`--max-tokens=3000`, `--for`, `--callers`, `--test-gate`) print compact XML sized for an agent's context window, not a page written for people. Nothing near them said so. A reader running them in a terminal could reasonably wonder whether the output is broken.

This adds one note directly under that block:

> **Written for your agent.** Every command prints compact XML sized for an AI agent to read, not for a person scanning a terminal. Human-readable output is on the roadmap.

- **Scope:** the change is additive. Two lines are inserted, and nothing else in the README moves.
- **No conflict with #192:** #192 adds lines near the top and at the bottom, and this note sits in the Quickstart, so the two merge cleanly.
- **Verification:** every gate that reads `README.md` passes (`gates=27 pass=27 skip=0 fail=0`), and `gatecount_build --check` returns 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
